### PR TITLE
Combat fixes

### DIFF
--- a/lib/storage/10003
+++ b/lib/storage/10003
@@ -1,8 +1,8 @@
 [HOUSE]
 	[Object 0]
-		Vnum:	10000
+		Vnum:	10009
 		Inside:	0
-		Value 0:	1
+		Value 0:	4
 		Value 1:	15
 		Value 2:	0
 		Value 3:	0
@@ -17,7 +17,7 @@
 		Condition:	32
 		Timer:	2
 		Attempt:	0
-		Cost:	0
+		Cost:	1410065407
 		ExtraFlags:	0
 	[Object 1]
 		Vnum:	10008
@@ -40,9 +40,9 @@
 		Cost:	0
 		ExtraFlags:	0
 	[Object 2]
-		Vnum:	10009
+		Vnum:	10000
 		Inside:	0
-		Value 0:	4
+		Value 0:	1
 		Value 1:	15
 		Value 2:	0
 		Value 3:	0
@@ -57,5 +57,5 @@
 		Condition:	32
 		Timer:	2
 		Attempt:	0
-		Cost:	1410065407
+		Cost:	0
 		ExtraFlags:	0

--- a/lib/storage/10013
+++ b/lib/storage/10013
@@ -1,10 +1,10 @@
 [HOUSE]
 	[Object 0]
-		Vnum:	10016
+		Vnum:	10011
 		Inside:	0
-		Value 0:	3
-		Value 1:	1
-		Value 2:	0
+		Value 0:	2
+		Value 1:	100000000
+		Value 2:	100000000
 		Value 3:	0
 		Value 4:	0
 		Value 5:	0
@@ -17,13 +17,13 @@
 		Condition:	32
 		Timer:	2
 		Attempt:	0
-		Cost:	99999999
+		Cost:	0
 		ExtraFlags:	0
 	[Object 1]
-		Vnum:	10015
+		Vnum:	10012
 		Inside:	0
-		Value 0:	3
-		Value 1:	0
+		Value 0:	1
+		Value 1:	3
 		Value 2:	0
 		Value 3:	0
 		Value 4:	0
@@ -37,13 +37,13 @@
 		Condition:	32
 		Timer:	2
 		Attempt:	0
-		Cost:	999999999
+		Cost:	0
 		ExtraFlags:	0
 	[Object 2]
-		Vnum:	10014
+		Vnum:	10013
 		Inside:	0
-		Value 0:	4
-		Value 1:	0
+		Value 0:	2
+		Value 1:	3
 		Value 2:	0
 		Value 3:	0
 		Value 4:	0
@@ -240,10 +240,10 @@
 		Cost:	0
 		ExtraFlags:	0
 	[Object 12]
-		Vnum:	10013
+		Vnum:	10014
 		Inside:	0
-		Value 0:	2
-		Value 1:	3
+		Value 0:	4
+		Value 1:	0
 		Value 2:	0
 		Value 3:	0
 		Value 4:	0
@@ -260,10 +260,10 @@
 		Cost:	0
 		ExtraFlags:	0
 	[Object 13]
-		Vnum:	10012
+		Vnum:	10015
 		Inside:	0
-		Value 0:	1
-		Value 1:	3
+		Value 0:	3
+		Value 1:	0
 		Value 2:	0
 		Value 3:	0
 		Value 4:	0
@@ -277,14 +277,14 @@
 		Condition:	32
 		Timer:	2
 		Attempt:	0
-		Cost:	0
+		Cost:	999999999
 		ExtraFlags:	0
 	[Object 14]
-		Vnum:	10011
+		Vnum:	10016
 		Inside:	0
-		Value 0:	2
-		Value 1:	100000000
-		Value 2:	100000000
+		Value 0:	3
+		Value 1:	1
+		Value 2:	0
 		Value 3:	0
 		Value 4:	0
 		Value 5:	0
@@ -297,5 +297,5 @@
 		Condition:	32
 		Timer:	2
 		Attempt:	0
-		Cost:	0
+		Cost:	99999999
 		ExtraFlags:	0

--- a/src/act.movement.cpp
+++ b/src/act.movement.cpp
@@ -1408,7 +1408,7 @@ ACMD(do_sit)
     act("You have to wake up first.", FALSE, ch, 0, 0, TO_CHAR);
     break;
   case POS_FIGHTING:
-    act("Sit down while fighting? are you MAD?", FALSE, ch, 0, 0, TO_CHAR);
+    act("Sit down while fighting? Are you MAD?", FALSE, ch, 0, 0, TO_CHAR);
     break;
   default:
     act("You stop floating around, and sit down.", FALSE, ch, 0, 0, TO_CHAR);

