### PR TITLE
Consolidated wizload and iload functions; they now both invoke perfor…

### DIFF
--- a/src/act.wizard.cpp
+++ b/src/act.wizard.cpp
@@ -1618,11 +1618,72 @@ ACMD(do_return)
   }
 }
 
+void perform_wizload_object(struct char_data *ch, int vnum) {
+  int real_num, counter, i;
+  bool found = FALSE;
+  struct obj_data *obj = NULL;
+  
+  assert(ch != NULL);
+  
+  // Precondition: Number cannot be negative.
+  if (vnum < 0) {
+    send_to_char("You must specify a positive number.\r\n", ch);
+    return;
+  }
+  
+  // Precondition: Number must be a vnum for a real object.
+  if ((real_num = real_object(vnum)) < 0) {
+    send_to_char("There is no object with that number.\r\n", ch);
+    return;
+  }
+  
+  // Precondition: Object cannot be a credstick.
+  if (obj_proto[real_num].obj_flags.type_flag == ITEM_MONEY) {
+    send_to_char("You can't wizload credsticks.\r\n", ch);
+    return;
+  }
+  
+  // Precondition: Object must belong to a zone.
+  for (counter = 0; counter <= top_of_zone_table; counter++)
+    if ((vnum >= (zone_table[counter].number * 100)) && (vnum <= (zone_table[counter].top))) {
+      found = TRUE;
+      break;
+    }
+  
+  if (!found) {
+    send_to_char ("Sorry, that number is not part of any zone!\r\n", ch);
+    return;
+  }
+  
+  // Precondition: Staff member must have access to the zone the item is in.
+  if (!access_level(ch, LVL_DEVELOPER)) {
+    for (i = 0; i < 5; i++) {
+      if (zone_table[counter].editor_ids[i] == GET_IDNUM(ch))
+        break;
+    }
+  
+    if ((i >= 5)) {
+      send_to_char("Sorry, you don't have access to edit this zone.\r\n", ch);
+      return;
+    }
+  }
+  
+  obj = read_object(real_num, REAL);
+  obj_to_char(obj, ch);
+  GET_OBJ_TIMER(obj) = 2;
+  obj->obj_flags.extra_flags.SetBit(ITEM_IMMLOAD); // Why the hell do we have immload AND wizload?
+  obj->obj_flags.extra_flags.SetBit(ITEM_WIZLOAD);
+  act("$n makes a strange magical gesture.", TRUE, ch, 0, 0, TO_ROOM);
+  act("$n has created $p!", FALSE, ch, obj, 0, TO_ROOM);
+  act("You create $p.", FALSE, ch, obj, 0, TO_CHAR);
+  sprintf(buf, "%s wizloaded object #%d (%s).",
+          GET_CHAR_NAME(ch), vnum, GET_OBJ_NAME(obj));
+  mudlog(buf, ch, LOG_CHEATLOG, TRUE);
+}
+
 ACMD(do_iload)
 {
-  struct obj_data *obj;
-  int number, r_num, counter, i;
-  bool found = FALSE;
+  int number;
 
   one_argument(argument, buf2);
 
@@ -1640,46 +1701,7 @@ ACMD(do_iload)
     return;
   }
 
-  if ((r_num = real_object(number)) < 0) {
-    send_to_char("There is no object with that number.\r\n", ch);
-    return;
-  }
-
-  if (obj_proto[r_num].obj_flags.type_flag == ITEM_MONEY) {
-    send_to_char("You can't iload credsticks!\r\n", ch);
-    return;
-  }
-
-  for (counter = 0; counter <= top_of_zone_table; counter++)
-    if ((number >= (zone_table[counter].number * 100)) && (number <= (zone_table[counter].top))) {
-      found = TRUE;
-      break;
-    }
-
-  if (!found) {
-    send_to_char ("Sorry, that number is not part of any zone!\r\n", ch);
-    return;
-  }
-
-  for (i = 0; i < 5; i++)
-    if (zone_table[counter].editor_ids[i] == GET_IDNUM(ch))
-      break;
-
-  if ((i >= 5) && (!access_level(ch, LVL_DEVELOPER))) {
-    send_to_char("Sorry, you don't have access to edit this zone.\r\n", ch);
-    return;
-  }
-
-  obj = read_object(r_num, REAL);
-  obj_to_char(obj, ch);
-  GET_OBJ_TIMER(obj) = 2;
-  obj->obj_flags.extra_flags.SetBit(ITEM_IMMLOAD);
-  act("$n makes a strange magical gesture.", TRUE, ch, 0, 0, TO_ROOM);
-  act("$n has created $p!", FALSE, ch, obj, 0, TO_ROOM);
-  act("You create $p.", FALSE, ch, obj, 0, TO_CHAR);
-  sprintf(buf, "%s iloaded object #%d (%s).",
-          GET_CHAR_NAME(ch), number, GET_OBJ_NAME(obj));
-  mudlog(buf, ch, LOG_CHEATLOG, TRUE);
+  perform_wizload_object(ch, number);
 }
 
 ACMD(do_wizload)
@@ -1690,7 +1712,6 @@ ACMD(do_wizload)
     return;
   }
   struct char_data *mob;
-  struct obj_data *obj;
   struct veh_data *veh;
 
   int numb, r_num;
@@ -1731,22 +1752,9 @@ ACMD(do_wizload)
     act("$n has created $N!", FALSE, ch, 0, mob, TO_ROOM);
     act("You create $N.", FALSE, ch, 0, mob, TO_CHAR);
   } else if (is_abbrev(buf, "obj")) {
-    if ((r_num = real_object(numb)) < 0) {
-      send_to_char("There is no object with that number.\r\n", ch);
-      return;
-    }
-    obj = read_object(r_num, REAL);
-    obj->obj_flags.extra_flags.SetBit(ITEM_WIZLOAD);
-    obj_to_char(obj, ch);
-
-    act("$n makes a strange magical gesture.", TRUE, ch, 0, 0, TO_ROOM);
-    act("$n has created $p!", FALSE, ch, obj, 0, TO_ROOM);
-    act("You create $p.", FALSE, ch, obj, 0, TO_CHAR);
-    sprintf(buf, "%s wizloaded object #%d (%s).",
-            GET_CHAR_NAME(ch), numb, obj->text.name);
-    mudlog(buf, ch, LOG_CHEATLOG, TRUE);
+    perform_wizload_object(ch, numb);
   } else
-    send_to_char("That'll have to be either 'obj' or 'mob'.\r\n", ch);
+    send_to_char("That'll have to be either 'obj', 'mob', or 'veh'.\r\n", ch);
 }
 
 ACMD(do_vstat)


### PR DESCRIPTION
…m_wizload_obj. This unifies the logic (no more arbitrary restrictions on one but not the other) and gets rid of a bug where an object created by the staff could be treated as a non-staff object. Also, why do we have both IMMLOAD and WIZLOAD flags? (Resolves #45)