### PR TITLE
autorun-ng logs correctly and calls crash_report.sh for dump analysis…

### DIFF
--- a/autorun-ng
+++ b/autorun-ng
@@ -1,0 +1,91 @@
+# CircleMUD 2.0 autorun script
+# Originally by Fred C. Merkel
+# Copyright (c) 1993 The Trustees of The Johns Hopkins University
+# All Rights Reserved
+# See license.doc for more information
+# Modifed by Christopher Dickey, Rift, Dunkelzahn, Demise, and Root.
+# (c)2001 The AwakeMUD Consortium
+
+# converted to bash by John Watson, June 22 1999.
+# https://github.com/TempusMUD/Tempuscode/blob/master/bin/autorun
+# Adapted to AwakeMUD CE by Finster
+
+# If .fastboot exists, the script will sleep for only 5 seconds between reboot
+# attempts.  If .killscript exists, the script commit suicide (and remove
+# .killscript).  If pause exists, the script will repeatedly sleep for
+# 60 seconds and will not restart the mud until pause is removed.
+
+
+PORT=4000
+DATE=$(date -u +"%Y-%m-%dT%H%M%SZ")
+DEVS="someone@somewhere.tld someone_else@somewhere-else.tld"
+
+rm -f .killscript
+
+while [ ! -e .killscript ]; do
+        rm -f pause
+        echo "autoscript starting game $DATE" >> syslog
+	bin/awake $PORT ~/AwakeMUD/lib > syslog 2>&1 &
+        PID=$!
+        echo $PID > ~/.awake.pid
+
+        wait $PID
+        RESULT=$?
+
+        rm ~/.awake.pid
+
+        tail -500 syslog >> log/crashlog
+
+        fgrep "self-delete" syslog >> log/delete
+        fgrep "Running" syslog >> log/restarts
+        fgrep "advanced" syslog >> log/levels
+        fgrep "equipment lost" syslog >> log/rentgone
+        fgrep "usage" syslog >> log/usage
+        fgrep "CONNLOG" syslog >> log/connlog
+        fgrep "MISCLOG" syslog >> log/misclog
+        fgrep "SYSLOG" syslog >> log/syslog
+        fgrep "WIZLOG" syslog >> log/wizlog
+        fgrep "DEATHLOG" syslog >> log/deathlog
+        fgrep "CHEATLOG" syslog >> log/cheatlog
+        fgrep "Bad PW" syslog >> log/badpws
+
+        mv syslog log/$DATE-system.log
+
+        if [ $RESULT -gt "128" ]; then
+                # We died as a result of a signal here: this pretty much means a segfault
+                if [ ! -x crash_report.sh ]; then
+                        echo "A crash was detected but the crash report permissions were wrong." | mailx -s "AwakeMUD CE CRASH REPORT" $DEVS
+                elif [ ! -e ./lib/core ]; then
+                        echo "A crash was detected but no core file was made." | mailx -s "AwakeMUD CE CRASH REPORT" $DEVS
+                else
+                        ./crash_report.sh lib/core log/$DATE-system.log >log/$DATE-crashreport.txt
+                        mv lib/core log/$DATE-core
+                        cat log/$DATE-crashreport.txt | mailx -s "AwakeMUD CE CRASH REPORT" $DEVS
+                fi
+
+                # Check to see if the mud ever actually started.  If the mud
+                # never came up, we have a crash loop and need to stop the mud
+                # until someone comes and rescues it
+                if ! fgrep "Entering game loop" log/$DATE-system.log; then
+                        touch pause
+                fi
+        elif [ -e .killscript ]; then
+                # Peaceful process death - permadeath
+                echo "autoscript killed" `udate` >> syslog
+                rm .killscript
+                exit
+        else
+                # Peaceful process death - a reboot is desired
+                echo "Reboot requested." | mailx -s "AwakeMUD CE Reboot Notification" $DEVS
+        fi
+
+        sleep 5
+
+        while [ -r pause ]; do
+                # Pause while the pause file still exists
+                sleep 5
+        done
+done
+
+echo "autoscript ending" $DATE >> syslog
+

--- a/crash_report.sh
+++ b/crash_report.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Written by Daniel Lowe, 2008
+# https://github.com/TempusMUD/Tempuscode/blob/master/bin/crash_report.sh
+# Modified for AwakeMUD CE by Finster
+
+LINECOUNT=`wc -l $0 | awk '{print $1}'`
+CUTLINE=`grep --line-number "^\# GDB COMMAND LIST CUT HERE" $0 | awk -F: '{print $1}'`
+TAILCOUNT=`echo $((LINECOUNT-CUTLINE))`
+
+
+echo " >>>>"
+echo " >>>> MUD CRASH REPORT <<<<"
+echo " >>>> `date`"
+echo " >>>>"
+echo
+echo " >>>>"
+echo " >>>> TAIL of last syslog (log/syslog.0)"
+echo " >>>>"
+echo
+
+tail $2
+
+echo
+echo " >>>>"
+echo " >>>> GDB OUTPUT"
+echo " >>>>"
+echo
+
+tail -${TAILCOUNT} $0 > /tmp/awake.crash.cmds
+gdb bin/awake $1 </tmp/awake.crash.cmds
+chmod g+r $1
+
+exit
+
+# gbd coms
+#
+# GDB COMMAND LIST CUT HERE
+set prompt \n
+set print null-stop on
+set print pretty on
+printf " >>>>\n >>>> STACK TRACE\n >>>>\n"
+bt
+printf " >>>>\n >>>> LAST CMD ISSUED\n >>>>\n"
+print last_cmd
+quit


### PR DESCRIPTION
…, mails results to devs

postifx on test system already configured to use external relay. $DEVS needs to be changed in production, obviously.

Resolves #86 