--- a/src/act.offensive.cpp
+++ b/src/act.offensive.cpp
@@ -646,13 +646,13 @@ ACMD(do_retract)
   else if ((GET_OBJ_VAL(cyber, 0) == CYB_HANDRAZOR || GET_OBJ_VAL(cyber, 0) == CYB_HANDSPUR || GET_OBJ_VAL(cyber, 0) == CYB_HANDBLADE) && !IS_SET(GET_OBJ_VAL(cyber, 3), CYBERWEAPON_RETRACTABLE))
     send_to_char("That cyberweapon isn't retractable.\r\n",ch );
   else {
-    if (GET_OBJ_VAL(cyber, 9)) {
-      GET_OBJ_VAL(cyber, 9)--;
+    if (GET_OBJ_VAL(cyber, CYBER_DISABLED_BIT)) {
+      GET_OBJ_VAL(cyber, CYBER_DISABLED_BIT) = 0;
       sprintf(buf, "$n extends %s.", GET_OBJ_NAME(cyber)+2);
       act(buf, TRUE, ch, 0, 0, TO_ROOM);
       send_to_char(ch, "You extend %s.\r\n", GET_OBJ_NAME(cyber)+2);
     } else {
-      GET_OBJ_VAL(cyber, 9)++;
+      GET_OBJ_VAL(cyber, CYBER_DISABLED_BIT) = 1;
       sprintf(buf, "$n retracts %s.", GET_OBJ_NAME(cyber)+2);
       act(buf, TRUE, ch, 0, 0, TO_ROOM);
       send_to_char(ch, "You retract a %s.\r\n", GET_OBJ_NAME(cyber)+2);

--- a/src/awake.h
+++ b/src/awake.h
@@ -1915,50 +1915,53 @@ enum {
 
 #define QUEST_TIMER	15
 
-#define OPT_USEC        100000  /* 10 passes per second */
-#define PASSES_PER_SEC  (1000000 / OPT_USEC)
-#define RL_SEC          * PASSES_PER_SEC
+#define OPT_USEC                 100000  /* 10 passes per second */
+#define PASSES_PER_SEC           (1000000 / OPT_USEC)
+#define RL_SEC                   * PASSES_PER_SEC
 
-#define PULSE_ZONE      (3 RL_SEC)
-#define PULSE_SPECIAL   (10 RL_SEC)
-#define PULSE_MOBILE    (10 RL_SEC)
-#define PULSE_VIOLENCE  (3 RL_SEC)
-#define PULSE_MONORAIL  (5 RL_SEC)
+#define PULSE_ZONE               (3 RL_SEC)
+#define PULSE_SPECIAL            (10 RL_SEC)
+#define PULSE_MOBILE             (10 RL_SEC)
+#define PULSE_VIOLENCE           (3 RL_SEC)
+#define PULSE_MONORAIL           (5 RL_SEC)
 
-#define MAX_SOCK_BUF            (12 * 1024) /* Size of kernel's sock buf   */
-#define MAX_PROMPT_LENGTH       96          /* Max length of prompt        */
-#define GARBAGE_SPACE           32
-#define SMALL_BUFSIZE           1024
+#define MAX_SOCK_BUF             (12 * 1024) /* Size of kernel's sock buf   */
+#define MAX_PROMPT_LENGTH        96          /* Max length of prompt        */
+#define GARBAGE_SPACE            32
+#define SMALL_BUFSIZE            1024
 #define LARGE_BUFSIZE    (MAX_SOCK_BUF - GARBAGE_SPACE - MAX_PROMPT_LENGTH)
 
-#define MAX_STRING_LENGTH       8192
-#define MAX_INPUT_LENGTH        2048     /* Max length per *line* of input */
-#define MAX_RAW_INPUT_LENGTH    4096     /* Max size of *raw* input */
-#define MAX_MESSAGES            100
-#define MAX_NAME_LENGTH         20  /* Used in char_file_u *DO*NOT*CHANGE* */
+#define MAX_STRING_LENGTH        8192
+#define MAX_INPUT_LENGTH         2048     /* Max length per *line* of input */
+#define MAX_RAW_INPUT_LENGTH     4096     /* Max size of *raw* input */
+#define MAX_MESSAGES             100
+#define MAX_NAME_LENGTH          20  /* Used in char_file_u *DO*NOT*CHANGE* */
 
 // MAX_PWD_LENGTH is bullshit though, crypt() truncates it to 8. Go go 90s security!
-#define MAX_PWD_LENGTH          30  /* Used in char_file_u *DO*NOT*CHANGE* */
+#define MAX_PWD_LENGTH           30  /* Used in char_file_u *DO*NOT*CHANGE* */
 
-#define MAX_TITLE_LENGTH        50  /* Used in char_file_u *DO*NOT*CHANGE* */
-#define MAX_WHOTITLE_LENGTH     10  /* Used in char_file_u *DO*NOT*CHANGE* */
-#define HOST_LENGTH             50 
-#define LINE_LENGTH             80  /* Used in char_file_u *DO*NOT*CHANGE* */
-#define EXDSCR_LENGTH           2040/* Used in char_file_u *DO*NOT*CHANGE* */
-#define MAX_AFFECT              32  /* Used in char_file_u *DO*NOT*CHANGE* */
-#define MAX_OBJ_AFFECT          6 /* Used in obj_file_elem *DO*NOT*CHANGE* */
-#define IDENT_LENGTH            8
+#define MAX_TITLE_LENGTH         50  /* Used in char_file_u *DO*NOT*CHANGE* */
+#define MAX_WHOTITLE_LENGTH      10  /* Used in char_file_u *DO*NOT*CHANGE* */
+#define HOST_LENGTH              50
+#define LINE_LENGTH              80  /* Used in char_file_u *DO*NOT*CHANGE* */
+#define EXDSCR_LENGTH            2040/* Used in char_file_u *DO*NOT*CHANGE* */
+#define MAX_AFFECT               32  /* Used in char_file_u *DO*NOT*CHANGE* */
+#define MAX_OBJ_AFFECT           6 /* Used in obj_file_elem *DO*NOT*CHANGE* */
+#define IDENT_LENGTH             8
 
-#define COMBAT_MOD_RECOIL   0
-#define COMBAT_MOD_MOVEMENT 1
+// New combat modifiers used in the rework of hit().
+#define COMBAT_MOD_RECOIL        0
+#define COMBAT_MOD_MOVEMENT      1
 #define COMBAT_MOD_DUAL_WIELDING 2
-#define COMBAT_MOD_SMARTLINK 3
-#define COMBAT_MOD_DISTANCE 4
-#define COMBAT_MOD_VISIBILITY 5
-#define COMBAT_MOD_POSITION 6
-#define COMBAT_MOD_GYRO 7
+#define COMBAT_MOD_SMARTLINK     3
+#define COMBAT_MOD_DISTANCE      4
+#define COMBAT_MOD_VISIBILITY    5
+#define COMBAT_MOD_POSITION      6
+#define COMBAT_MOD_GYRO          7
+#define COMBAT_MOD_REACH         8
 
-#define NUM_COMBAT_MODIFIERS 8
+#define NUM_COMBAT_MODIFIERS     9
+// End new combat modifiers.
 
 /* ban struct */
 struct ban_list_element

--- a/src/awake.h
+++ b/src/awake.h
@@ -1240,6 +1240,8 @@ enum {
 #define CYB_MUSCLEREP		46
 #define NUM_CYBER		47
 
+#define CYBER_DISABLED_BIT 9
+
 #define BIO_ADRENALPUMP		0
 #define BIO_CATSEYES		1
 #define BIO_DIGESTIVEEXPANSION	2
@@ -1942,6 +1944,16 @@ enum {
 #define MAX_AFFECT              32  /* Used in char_file_u *DO*NOT*CHANGE* */
 #define MAX_OBJ_AFFECT          6 /* Used in obj_file_elem *DO*NOT*CHANGE* */
 #define IDENT_LENGTH            8
+
+#define COMBAT_MOD_RECOIL   0
+#define COMBAT_MOD_MOVEMENT 1
+#define COMBAT_MOD_DUAL_WIELDING 2
+#define COMBAT_MOD_SMARTLINK 3
+#define COMBAT_MOD_DISTANCE 4
+#define COMBAT_MOD_VISIBILITY 5
+#define COMBAT_MOD_POSITION 6
+
+#define NUM_COMBAT_MODS 7
 
 /* ban struct */
 struct ban_list_element

--- a/src/awake.h
+++ b/src/awake.h
@@ -1915,52 +1915,53 @@ enum {
 
 #define QUEST_TIMER	15
 
-#define OPT_USEC                 100000  /* 10 passes per second */
-#define PASSES_PER_SEC           (1000000 / OPT_USEC)
-#define RL_SEC                   * PASSES_PER_SEC
+#define OPT_USEC                  100000  /* 10 passes per second */
+#define PASSES_PER_SEC            (1000000 / OPT_USEC)
+#define RL_SEC                    * PASSES_PER_SEC
 
-#define PULSE_ZONE               (3 RL_SEC)
-#define PULSE_SPECIAL            (10 RL_SEC)
-#define PULSE_MOBILE             (10 RL_SEC)
-#define PULSE_VIOLENCE           (3 RL_SEC)
-#define PULSE_MONORAIL           (5 RL_SEC)
+#define PULSE_ZONE                (3 RL_SEC)
+#define PULSE_SPECIAL             (10 RL_SEC)
+#define PULSE_MOBILE              (10 RL_SEC)
+#define PULSE_VIOLENCE            (3 RL_SEC)
+#define PULSE_MONORAIL            (5 RL_SEC)
 
-#define MAX_SOCK_BUF             (12 * 1024) /* Size of kernel's sock buf   */
-#define MAX_PROMPT_LENGTH        96          /* Max length of prompt        */
-#define GARBAGE_SPACE            32
-#define SMALL_BUFSIZE            1024
+#define MAX_SOCK_BUF              (12 * 1024) /* Size of kernel's sock buf   */
+#define MAX_PROMPT_LENGTH         96          /* Max length of prompt        */
+#define GARBAGE_SPACE             32
+#define SMALL_BUFSIZE             1024
 #define LARGE_BUFSIZE    (MAX_SOCK_BUF - GARBAGE_SPACE - MAX_PROMPT_LENGTH)
 
-#define MAX_STRING_LENGTH        8192
-#define MAX_INPUT_LENGTH         2048     /* Max length per *line* of input */
-#define MAX_RAW_INPUT_LENGTH     4096     /* Max size of *raw* input */
-#define MAX_MESSAGES             100
-#define MAX_NAME_LENGTH          20  /* Used in char_file_u *DO*NOT*CHANGE* */
+#define MAX_STRING_LENGTH         8192
+#define MAX_INPUT_LENGTH          2048     /* Max length per *line* of input */
+#define MAX_RAW_INPUT_LENGTH      4096     /* Max size of *raw* input */
+#define MAX_MESSAGES              100
+#define MAX_NAME_LENGTH           20  /* Used in char_file_u *DO*NOT*CHANGE* */
 
 // MAX_PWD_LENGTH is bullshit though, crypt() truncates it to 8. Go go 90s security!
-#define MAX_PWD_LENGTH           30  /* Used in char_file_u *DO*NOT*CHANGE* */
+#define MAX_PWD_LENGTH            30  /* Used in char_file_u *DO*NOT*CHANGE* */
 
-#define MAX_TITLE_LENGTH         50  /* Used in char_file_u *DO*NOT*CHANGE* */
-#define MAX_WHOTITLE_LENGTH      10  /* Used in char_file_u *DO*NOT*CHANGE* */
-#define HOST_LENGTH              50
-#define LINE_LENGTH              80  /* Used in char_file_u *DO*NOT*CHANGE* */
-#define EXDSCR_LENGTH            2040/* Used in char_file_u *DO*NOT*CHANGE* */
-#define MAX_AFFECT               32  /* Used in char_file_u *DO*NOT*CHANGE* */
-#define MAX_OBJ_AFFECT           6 /* Used in obj_file_elem *DO*NOT*CHANGE* */
-#define IDENT_LENGTH             8
+#define MAX_TITLE_LENGTH          50  /* Used in char_file_u *DO*NOT*CHANGE* */
+#define MAX_WHOTITLE_LENGTH       10  /* Used in char_file_u *DO*NOT*CHANGE* */
+#define HOST_LENGTH               50
+#define LINE_LENGTH               80  /* Used in char_file_u *DO*NOT*CHANGE* */
+#define EXDSCR_LENGTH             2040/* Used in char_file_u *DO*NOT*CHANGE* */
+#define MAX_AFFECT                32  /* Used in char_file_u *DO*NOT*CHANGE* */
+#define MAX_OBJ_AFFECT            6 /* Used in obj_file_elem *DO*NOT*CHANGE* */
+#define IDENT_LENGTH              8
 
 // New combat modifiers used in the rework of hit().
-#define COMBAT_MOD_RECOIL        0
-#define COMBAT_MOD_MOVEMENT      1
-#define COMBAT_MOD_DUAL_WIELDING 2
-#define COMBAT_MOD_SMARTLINK     3
-#define COMBAT_MOD_DISTANCE      4
-#define COMBAT_MOD_VISIBILITY    5
-#define COMBAT_MOD_POSITION      6
-#define COMBAT_MOD_GYRO          7
-#define COMBAT_MOD_REACH         8
+#define COMBAT_MOD_RECOIL         0
+#define COMBAT_MOD_MOVEMENT       1
+#define COMBAT_MOD_DUAL_WIELDING  2
+#define COMBAT_MOD_SMARTLINK      3
+#define COMBAT_MOD_DISTANCE       4
+#define COMBAT_MOD_VISIBILITY     5
+#define COMBAT_MOD_POSITION       6
+#define COMBAT_MOD_GYRO           7
+#define COMBAT_MOD_REACH          8
+#define COMBAT_MOD_VEHICLE_DAMAGE 9
 
-#define NUM_COMBAT_MODIFIERS     9
+#define NUM_COMBAT_MODIFIERS      10
 // End new combat modifiers.
 
 /* ban struct */

--- a/src/awake.h
+++ b/src/awake.h
@@ -1464,6 +1464,10 @@ enum {
 #define ACCESS_TRIPOD		9
 #define ACCESS_BAYONET		10
 
+#define ACCESS_LOCATION_TOP    7
+#define ACCESS_LOCATION_BARREL 8
+#define ACCESS_LOCATION_UNDER  9
+
 #define MOD_NOWHERE		0
 #define MOD_INTAKE_FRONT	1
 #define MOD_INTAKE_MID		2
@@ -1952,8 +1956,9 @@ enum {
 #define COMBAT_MOD_DISTANCE 4
 #define COMBAT_MOD_VISIBILITY 5
 #define COMBAT_MOD_POSITION 6
+#define COMBAT_MOD_GYRO 7
 
-#define NUM_COMBAT_MODS 7
+#define NUM_COMBAT_MODIFIERS 8
 
 /* ban struct */
 struct ban_list_element

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -2073,5 +2073,6 @@ const char *combat_modifiers[] =
   "Distance",
   "Visibility",
   "Position",
-  "Gyro"
+  "Gyro",
+  "Reach"
 };

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -2063,3 +2063,14 @@ const char *fire_mode[] =
   "Burst Fire",
   "Full Automatic"
 };
+
+const char *combat_modifiers[] =
+{
+  "Recoil",
+  "Movement",
+  "2Weap",
+  "Smart",
+  "Distance",
+  "Visibility",
+  "Position"
+};

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -2073,5 +2073,6 @@ const char *combat_modifiers[] =
   "Visibility",
   "Position",
   "Gyro",
-  "Reach"
+  "Reach",
+  "VehDamaged"
 };

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -1234,8 +1234,7 @@ const char *adept_powers[] =
 
 struct skill_data skills[] =
   {
-    {"OMGWTFBBQ", BOD, 0
-    },
+    {"OMGWTFBBQ", BOD, 0},
     {"athletics", BOD, 0},
     {"armed combat", STR, 0},
     {"edged weapons", STR, 0},

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -1858,7 +1858,7 @@ const char *room_types[] =
     "Suburban Street",
     "Highway",
     "Field",
-    "Forrest",
+    "Forest",
     "Indoors (Shop)",
     "Indoors (Warehouse)",
     "Indoors (Club)",
@@ -2072,5 +2072,6 @@ const char *combat_modifiers[] =
   "Smart",
   "Distance",
   "Visibility",
-  "Position"
+  "Position",
+  "Gyro"
 };

--- a/src/constants.h
+++ b/src/constants.h
@@ -97,4 +97,5 @@ extern const char *legality_codes[][2];
 extern const char *background_types[];
 extern const char *fire_mode[];
 extern const char *weapon_type[];
+extern const char *combat_modifiers[];
 #endif

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -484,8 +484,8 @@ void affect_total(struct char_data * ch)
   /* effects of bioware */
   for (cyber = ch->bioware; cyber; cyber = cyber->next_content)
   {
-    if (GET_OBJ_VAL(cyber, 0) != BIO_ADRENALPUMP || (GET_OBJ_VAL(cyber, 0) == BIO_ADRENALPUMP &&
-                                       GET_OBJ_VAL(cyber, 5) > 0))
+    if ((GET_OBJ_VAL(cyber, 0) != BIO_ADRENALPUMP || (GET_OBJ_VAL(cyber, 0) == BIO_ADRENALPUMP))
+        && GET_OBJ_VAL(cyber, 5) > 0)
       for (j = 0; j < MAX_OBJ_AFFECT; j++)
         affect_modify(ch,
                       cyber->affected[j].location,
@@ -530,7 +530,9 @@ void affect_total(struct char_data * ch)
     GET_IMPACT(ch) = mob_proto[GET_MOB_RNUM(ch)].points.impact[0];
   } else
     GET_BALLISTIC(ch) = GET_IMPACT(ch) = 0;
+  
   GET_TOTALBAL(ch) = GET_TOTALIMP(ch) = 0;
+  
   for (obj = ch->carrying; obj; obj = obj->next_content)
     if (GET_OBJ_TYPE(obj) == ITEM_FOCUS)
       apply_focus_effect(ch, obj);
@@ -627,8 +629,11 @@ void affect_total(struct char_data * ch)
       has_wired = GET_OBJ_VAL(cyber, 1);
     else if (GET_OBJ_VAL(cyber, 0) == CYB_MOVEBYWIRE)
       has_mbw = GET_OBJ_VAL(cyber, 1);
-    else if (GET_OBJ_VAL(cyber, 0) == CYB_DERMALSHEATHING && GET_OBJ_VAL(cyber, 3) == 1 && !wearing)
-      AFF_FLAGS(ch).SetBit(AFF_INVISIBLE);
+    else if (GET_OBJ_VAL(cyber, 0) == CYB_DERMALSHEATHING || GET_OBJ_VAL(cyber, 0) == CYB_DERMALPLATING) {
+      if (GET_OBJ_VAL(cyber, 0) == CYB_DERMALSHEATHING && GET_OBJ_VAL(cyber, 3) == 1 && !wearing)
+        AFF_FLAGS(ch).SetBit(AFF_INVISIBLE);
+      // todo
+    }
     for (j = 0; j < MAX_OBJ_AFFECT; j++)
       affect_modify(ch,
                     cyber->affected[j].location,

--- a/src/newshop.cpp
+++ b/src/newshop.cpp
@@ -246,7 +246,7 @@ bool shop_receive(struct char_data *ch, struct char_data *keeper, char *arg, int
       }
       if ((GET_OBJ_VAL(obj, 0) == BIO_PATHOGENICDEFENSE || GET_OBJ_VAL(obj, 0) == BIO_TOXINEXTRACTOR) && 
           GET_OBJ_VAL(obj, 1) > GET_REAL_BOD(ch) / 2) {
-        send_to_char("Your body can not support pathogenic defense of that level.\r\n", ch);
+        send_to_char("Your body cannot support pathogenic defense of that level.\r\n", ch);
         return FALSE;
       }
       for (check = ch->bioware; check; check = check->next_content) {

--- a/src/structs.h
+++ b/src/structs.h
@@ -973,14 +973,14 @@ struct combat_data
   // Weapon / unarmed damage data.
   int dam_type;
   bool is_physical;
-  unsigned char power;
-  unsigned char damage_level; // Light/Med/etc
+  char power;
+  char damage_level; // Light/Med/etc
   
   // Gun data.
   bool weapon_is_gun;
   bool weapon_has_bayonet;
-  unsigned char burst_count;
-  unsigned char recoil_comp;
+  char burst_count;
+  char recoil_comp;
   
   // Cyberware data.
   unsigned char climbingclaws;

--- a/src/structs.h
+++ b/src/structs.h
@@ -957,3 +957,33 @@ struct ammo_data
   unsigned char cost;
 };
 #endif
+
+/* Combat data. */
+struct combat_data
+{
+  int modifiers[NUM_COMBAT_MODIFIERS];
+  bool too_tall;
+  
+  unsigned char dam_type;
+  bool is_physical;
+  
+  unsigned char burst_count;
+  unsigned char recoil_comp;
+  
+  struct char_data *ch;
+  
+  struct veh_data *veh;
+  
+  bool weapon_is_gun;
+  struct obj_data *weapon;
+  struct obj_data *magazine;
+  struct obj_data *gyro;
+  
+  combat_data(struct obj_data *weap) :
+    modifiers({0}), ch(NULL), veh(NULL), weapon(NULL), magazine(NULL), gyro(NULL)
+  {
+    weapon = weap;
+    weapon_is_gun = weapon && IS_GUN(GET_OBJ_VAL((weapon), 3));
+    if (weapon_is_gun) maazine = weapon->contains;
+  }
+};

--- a/src/structs.h
+++ b/src/structs.h
@@ -1012,7 +1012,7 @@ struct combat_data
     ch = character;
     weapon = weap;
     
-    weapon_is_gun = weapon && IS_GUN(GET_OBJ_VAL((weapon), 3));
+    weapon_is_gun = (weapon && IS_GUN(GET_OBJ_VAL((weapon), 3)));
     if (weapon_is_gun)
       magazine = weapon->contains;
   }

--- a/src/structs.h
+++ b/src/structs.h
@@ -9,6 +9,8 @@
 #include "awake.h"
 #include "list.h"
 #include "bitfield.h"
+#include "utils.h"
+
 #define SPECIAL(name) \
    int (name)(struct char_data *ch, void *me, int cmd, char *argument)
 #define WSPEC(name) \
@@ -956,34 +958,63 @@ struct ammo_data
   float weight;
   unsigned char cost;
 };
-#endif
 
 /* Combat data. */
 struct combat_data
 {
-  int modifiers[NUM_COMBAT_MODIFIERS];
+  // Generic combat data.
+  char modifiers[NUM_COMBAT_MODIFIERS];
   bool too_tall;
+  int skill;
+  int tn;
+  int dice;
+  int successes;
   
-  unsigned char dam_type;
+  // Weapon / unarmed damage data.
+  int dam_type;
   bool is_physical;
+  unsigned char power;
+  unsigned char damage_level; // Light/Med/etc
   
+  // Gun data.
+  bool weapon_is_gun;
+  bool weapon_has_bayonet;
   unsigned char burst_count;
   unsigned char recoil_comp;
   
+  // Cyberware data.
+  unsigned char climbingclaws;
+  unsigned char fins;
+  unsigned char handblades;
+  unsigned char handrazors;
+  unsigned char improved_handrazors;
+  unsigned char handspurs;
+  unsigned char footanchors;
+  unsigned char bone_lacing_power;
+  unsigned char num_cyberweapons;
+  
+  // Pointers.
   struct char_data *ch;
-  
   struct veh_data *veh;
-  
-  bool weapon_is_gun;
   struct obj_data *weapon;
   struct obj_data *magazine;
   struct obj_data *gyro;
   
-  combat_data(struct obj_data *weap) :
-    modifiers({0}), ch(NULL), veh(NULL), weapon(NULL), magazine(NULL), gyro(NULL)
+  combat_data(struct char_data *character, struct obj_data *weap) :
+    skill(0), tn(0), dice(0), successes(0), dam_type(0), power(0), damage_level(0),
+    burst_count(0), recoil_comp(0), climbingclaws(0), handblades(0), handrazors(0), improved_handrazors(0),
+    handspurs(0), fins(0), footanchors(0), bone_lacing_power(0), num_cyberweapons(0),
+    too_tall(FALSE), is_physical(FALSE), weapon_is_gun(FALSE), weapon_has_bayonet(FALSE),
+    ch(NULL), veh(NULL), weapon(NULL), magazine(NULL), gyro(NULL)
   {
+    memset(modifiers, 0, sizeof(modifiers));
+    
+    ch = character;
     weapon = weap;
+    
     weapon_is_gun = weapon && IS_GUN(GET_OBJ_VAL((weapon), 3));
-    if (weapon_is_gun) maazine = weapon->contains;
+    if (weapon_is_gun)
+      magazine = weapon->contains;
   }
 };
+#endif

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1099,6 +1099,8 @@ int get_skill(struct char_data *ch, int skill, int &target)
       target += GET_TOTALBAL(ch) - GET_QUI(ch);
   }
   
+  // TODO: Adept power Improved Ability.
+  
   if (GET_SKILL(ch, skill))
   {
     int totalskill, mbw = 0, enhan = 0, synth = 0;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,12 +1,12 @@
 /* ************************************************************************
-*   File: utils.c                                       Part of CircleMUD *
-*  Usage: various internal functions of a utility nature                  *
-*                                                                         *
-*  All rights reserved.  See license.doc for complete information.        *
-*                                                                         *
-*  Copyright (C) 1993, 94 by the Trustees of the Johns Hopkins University *
-*  CircleMUD is based on DikuMUD, Copyright (C) 1990, 1991.               *
-************************************************************************ */
+ *   File: utils.c                                       Part of CircleMUD *
+ *  Usage: various internal functions of a utility nature                  *
+ *                                                                         *
+ *  All rights reserved.  See license.doc for complete information.        *
+ *                                                                         *
+ *  Copyright (C) 1993, 94 by the Trustees of the Johns Hopkins University *
+ *  CircleMUD is based on DikuMUD, Copyright (C) 1990, 1991.               *
+ ************************************************************************ */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -70,17 +70,17 @@ int number(int from, int to)
 int dice(int number, int size)
 {
   int sum = 0;
-
+  
   if (size <= 0 || number <= 0)
     return 0;
-
+  
   while (number-- > 0)
     sum += ((random() % size) + 1);
-
+  
   return sum;
 }
 
-#ifndef __GNUG__   
+#ifndef __GNUG__
 int MIN(long a, long b)
 {
   return a < b ? a : b;
@@ -98,7 +98,7 @@ int srdice(void)
   static int roll;
   int sum = 0, num = 1;
   register int i;
-
+  
   for (i = 1; i <= num; i++) {
     roll = ((random() % 6) + 1);
     if (roll == 6)
@@ -112,19 +112,19 @@ int success_test(int number, int target)
 {
   if (number < 1)
     return -1;
-
+  
   int total = 0, roll, one = 0;
   register int i;
-
+  
   target = MAX(target, 2);
-
+  
   for (i = 1; i <= number; i++) {
     if ((roll = srdice()) == 1)
       one++;
     else if (roll >= target)
       total++;
   }
-
+  
   if (one == number)
     return -1;
   return total;
@@ -155,8 +155,8 @@ int convert_damage(int damage)
   if (damage < 0)
     damage = 0;
   else
-    damage = damage_array[MIN(4, damage)];
-
+    damage = damage_array[MIN(DEADLY, damage)];
+  
   return damage;
 }
 
@@ -259,74 +259,74 @@ int modify_target_rbuf_raw(struct char_data *ch, char *rbuf, int current_visibil
     base_target += ((GET_SUSTAINED_NUM(ch) - GET_SUSTAINED_FOCI(ch)) * 2);
     buf_mod( rbuf, "Sustain", (GET_SUSTAINED_NUM(ch) - GET_SUSTAINED_FOCI(ch)) * 2);
   }
-
+  
   if (PLR_FLAGGED(ch, PLR_PERCEIVE))
   {
     base_target += 2;
     buf_mod(rbuf, "AstralPercep", 2);
   } else if (current_visibility_penalty < 8) {
     switch (light_level(ch->in_room)) {
-    case LIGHT_FULLDARK:
-      if (CURRENT_VISION(ch) == THERMOGRAPHIC) {
-        if (NATURAL_VISION(ch) == THERMOGRAPHIC) {
-          light_target += 2;
-          buf_mod(rbuf, "FullDark", 2);
+      case LIGHT_FULLDARK:
+        if (CURRENT_VISION(ch) == THERMOGRAPHIC) {
+          if (NATURAL_VISION(ch) == THERMOGRAPHIC) {
+            light_target += 2;
+            buf_mod(rbuf, "FullDark", 2);
+          } else {
+            light_target += 4;
+            buf_mod(rbuf, "FullDark", 4);
+          }
         } else {
-          light_target += 4;
-          buf_mod(rbuf, "FullDark", 4);
+          light_target += 8;
+          buf_mod(rbuf, "FullDark", 8);
         }
-      } else {
-        light_target += 8;
-        buf_mod(rbuf, "FullDark", 8);
-      }
-      break;
-    case LIGHT_MINLIGHT:
-      if (CURRENT_VISION(ch) == NORMAL) {
-        light_target += 6;
-        buf_mod(rbuf, "MinLight", 6);
-      } else {
-        if (NATURAL_VISION(ch) == NORMAL) {
-          light_target += 4;
-          buf_mod(rbuf, "MinLight", 4);
+        break;
+      case LIGHT_MINLIGHT:
+        if (CURRENT_VISION(ch) == NORMAL) {
+          light_target += 6;
+          buf_mod(rbuf, "MinLight", 6);
         } else {
-          base_target += 2;
-          buf_mod(rbuf, "MinLight", 2);
+          if (NATURAL_VISION(ch) == NORMAL) {
+            light_target += 4;
+            buf_mod(rbuf, "MinLight", 4);
+          } else {
+            base_target += 2;
+            buf_mod(rbuf, "MinLight", 2);
+          }
         }
-      }
-      break;
-    case LIGHT_PARTLIGHT:
-      if (CURRENT_VISION(ch) == NORMAL) {
-        light_target += 2;
-        buf_mod(rbuf, "PartLight", 2);
-      } else if (CURRENT_VISION(ch) == LOWLIGHT) {
-        if (NATURAL_VISION(ch) != LOWLIGHT) {
-          light_target++;
-          buf_mod(rbuf, "PartLight", 1);
-        }
-      } else {
-        if (NATURAL_VISION(ch) != THERMOGRAPHIC) {
+        break;
+      case LIGHT_PARTLIGHT:
+        if (CURRENT_VISION(ch) == NORMAL) {
           light_target += 2;
           buf_mod(rbuf, "PartLight", 2);
+        } else if (CURRENT_VISION(ch) == LOWLIGHT) {
+          if (NATURAL_VISION(ch) != LOWLIGHT) {
+            light_target++;
+            buf_mod(rbuf, "PartLight", 1);
+          }
         } else {
-          light_target++;
-          buf_mod(rbuf, "PartLight", 1);
+          if (NATURAL_VISION(ch) != THERMOGRAPHIC) {
+            light_target += 2;
+            buf_mod(rbuf, "PartLight", 2);
+          } else {
+            light_target++;
+            buf_mod(rbuf, "PartLight", 1);
+          }
         }
-      }
-      break;
-    case LIGHT_GLARE:
-      if (CURRENT_VISION(ch) == NORMAL) {
-        light_target += 2;
-        buf_mod(rbuf, "Glare", 2);
-      } else {
-        if (NATURAL_VISION(ch) == NORMAL) {
-          light_target += 4;
-          buf_mod(rbuf, "Glare", 2);
-        } else {
+        break;
+      case LIGHT_GLARE:
+        if (CURRENT_VISION(ch) == NORMAL) {
           light_target += 2;
           buf_mod(rbuf, "Glare", 2);
+        } else {
+          if (NATURAL_VISION(ch) == NORMAL) {
+            light_target += 4;
+            buf_mod(rbuf, "Glare", 2);
+          } else {
+            light_target += 2;
+            buf_mod(rbuf, "Glare", 2);
+          }
         }
-      }
-      break;
+        break;
     }
     if (light_target > 0 && world[ch->in_room].light[1]) {
       if (world[ch->in_room].light[2]) {
@@ -340,14 +340,14 @@ int modify_target_rbuf_raw(struct char_data *ch, char *rbuf, int current_visibil
       buf_mod(rbuf, "ShadowSpell", world[ch->in_room].shadow[1]);
     }
     int smoke_target = 0;
-
+    
     if (world[ch->in_room].vision[1] == LIGHT_MIST)
       if (CURRENT_VISION(ch) == NORMAL || (CURRENT_VISION(ch) == LOWLIGHT && NATURAL_VISION(ch) == LOWLIGHT)) {
         smoke_target += 2;
         buf_mod(rbuf, "Mist", 2);
       }
     if (world[ch->in_room].vision[1] == LIGHT_LIGHTSMOKE || (weather_info.sky == SKY_RAINING &&
-        world[ch->in_room].sector_type != SPIRIT_HEARTH && !ROOM_FLAGGED(ch->in_room, ROOM_INDOORS))) {
+                                                             world[ch->in_room].sector_type != SPIRIT_HEARTH && !ROOM_FLAGGED(ch->in_room, ROOM_INDOORS))) {
       if (CURRENT_VISION(ch) == NORMAL || (CURRENT_VISION(ch) == LOWLIGHT && NATURAL_VISION(ch) != LOWLIGHT)) {
         smoke_target += 4;
         buf_mod(rbuf, "LSmoke", 4);
@@ -357,7 +357,7 @@ int modify_target_rbuf_raw(struct char_data *ch, char *rbuf, int current_visibil
       }
     }
     if (world[ch->in_room].vision[1] == LIGHT_HEAVYSMOKE || (weather_info.sky == SKY_LIGHTNING &&
-        world[ch->in_room].sector_type != SPIRIT_HEARTH && !ROOM_FLAGGED(ch->in_room, ROOM_INDOORS))) {
+                                                             world[ch->in_room].sector_type != SPIRIT_HEARTH && !ROOM_FLAGGED(ch->in_room, ROOM_INDOORS))) {
       if (CURRENT_VISION(ch) == NORMAL || (CURRENT_VISION(ch) == LOWLIGHT && NATURAL_VISION(ch) == NORMAL)) {
         smoke_target += 6;
         buf_mod(rbuf, "HSmoke", 6);
@@ -454,29 +454,29 @@ int modify_target(struct char_data *ch)
 
 // this returns the general skill
 int return_general(int skill_num)
-          {
-            switch (skill_num) {
-            case SKILL_PISTOLS:
-            case SKILL_RIFLES:
-            case SKILL_SHOTGUNS:
-            case SKILL_ASSAULT_RIFLES:
-            case SKILL_SMG:
-            case SKILL_GRENADE_LAUNCHERS:
-            case SKILL_TASERS:
-            case SKILL_MACHINE_GUNS:
-            case SKILL_MISSILE_LAUNCHERS:
-            case SKILL_ASSAULT_CANNON:
-            case SKILL_ARTILLERY:
-              return (SKILL_FIREARMS);
-            case SKILL_EDGED_WEAPONS:
-            case SKILL_POLE_ARMS:
-            case SKILL_WHIPS_FLAILS:
-            case SKILL_CLUBS:
-              return (SKILL_ARMED_COMBAT);
-            default:
-              return (skill_num);
-            }
-          }
+{
+  switch (skill_num) {
+    case SKILL_PISTOLS:
+    case SKILL_RIFLES:
+    case SKILL_SHOTGUNS:
+    case SKILL_ASSAULT_RIFLES:
+    case SKILL_SMG:
+    case SKILL_GRENADE_LAUNCHERS:
+    case SKILL_TASERS:
+    case SKILL_MACHINE_GUNS:
+    case SKILL_MISSILE_LAUNCHERS:
+    case SKILL_ASSAULT_CANNON:
+    case SKILL_ARTILLERY:
+      return (SKILL_FIREARMS);
+    case SKILL_EDGED_WEAPONS:
+    case SKILL_POLE_ARMS:
+    case SKILL_WHIPS_FLAILS:
+    case SKILL_CLUBS:
+      return (SKILL_ARMED_COMBAT);
+    default:
+      return (skill_num);
+  }
+}
 
 // capitalize a string, now allows for color strings at the beginning
 char *capitalize(const char *source)
@@ -497,7 +497,7 @@ char *str_dup(const char *source)
 {
   if (!source)
     return NULL;
-
+  
   char *New = new char[strlen(source) + 1];
   sprintf(New, "%s", source);
   return New;
@@ -510,21 +510,21 @@ char *get_token(char *str, char *token)
 {
   if (!str)
     return NULL;
-
+  
   register char *temp = str;
   register char *temp1 = token;
-
+  
   // first eat up any white space
   while (isspace(*temp))
     temp++;
-
+  
   // now loop through the string and copy each char till we find a space
   while (*temp && !isspace(*temp))
     *temp1++ = *temp++;
-
+  
   // terminate the string properly
   *temp1 = '\0';
-
+  
   return temp;
 }
 
@@ -533,13 +533,13 @@ char *cleanup(char *dest, const char *src)
 {
   if (!src) // this is because sometimes a null gets sent to src
     return NULL;
-
+  
   register char *temp = &dest[0];
-
+  
   for (; *src; src++)
     if (*src != '\r')
       *temp++ = *src;
-
+  
   *temp = '\0';
   return dest;
 }
@@ -553,11 +553,11 @@ int str_cmp(const char *one, const char *two)
     return 1;
   for (; *one; one++, two++) {
     int diff = LOWER(*one) - LOWER(*two);
-
+    
     if (diff!= 0)
       return diff;
   }
-
+  
   return (LOWER(*one) - LOWER(*two));
 }
 
@@ -569,19 +569,19 @@ char *str_str( const char *str1, const char *str2 )
 {
   int i;
   char temp1[MAX_INPUT_LENGTH], temp2[MAX_INPUT_LENGTH];
-
+  
   for ( i = 0; *(str1 + i); i++ ) {
     temp1[i] = LOWER(*(str1 + i));
   }
-
+  
   temp1[i] = '\0';
-
+  
   for ( i = 0; *(str2 + i); i++ ) {
     temp2[i] = LOWER(*(str2 + i));
   }
-
+  
   temp2[i] = '\0';
-
+  
   return (strstr(temp1, temp2));
 }
 
@@ -592,16 +592,16 @@ char *str_str( const char *str1, const char *str2 )
 int strn_cmp(const char *arg1, const char *arg2, int n)
 {
   int chk, i;
-
+  
   if (arg1 == NULL || arg2 == NULL) {
     log_vfprintf("SYSERR: strn_cmp() passed a NULL pointer, %p or %p.", arg1, arg2);
     return (0);
   }
-
+  
   for (i = 0; (arg1[i] || arg2[i]) && (n > 0); i++, n--)
     if ((chk = LOWER(arg1[i]) - LOWER(arg2[i])) != 0)
       return (chk); /* not equal */
-
+  
   return (0);
 }
 
@@ -624,7 +624,7 @@ void log_death_trap(struct char_data * ch)
 {
   char buf[150];
   extern struct room_data *world;
-
+  
   sprintf(buf, "%s hit DeathTrap #%ld (%s)", GET_CHAR_NAME(ch),
           world[ch->in_room].number, world[ch->in_room].name);
   mudlog(buf, ch, LOG_DEATHLOG, TRUE);
@@ -645,15 +645,15 @@ void log_vfprintf(const char *format, ...)
   va_list args;
   time_t ct = time(0);
   char *tmstr;
-
+  
   tmstr = asctime(localtime(&ct));
   *(tmstr + strlen(tmstr) - 1) = '\0';
   fprintf(stderr, "%-15.15s :: ", tmstr + 4);
-
+  
   va_start(args, format);
   vfprintf(stderr, format, args);
   va_end(args);
-
+  
   fprintf(stderr, "\n");
 }
 
@@ -670,10 +670,10 @@ void mudlog(const char *str, struct char_data *ch, int log, bool file)
   char *tmp;
   time_t ct;
   int check_log = 0;
-
+  
   ct = time(0);
   tmp = asctime(localtime(&ct));
-
+  
   if ( ch && ch->desc && ch->desc->original )
     sprintf(buf2, "[%5ld] (%s) ",
             world[ch->in_room].number,
@@ -682,13 +682,13 @@ void mudlog(const char *str, struct char_data *ch, int log, bool file)
     sprintf(buf2, "[%5ld] ", world[ch->in_room].number);
   else
     strcpy(buf2, "");
-
+  
   if (file)
     fprintf(stderr, "%-19.19s :: %s: %s%s\n", tmp, log_types[log], buf2, str);
-
+  
   ct = ct;
   sprintf(buf, "^g[%s: %s%s]^n\r\n", log_types[log], buf2, str);
-
+  
   for (i = descriptor_list; i; i = i->next)
     if (!i->connected)
     {
@@ -700,45 +700,45 @@ void mudlog(const char *str, struct char_data *ch, int log, bool file)
           PLR_FLAGS(tch).AreAnySet(PLR_WRITING, PLR_MAILING,
                                    PLR_EDITING, ENDBIT))
         continue;
-
+      
       if (ch
           && !access_level(tch, GET_INVIS_LEV(ch))
           && !access_level(tch, LVL_VICEPRES))
         continue;
       switch (log) {
-      case LOG_CONNLOG:
-        check_log = PRF_CONNLOG;
-        break;
-      case LOG_DEATHLOG:
-        check_log = PRF_DEATHLOG;
-        break;
-      case LOG_MISCLOG:
-        check_log = PRF_MISCLOG;
-        break;
-      case LOG_WIZLOG:
-        check_log = PRF_WIZLOG;
-        break;
-      case LOG_SYSLOG:
-        check_log = PRF_SYSLOG;
-        break;
-      case LOG_ZONELOG:
-        check_log = PRF_ZONELOG;
-        break;
-      case LOG_CHEATLOG:
-        check_log = PRF_CHEATLOG;
-        break;
-      case LOG_WIZITEMLOG:
-        check_log = PRF_CHEATLOG;
-        break;
-      case LOG_BANLOG:
-        check_log = PRF_BANLOG;
-        break;
-      case LOG_GRIDLOG:
-        check_log = PRF_GRIDLOG;
-        break;
-      case LOG_WRECKLOG:
-        check_log = PRF_WRECKLOG;
-        break;
+        case LOG_CONNLOG:
+          check_log = PRF_CONNLOG;
+          break;
+        case LOG_DEATHLOG:
+          check_log = PRF_DEATHLOG;
+          break;
+        case LOG_MISCLOG:
+          check_log = PRF_MISCLOG;
+          break;
+        case LOG_WIZLOG:
+          check_log = PRF_WIZLOG;
+          break;
+        case LOG_SYSLOG:
+          check_log = PRF_SYSLOG;
+          break;
+        case LOG_ZONELOG:
+          check_log = PRF_ZONELOG;
+          break;
+        case LOG_CHEATLOG:
+          check_log = PRF_CHEATLOG;
+          break;
+        case LOG_WIZITEMLOG:
+          check_log = PRF_CHEATLOG;
+          break;
+        case LOG_BANLOG:
+          check_log = PRF_BANLOG;
+          break;
+        case LOG_GRIDLOG:
+          check_log = PRF_GRIDLOG;
+          break;
+        case LOG_WRECKLOG:
+          check_log = PRF_WRECKLOG;
+          break;
       }
       if (PRF_FLAGGED(tch, check_log))
         SEND_TO_Q(buf, i);
@@ -748,9 +748,9 @@ void mudlog(const char *str, struct char_data *ch, int log, bool file)
 void sprintbit(long vektor, const char *names[], char *result)
 {
   long nr;
-
+  
   *result = '\0';
-
+  
   if (vektor < 0) {
     strcpy(result, "SPRINTBIT ERROR!");
     return;
@@ -766,7 +766,7 @@ void sprintbit(long vektor, const char *names[], char *result)
     if (*names[nr] != '\n')
       nr++;
   }
-
+  
   if (!*result)
     strcat(result, "None ");
 }
@@ -790,7 +790,7 @@ void sprint_obj_mods(struct obj_data *obj, char *result)
                                        affected_bits, AFF_MAX);
     sprintf(result,"%s %s", result, xbuf);
   }
-
+  
   for (register int i = 0; i < MAX_OBJ_AFFECT; i++)
     if (obj->affected[i].modifier != 0)
     {
@@ -807,18 +807,18 @@ struct time_info_data real_time_passed(time_t t2, time_t t1)
 {
   long secs;
   struct time_info_data now;
-
+  
   secs = (long) (t2 - t1);
-
+  
   now.hours = (secs / SECS_PER_REAL_HOUR) % 24; /* 0..23 hours */
   secs -= SECS_PER_REAL_HOUR * now.hours;
-
+  
   now.day = (secs / SECS_PER_REAL_DAY); /* 0..34 days  */
   secs -= SECS_PER_REAL_DAY * now.day;
-
+  
   now.month = 0;
   now.year = 0;
-
+  
   return now;
 }
 
@@ -827,27 +827,27 @@ struct time_info_data mud_time_passed(time_t t2, time_t t1)
 {
   long secs;
   struct time_info_data now;
-
+  
   secs = (long) (t2 - t1);
-
+  
   now.hours = (secs / SECS_PER_MUD_HOUR) % 24;  /* 0..23 hours */
   secs -= SECS_PER_MUD_HOUR * now.hours;
-
+  
   now.day = (secs / SECS_PER_MUD_DAY) % 30;     /* 0..34 days  */
   secs -= SECS_PER_MUD_DAY * now.day;
-
+  
   now.month = (secs / SECS_PER_MUD_MONTH) % 12; /* 0..16 months */
   secs -= SECS_PER_MUD_MONTH * now.month;
-
+  
   now.year = (secs / SECS_PER_MUD_YEAR);        /* 0..XX? years */
-
+  
   return now;
 }
 
 bool access_level(struct char_data *ch, int level)
 {
   ch = ch->desc && ch->desc->original ? ch->desc->original : ch;
-
+  
   return (!IS_NPC(ch)
           && (GET_LEVEL(ch) >= level ));
 }
@@ -857,13 +857,13 @@ bool access_level(struct char_data *ch, int level)
 bool circle_follow(struct char_data * ch, struct char_data * victim)
 {
   struct char_data *k;
-
+  
   for (k = victim; k; k = k->master)
   {
     if (k == ch)
       return TRUE;
   }
-
+  
   return FALSE;
 }
 
@@ -872,7 +872,7 @@ bool circle_follow(struct char_data * ch, struct char_data * victim)
 void stop_follower(struct char_data * ch)
 {
   struct follow_type *j, *k;
-
+  
   if (ch->master->followers->follower == ch)
   {  /* Head of follower-list? */
     k = ch->master->followers;
@@ -882,12 +882,12 @@ void stop_follower(struct char_data * ch)
   {                      /* locate follower who is not head of list */
     for (k = ch->master->followers; k->next->follower != ch; k = k->next)
       ;
-
+    
     j = k->next;
     k->next = j->next;
     delete j;
   }
-
+  
   AFF_FLAGS(ch).RemoveBits(AFF_CHARM, AFF_GROUP, ENDBIT);
   act("You stop following $N.", FALSE, ch, 0, ch->master, TO_CHAR);
   act("$n stops following $N.", TRUE, ch, 0, ch->master, TO_NOTVICT);
@@ -899,10 +899,10 @@ void stop_follower(struct char_data * ch)
 void die_follower(struct char_data * ch)
 {
   struct follow_type *j, *k;
-
+  
   if (ch->master)
     stop_follower(ch);
-
+  
   for (k = ch->followers; k; k = j)
   {
     j = k->next;
@@ -915,11 +915,11 @@ void die_follower(struct char_data * ch)
 void add_follower(struct char_data * ch, struct char_data * leader)
 {
   struct follow_type *k;
-
+  
   ch->master = leader;
-
+  
   k = new follow_type;
-
+  
   k->follower = ch;
   k->next = leader->followers;
   leader->followers = k;
@@ -943,14 +943,14 @@ int get_line(FILE * fl, char *buf)
 {
   char temp[256];
   int lines = 0;
-
+  
   do {
     lines++;
     fgets(temp, 256, fl);
     if (*temp)
       temp[strlen(temp) - 1] = '\0';
   } while (!feof(fl) && (*temp == '*' || !*temp));
-
+  
   if (feof(fl))
     return 0;
   else {
@@ -962,14 +962,14 @@ int get_line(FILE * fl, char *buf)
 bool PRF_TOG_CHK(char_data *ch, dword offset)
 {
   PRF_FLAGS(ch).ToggleBit(offset);
-
+  
   return PRF_FLAGS(ch).IsSet(offset);
 }
 
 bool PLR_TOG_CHK(char_data *ch, dword offset)
 {
   PLR_FLAGS(ch).ToggleBit(offset);
-
+  
   return PLR_FLAGS(ch).IsSet(offset);
 }
 
@@ -1000,31 +1000,31 @@ char * buf_roll(char *rbuf, const char *name, int bonus)
 int get_speed(struct veh_data *veh)
 {
   int speed = 0, maxspeed = (int)(veh->speed * ((veh->load - veh->usedload) / veh->load));
-
+  
   switch (veh->cspeed)
   {
-  case SPEED_OFF:
-  case SPEED_IDLE:
-    speed = 0;
-    break;
-  case SPEED_CRUISING:
-    if (ROOM_FLAGGED(veh->in_room, ROOM_INDOORS))
-      speed = MIN(maxspeed, 3);
-    else
-      speed = MIN(maxspeed, 55);
-    break;
-  case SPEED_SPEEDING:
-    if (ROOM_FLAGGED(veh->in_room, ROOM_INDOORS))
-      speed = MIN(maxspeed, MAX(5, (int)(maxspeed * .7)));
-    else
-      speed = MIN(maxspeed, MAX(55, (int)(maxspeed * .7)));
-    break;
-  case SPEED_MAX:
-    if (ROOM_FLAGGED(veh->in_room, ROOM_INDOORS))
-      speed = MIN(maxspeed, 8);
-    else
-      speed = maxspeed;
-    break;
+    case SPEED_OFF:
+    case SPEED_IDLE:
+      speed = 0;
+      break;
+    case SPEED_CRUISING:
+      if (ROOM_FLAGGED(veh->in_room, ROOM_INDOORS))
+        speed = MIN(maxspeed, 3);
+      else
+        speed = MIN(maxspeed, 55);
+      break;
+    case SPEED_SPEEDING:
+      if (ROOM_FLAGGED(veh->in_room, ROOM_INDOORS))
+        speed = MIN(maxspeed, MAX(5, (int)(maxspeed * .7)));
+      else
+        speed = MIN(maxspeed, MAX(55, (int)(maxspeed * .7)));
+      break;
+    case SPEED_MAX:
+      if (ROOM_FLAGGED(veh->in_room, ROOM_INDOORS))
+        speed = MIN(maxspeed, 8);
+      else
+        speed = maxspeed;
+      break;
   }
   return (speed);
 }
@@ -1059,8 +1059,8 @@ int negotiate(struct char_data *ch, struct char_data *tch, int comp, int baseval
         tmod += 4;
         break;
     }
-  } 
-
+  }
+  
   for (bio = ch->bioware; bio; bio = bio->next_content)
     if (GET_OBJ_VAL(bio, 0) == BIO_TAILOREDPHEREMONES)
     {
@@ -1068,7 +1068,7 @@ int negotiate(struct char_data *ch, struct char_data *tch, int comp, int baseval
       break;
     }
   int tskill = get_skill(tch, SKILL_NEGOTIATION, tmod);
-
+  
   for (bio = tch->bioware; bio; bio = bio->next_content)
     if (GET_OBJ_VAL(bio, 0) == BIO_TAILOREDPHEREMONES)
     {
@@ -1097,29 +1097,29 @@ int negotiate(struct char_data *ch, struct char_data *tch, int comp, int baseval
       basevalue = MAX((int)(basevalue * 3/4), basevalue - (num * (basevalue / 20)));
   }
   return basevalue;
-
+  
 }
 
 // I hate this name. This isn't just a getter, it's a setter as well. -LS
 int get_skill(struct char_data *ch, int skill, int &target)
 {
-  char rbuf[MAX_STRING_LENGTH];
+  char gskbuf[MAX_STRING_LENGTH];
   
   // Wearing too much armor? That'll hurt.
   if (skills[skill].attribute == QUI) {
     int increase = 0;
     if (GET_TOTALIMP(ch) > GET_QUI(ch)) {
       increase = GET_TOTALIMP(ch) - GET_QUI(ch);
-      buf_mod(rbuf, "OverImp", increase);
+      buf_mod(gskbuf, "OverImp", increase);
       target += increase;
     }
     if (GET_TOTALBAL(ch) > GET_QUI(ch)) {
       increase = GET_TOTALBAL(ch) - GET_QUI(ch);
-      buf_mod(rbuf, "OverBal", increase);
+      buf_mod(gskbuf, "OverBal", increase);
       target += increase;
     }
   }
-  act(rbuf, 1, ch, NULL, NULL, TO_ROLLS);
+  //act(gskbuf, 1, ch, NULL, NULL, TO_ROLLS);
   
   // Core p38
   if (target < 2)
@@ -1163,16 +1163,17 @@ int get_skill(struct char_data *ch, int skill, int &target)
     if (skill == SKILL_ATHLETICS)
       totalskill += synth + mbw;
     if (enhan && (skills[skill].attribute == QUI || skill == SKILL_BR_CAR || skill == SKILL_BR_BIKE ||
-        skill == SKILL_BR_COMPUTER || skill == SKILL_BR_ELECTRONICS || skill == SKILL_BR_TRUCK ||
-        skill == SKILL_BR_DRONE))
+                  skill == SKILL_BR_COMPUTER || skill == SKILL_BR_ELECTRONICS || skill == SKILL_BR_TRUCK ||
+                  skill == SKILL_BR_DRONE))
       totalskill++;
     return totalskill;
-  } else
-  {
+  }
+  else {
     if (target >= 8)
       return 0;
     target += 4;
-    act("Unskilled: +4 TN", 1, ch, NULL, NULL, TO_ROLLS);
+    sprintf(gskbuf, "$n (%s) %s(%d) = %d(%d): +4 TN", GET_CHAR_NAME(ch), skills[skill].name, skill, GET_SKILL(ch, skill), REAL_SKILL(ch, skill));
+    act(gskbuf, 1, ch, NULL, NULL, TO_ROLLS);
     return GET_ATT(ch, skills[skill].attribute);
   }
 }
@@ -1185,7 +1186,7 @@ bool biocyber_compatibility(struct obj_data *obj1, struct obj_data *obj2, struct
   else
     bio1 = obj1;
   if (GET_OBJ_TYPE(obj2) == ITEM_BIOWARE)
-      bio1 = obj2;
+    bio1 = obj2;
   else {
     if (cyber1)
       cyber2 = obj2;
@@ -1195,63 +1196,63 @@ bool biocyber_compatibility(struct obj_data *obj1, struct obj_data *obj2, struct
   if (cyber1 && cyber2) {
     if (GET_OBJ_VAL(cyber1, 0) != CYB_EYES)
       switch (GET_OBJ_VAL(cyber1, 0)) {
-      case CYB_FILTRATION:
-        if (GET_OBJ_VAL(cyber1, 3) == GET_OBJ_VAL(cyber2, 3)) {
-          send_to_char("You already have this type of filtration installed.\r\n", ch);
-          return FALSE;
-        }
-        break;
-      case CYB_DATAJACK:
-        if (GET_OBJ_VAL(cyber2, 0) == CYB_EYES && IS_SET(GET_OBJ_VAL(cyber2, 3), EYE_DATAJACK)) {
-          send_to_char("You already have an eye datajack installed.\r\n", ch);
-          return FALSE;
-        }
-        break;
-      case CYB_VCR:
-        if (GET_OBJ_VAL(cyber2, 0) == CYB_BOOSTEDREFLEXES) {
-          send_to_char("Vehicle Control Rigs are not compatible with Boosted reflexes.\r\n", ch);
-          return FALSE;
-        }
-        break;
-      case CYB_BOOSTEDREFLEXES:
-        if (GET_OBJ_VAL(cyber2, 0) == CYB_VCR) {
-          send_to_char("Boosted reflexes is not compatible with Vehicle Control Rigs.\r\n", ch);
-          return FALSE;
-        }
-      case CYB_MOVEBYWIRE:
-      case CYB_WIREDREFLEXES:
-        if (GET_OBJ_VAL(cyber2, 0) == CYB_WIREDREFLEXES || GET_OBJ_VAL(cyber2, 0) == CYB_MOVEBYWIRE ||
-            GET_OBJ_VAL(cyber2, 0) == CYB_BOOSTEDREFLEXES) {
-          send_to_char("You already have reaction enhancing cyberware installed.\r\n", ch);
-          return FALSE;
-        }
-        if (GET_OBJ_VAL(cyber1, 0) == CYB_MOVEBYWIRE && GET_OBJ_VAL(cyber2, 0) == CYB_REACTIONENHANCE) {
-          send_to_char("Move-by-wire is not compatible with reaction enhancers.\r\n", ch);
-          return FALSE;
-        }
-        break;
-      case CYB_ORALSLASHER:
-      case CYB_ORALDART:
-      case CYB_ORALGUN:
-        if (GET_OBJ_VAL(cyber2, 0) == CYB_ORALSLASHER || GET_OBJ_VAL(cyber2, 0) == CYB_ORALDART || GET_OBJ_VAL(cyber2, 0)
-            == CYB_ORALGUN) {
-          send_to_char("You already have a weapon in your mouth.\r\n", ch);
-          return FALSE;
-        }
-        break;
-      case CYB_DERMALPLATING:
-      case CYB_DERMALSHEATHING:
-        if (GET_OBJ_VAL(cyber2, 0) == CYB_DERMALPLATING || GET_OBJ_VAL(cyber2, 0) == CYB_DERMALSHEATHING) {
-          send_to_char("You already have an skin modifiaction.\r\n", ch);
-          return FALSE;
-        }
-        break;
-      case CYB_REACTIONENHANCE:
-        if (GET_OBJ_VAL(cyber2, 0) == CYB_MOVEBYWIRE) {
-          send_to_char("Reaction enhancers are not compatible with Move-by-wire.\r\n", ch);
-          return FALSE;
-        }
-        break;
+        case CYB_FILTRATION:
+          if (GET_OBJ_VAL(cyber1, 3) == GET_OBJ_VAL(cyber2, 3)) {
+            send_to_char("You already have this type of filtration installed.\r\n", ch);
+            return FALSE;
+          }
+          break;
+        case CYB_DATAJACK:
+          if (GET_OBJ_VAL(cyber2, 0) == CYB_EYES && IS_SET(GET_OBJ_VAL(cyber2, 3), EYE_DATAJACK)) {
+            send_to_char("You already have an eye datajack installed.\r\n", ch);
+            return FALSE;
+          }
+          break;
+        case CYB_VCR:
+          if (GET_OBJ_VAL(cyber2, 0) == CYB_BOOSTEDREFLEXES) {
+            send_to_char("Vehicle Control Rigs are not compatible with Boosted reflexes.\r\n", ch);
+            return FALSE;
+          }
+          break;
+        case CYB_BOOSTEDREFLEXES:
+          if (GET_OBJ_VAL(cyber2, 0) == CYB_VCR) {
+            send_to_char("Boosted reflexes is not compatible with Vehicle Control Rigs.\r\n", ch);
+            return FALSE;
+          }
+        case CYB_MOVEBYWIRE:
+        case CYB_WIREDREFLEXES:
+          if (GET_OBJ_VAL(cyber2, 0) == CYB_WIREDREFLEXES || GET_OBJ_VAL(cyber2, 0) == CYB_MOVEBYWIRE ||
+              GET_OBJ_VAL(cyber2, 0) == CYB_BOOSTEDREFLEXES) {
+            send_to_char("You already have reaction enhancing cyberware installed.\r\n", ch);
+            return FALSE;
+          }
+          if (GET_OBJ_VAL(cyber1, 0) == CYB_MOVEBYWIRE && GET_OBJ_VAL(cyber2, 0) == CYB_REACTIONENHANCE) {
+            send_to_char("Move-by-wire is not compatible with reaction enhancers.\r\n", ch);
+            return FALSE;
+          }
+          break;
+        case CYB_ORALSLASHER:
+        case CYB_ORALDART:
+        case CYB_ORALGUN:
+          if (GET_OBJ_VAL(cyber2, 0) == CYB_ORALSLASHER || GET_OBJ_VAL(cyber2, 0) == CYB_ORALDART || GET_OBJ_VAL(cyber2, 0)
+              == CYB_ORALGUN) {
+            send_to_char("You already have a weapon in your mouth.\r\n", ch);
+            return FALSE;
+          }
+          break;
+        case CYB_DERMALPLATING:
+        case CYB_DERMALSHEATHING:
+          if (GET_OBJ_VAL(cyber2, 0) == CYB_DERMALPLATING || GET_OBJ_VAL(cyber2, 0) == CYB_DERMALSHEATHING) {
+            send_to_char("You already have an skin modifiaction.\r\n", ch);
+            return FALSE;
+          }
+          break;
+        case CYB_REACTIONENHANCE:
+          if (GET_OBJ_VAL(cyber2, 0) == CYB_MOVEBYWIRE) {
+            send_to_char("Reaction enhancers are not compatible with Move-by-wire.\r\n", ch);
+            return FALSE;
+          }
+          break;
       }
     if (IS_SET(GET_OBJ_VAL(cyber1, 3), EYE_DATAJACK) && GET_OBJ_VAL(cyber2, 0) == CYB_DATAJACK) {
       send_to_char("You already have a datajack installed.\r\n", ch);
@@ -1276,55 +1277,55 @@ bool biocyber_compatibility(struct obj_data *obj1, struct obj_data *obj2, struct
       }
   } else if (bio1 && cyber1) {
     switch (GET_OBJ_VAL(cyber1, 0)) {
-    case CYB_FILTRATION:
-      if (GET_OBJ_VAL(bio1, 0) == BIO_TRACHEALFILTER && GET_OBJ_VAL(cyber1, 3) == FILTER_AIR) {
-        send_to_char("Air filtration cyberware is not compatible with a Tracheal Filter.\r\n", ch);
-        return FALSE;
-      }
-      if (GET_OBJ_VAL(bio1, 0) == BIO_DIGESTIVEEXPANSION && GET_OBJ_VAL(cyber1, 3) == FILTER_INGESTED) {
-        send_to_char("Tracheal Filtration cyberware is not compatible with Digestive Expansion.\r\n", ch);
-        return FALSE;
-      }
-      break;
-    case CYB_MOVEBYWIRE:
-      if (GET_OBJ_VAL(bio1, 0) == BIO_ADRENALPUMP) {
-        send_to_char("Adrenal Pumps are not compatible with Move-By-Wire.\r\n", ch);
-        return FALSE;
-      }
-      if (GET_OBJ_VAL(bio1, 0) == BIO_SYNAPTICACCELERATOR) {
-        send_to_char("Synaptic Accelerators are not compatible with Move-By-Wire.\r\n", ch);
-        return FALSE;
-      }
-      if (GET_OBJ_VAL(bio1, 0) == BIO_SUPRATHYROIDGLAND) {
-        send_to_char("Suprathyroid Glands are not compatible with Move-By-Wire.\r\n", ch);
-        return FALSE;
-      }
-      break;
-    case CYB_WIREDREFLEXES:
-      if (GET_OBJ_VAL(bio1, 0) == BIO_SYNAPTICACCELERATOR) {
-        send_to_char("Your Synaptic Accelerator is not compatible with Wired Reflexes.\r\n", ch);
-        return FALSE;
-      }
-      break;
-    case CYB_EYES:
-      if (GET_OBJ_VAL(bio1, 0) == BIO_CATSEYES || GET_OBJ_VAL(bio1, 0) == BIO_NICTATINGGLAND) {
-        send_to_char("Bioware and cyberware eye modifications aren't compatible.\r\n", ch);
-        return FALSE;
-      }
-      break;
-    case CYB_MUSCLEREP:
-      if (GET_OBJ_VAL(bio1, 0) == BIO_MUSCLEAUG || GET_OBJ_VAL(bio1, 0) == BIO_MUSCLETONER) {
-        send_to_char("Muscle replacement isn't compatible with Muscle Augmentation or Toners.\r\n", ch);
-        return FALSE;
-      }
-      break;
-    case CYB_DERMALPLATING:
-    case CYB_DERMALSHEATHING:
-      if (GET_OBJ_VAL(bio1, 0) == BIO_ORTHOSKIN) {
-        send_to_char("Orthoskin is not compatible with Dermal Plating or Sheathing.\r\n", ch);
-        return FALSE;
-      }
-      break;
+      case CYB_FILTRATION:
+        if (GET_OBJ_VAL(bio1, 0) == BIO_TRACHEALFILTER && GET_OBJ_VAL(cyber1, 3) == FILTER_AIR) {
+          send_to_char("Air filtration cyberware is not compatible with a Tracheal Filter.\r\n", ch);
+          return FALSE;
+        }
+        if (GET_OBJ_VAL(bio1, 0) == BIO_DIGESTIVEEXPANSION && GET_OBJ_VAL(cyber1, 3) == FILTER_INGESTED) {
+          send_to_char("Tracheal Filtration cyberware is not compatible with Digestive Expansion.\r\n", ch);
+          return FALSE;
+        }
+        break;
+      case CYB_MOVEBYWIRE:
+        if (GET_OBJ_VAL(bio1, 0) == BIO_ADRENALPUMP) {
+          send_to_char("Adrenal Pumps are not compatible with Move-By-Wire.\r\n", ch);
+          return FALSE;
+        }
+        if (GET_OBJ_VAL(bio1, 0) == BIO_SYNAPTICACCELERATOR) {
+          send_to_char("Synaptic Accelerators are not compatible with Move-By-Wire.\r\n", ch);
+          return FALSE;
+        }
+        if (GET_OBJ_VAL(bio1, 0) == BIO_SUPRATHYROIDGLAND) {
+          send_to_char("Suprathyroid Glands are not compatible with Move-By-Wire.\r\n", ch);
+          return FALSE;
+        }
+        break;
+      case CYB_WIREDREFLEXES:
+        if (GET_OBJ_VAL(bio1, 0) == BIO_SYNAPTICACCELERATOR) {
+          send_to_char("Your Synaptic Accelerator is not compatible with Wired Reflexes.\r\n", ch);
+          return FALSE;
+        }
+        break;
+      case CYB_EYES:
+        if (GET_OBJ_VAL(bio1, 0) == BIO_CATSEYES || GET_OBJ_VAL(bio1, 0) == BIO_NICTATINGGLAND) {
+          send_to_char("Bioware and cyberware eye modifications aren't compatible.\r\n", ch);
+          return FALSE;
+        }
+        break;
+      case CYB_MUSCLEREP:
+        if (GET_OBJ_VAL(bio1, 0) == BIO_MUSCLEAUG || GET_OBJ_VAL(bio1, 0) == BIO_MUSCLETONER) {
+          send_to_char("Muscle replacement isn't compatible with Muscle Augmentation or Toners.\r\n", ch);
+          return FALSE;
+        }
+        break;
+      case CYB_DERMALPLATING:
+      case CYB_DERMALSHEATHING:
+        if (GET_OBJ_VAL(bio1, 0) == BIO_ORTHOSKIN) {
+          send_to_char("Orthoskin is not compatible with Dermal Plating or Sheathing.\r\n", ch);
+          return FALSE;
+        }
+        break;
     }
   }
   return TRUE;
@@ -1333,7 +1334,7 @@ bool biocyber_compatibility(struct obj_data *obj1, struct obj_data *obj2, struct
 void reduce_abilities(struct char_data *vict)
 {
   int i;
-
+  
   for (i = 0; i < ADEPT_NUMPOWER; i++)
     if (GET_POWER_TOTAL(vict, i) > GET_MAG(vict) / 100) {
       GET_PP(vict) += ability_cost(i, GET_POWER_TOTAL(vict, i));
@@ -1341,10 +1342,10 @@ void reduce_abilities(struct char_data *vict)
       send_to_char(vict, "Your loss in magic makes you feel less "
                    "skilled in %s.\r\n", adept_powers[i]);
     }
-
+  
   if (GET_PP(vict) >= 0)
     return;
-
+  
   for (i = number(1, ADEPT_NUMPOWER); GET_PP(vict) < 0;
        i = number(1, ADEPT_NUMPOWER))
   {
@@ -1356,13 +1357,13 @@ void reduce_abilities(struct char_data *vict)
     }
     int y = 0;
     for (int x = 0; x < ADEPT_NUMPOWER; x++)
-      if (GET_POWER_TOTAL(vict, x)) 
+      if (GET_POWER_TOTAL(vict, x))
         y += ability_cost(x, GET_POWER_TOTAL(vict, x));
     if (y < 1)
       return;
-  }  
+  }
 }
-  
+
 void magic_loss(struct char_data *ch, int magic, bool msg)
 {
   if (GET_TRADITION(ch) == TRAD_MUNDANE)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1103,13 +1103,23 @@ int negotiate(struct char_data *ch, struct char_data *tch, int comp, int baseval
 // I hate this name. This isn't just a getter, it's a setter as well. -LS
 int get_skill(struct char_data *ch, int skill, int &target)
 {
+  char rbuf[MAX_STRING_LENGTH];
+  
   // Wearing too much armor? That'll hurt.
   if (skills[skill].attribute == QUI) {
-    if (GET_TOTALIMP(ch) > GET_QUI(ch))
-      target += GET_TOTALIMP(ch) - GET_QUI(ch);
-    if (GET_TOTALBAL(ch) > GET_QUI(ch))
-      target += GET_TOTALBAL(ch) - GET_QUI(ch);
+    int increase = 0;
+    if (GET_TOTALIMP(ch) > GET_QUI(ch)) {
+      increase = GET_TOTALIMP(ch) - GET_QUI(ch);
+      buf_mod(rbuf, "OverImp", increase);
+      target += increase;
+    }
+    if (GET_TOTALBAL(ch) > GET_QUI(ch)) {
+      increase = GET_TOTALBAL(ch) - GET_QUI(ch);
+      buf_mod(rbuf, "OverBal", increase);
+      target += increase;
+    }
   }
+  act(rbuf, 1, ch, NULL, NULL, TO_ROLLS);
   
   // Core p38
   if (target < 2)
@@ -1162,6 +1172,7 @@ int get_skill(struct char_data *ch, int skill, int &target)
     if (target >= 8)
       return 0;
     target += 4;
+    act("Unskilled: +4 TN", 1, ch, NULL, NULL, TO_ROLLS);
     return GET_ATT(ch, skills[skill].attribute);
   }
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -51,6 +51,7 @@ int     stage(int successes, int wound);
 bool    access_level(struct char_data *ch, int level);
 char * buf_mod(char *buf, const char *name, int bonus);
 char * buf_roll(char *buf, const char *name, int bonus);
+int modify_target_rbuf_raw(struct char_data *ch, char *rbuf, int current_visibility_penalty);
 int modify_target_rbuf(struct char_data *ch, char *rbuf);
 int modify_target(struct char_data *ch);
 int damage_modifier(struct char_data *ch, char *rbuf);


### PR DESCRIPTION
A massive rewrite of fight.cpp's hit() function. Major changes:

- Nerve strike no longer ignores as many penalties, and has had its 4x Qui damage reduced to the canon amount.
- When fighting with cyberweapons, your best active weapon will be used instead of your first one. In addition, two cyberweapons now means you gain the half-strength power bonus from canon.
- When fighting with cyberweapons, you'll actually use your cyber_implants skill.
- You now won't surprise an NPC who's already attacking you.
- Implemented gyro mounts-- they now provide recoil/movement modifier reduction.
- Fixed several issues with firing from vehicles being way easier than it should have been.
- Added messaging to stop_fighting() and recoil damage calls so you actually know what's going on.
- Rolls messaging has been expanded to convey more information.
- Fixed strange smartlink case where you could get a -4 TN.
- Innumerable spellchecks and typo fixes.