### PR TITLE
Fold Argon2 password hashing changes from libsodium branch to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ Tested on:
 If you get an error like `newdb.cpp:11:10: fatal error: mysql/mysql.h: No such file or directory` while running `make`, you either haven't installed the MySQL development headers, or you haven't made them visible to your operating system. Since each OS is different, Google is your best bet for resolving this, but your goal / end state is to have the header inclusion path `mysql/mysql.h` resolve successfully.
 
 If you get an error like `AwakeMUD/src/act.wizard.cpp:3841: undefined reference to 'crypt'`, it means that you've probably not selected the right OS in your `src/Makefile`. Make sure you comment out the OS X lines near the top by adding a `#` at their beginnings, and uncomment the Linux lines by removing their `#`.
+
+### Runtime Troubleshooting
+
+If you get an error like `MYSQLERROR: Data too long for column 'Password' at row X` when running the game, you need to update your database's pfile table to use the longer password-column capacity. Go into your database and execute the command in `SQL/migration-libsodium.sql`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Tested on:
 - Raspbian Jessie
 
 ## Installation
-- Install MySQL 5, including its development headers (`mysql/mysql.h`)
+- Install MySQL 5, including its development headers (`mysql/mysql.h`).
+- Install [libsodium](https://github.com/jedisct1/libsodium/releases) (`./configure; make; make install`).
 - Clone this repository to your machine.
 - Run `SQL/gensql.sh` (or do the steps manually if it doesn't support your OS). If you plan on running this with MariaDB, use the `--skip-checks` command-line flag.
 - Copy the mysql_config.cpp file to src.

--- a/SQL/awakemud.sql
+++ b/SQL/awakemud.sql
@@ -1,7 +1,7 @@
 CREATE TABLE `pfiles` ( 
   `idnum` mediumint(5) unsigned unique default '0', 
   `Name` varchar(21) default '', 
-  `Password` varchar(30), 
+  `Password` varchar(200), 
   `Race` tinyint(2) default '0', 
   `Gender` tinyint(2) default '0', 
   `Rank` tinyint(2) default '1', 

--- a/SQL/migration-libsodium.sql
+++ b/SQL/migration-libsodium.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `pfiles` MODIFY `Password` VARCHAR(200);

--- a/src/Makefile
+++ b/src/Makefile
@@ -24,7 +24,7 @@ CVS = cvs
 # smooth, the define can be removed.
 
 # OSX? Uncomment these:
-LIBS = -L/usr/local/lib -lmysqlclient -lz -lm -lcurl
+LIBS = -L/usr/local/lib -lmysqlclient -lz -lm -lcurl -lsodium
 MYFLAGS = -DDEBUG -DSELFADVANCE -DIDLEDELETE_DRYRUN -DGITHUB_INTEGRATION -Dosx -I /usr/local/include/ -Wall -Wextra -Wno-unused-parameter
 
 # Linux / others? Uncomment these:

--- a/src/act.wizard.cpp
+++ b/src/act.wizard.cpp
@@ -43,6 +43,7 @@
 #include "config.h"
 #include "newmatrix.h"
 #include "limits.h"
+#include "security.h"
 
 #if defined(__CYGWIN__)
 #include <crypt.h>
@@ -3842,8 +3843,7 @@ ACMD(do_set)
       SET_CLEANUP(false);
       return;
     }
-    strncpy(vict->player.passwd, CRYPT(val_arg, GET_NAME(vict)), MAX_PWD_LENGTH);
-    vict->player.passwd[MAX_PWD_LENGTH] = '\0';
+    hash_and_store_password(val_arg, GET_PASSWD(vict));
     sprintf(buf, "Password changed to '%s'.", val_arg);
     break;
   case 40:

--- a/src/awake.h
+++ b/src/awake.h
@@ -1946,9 +1946,7 @@ enum {
 #define MAX_MESSAGES              100
 #define MAX_NAME_LENGTH           20  /* Used in char_file_u *DO*NOT*CHANGE* */
 
-// MAX_PWD_LENGTH is bullshit though, crypt() truncates it to 8. Go go 90s security!
-#define MAX_PWD_LENGTH            30  /* Used in char_file_u *DO*NOT*CHANGE* */
-
+#define MAX_PWD_LENGTH            30  /* Relic of the past, do not change. Dictates max length of crypt() hashes. */
 #define MAX_TITLE_LENGTH          50  /* Used in char_file_u *DO*NOT*CHANGE* */
 #define MAX_WHOTITLE_LENGTH       10  /* Used in char_file_u *DO*NOT*CHANGE* */
 #define HOST_LENGTH               50

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -201,6 +201,7 @@ void load_consist(void);
 void boot_shop_orders(void);
 void price_cyber(struct obj_data *obj);
 void price_bio(struct obj_data *obj);
+extern void verify_db_password_column_size();
 
 /* external vars */
 extern int no_specials;
@@ -286,6 +287,9 @@ void boot_world(void)
   
   log("Booting MYSQL database.");
   initialize_and_connect_to_mysql();
+  
+  log("Verifying DB compatibility with extended-length passwords.");
+  verify_db_password_column_size();
   
   log("Handling idle deletion.");
   idle_delete();

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -279,8 +279,10 @@ void boot_world(void)
     exit(1);
   }
   
-  log("Performing crypto tests.");
+#ifdef DEBUG
+  log("Performing crypto performance and validation tests.");
   run_crypto_tests();
+#endif
   
   log("Booting MYSQL database.");
   initialize_and_connect_to_mysql();

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -27,6 +27,7 @@
 #else
 #include <unistd.h>
 #endif
+#include <sodium.h>
 
 /* mysql_config.h must be filled out with your own connection info. */
 /* For obvious reasons, DO NOT ADD THIS FILE TO SOURCE CONTROL AFTER CUSTOMIZATION. */
@@ -51,6 +52,7 @@
 #include "constants.h"
 #include "vtable.h"
 #include "config.h"
+#include "security.h"
 #include <new>
 
 extern void calc_weight(struct char_data *ch);
@@ -270,6 +272,17 @@ void initialize_and_connect_to_mysql() {
 
 void boot_world(void)
 {
+#ifdef USE_ARGON2_FOR_HASHING
+  log("Initializing libsodium for crypto functions.");
+  if (sodium_init() < 0) {
+    // The library could not be initialized. Fail.
+    log("ERROR: Libsodium initialization failed. Terminating program.");
+    exit(1);
+  }
+  
+  log("Performing crypto tests.");
+  run_crypto_tests();
+#endif
   
   log("Booting MYSQL database.");
   initialize_and_connect_to_mysql();

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -272,7 +272,6 @@ void initialize_and_connect_to_mysql() {
 
 void boot_world(void)
 {
-#ifdef USE_ARGON2_FOR_HASHING
   log("Initializing libsodium for crypto functions.");
   if (sodium_init() < 0) {
     // The library could not be initialized. Fail.
@@ -282,7 +281,6 @@ void boot_world(void)
   
   log("Performing crypto tests.");
   run_crypto_tests();
-#endif
   
   log("Booting MYSQL database.");
   initialize_and_connect_to_mysql();

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -2258,6 +2258,18 @@ void nanny(struct descriptor_data * d, char *arg)
         }
         return;
       }
+      
+      // Commit the password to DB on the assumption it's changed.
+      char query_buf[2048];
+#ifdef NOCRYPT
+      char prepare_quotes_buf[2048];
+      sprintf(query_buf, "UPDATE pfiles SET password='%s' WHERE idnum=%ld;",
+              prepare_quotes(prepare_quotes_buf, GET_PASSWD(d->character)), GET_IDNUM(d->character));
+#else
+      sprintf(query_buf, "UPDATE pfiles SET password='%s' WHERE idnum=%ld;", GET_PASSWD(d->character), GET_IDNUM(d->character));
+#endif
+      mysql_wrapper(mysql, query_buf);
+      
       load_result = GET_BAD_PWS(d->character);
       GET_BAD_PWS(d->character) = 0;
 
@@ -2371,7 +2383,14 @@ void nanny(struct descriptor_data * d, char *arg)
         STATE(d) = CON_MENU;
       }
       if (STATE(d) == CON_CHPWD_VRFY) {
-        sprintf(buf, "UPDATE pfiles SET password='%s' WHERE idnum=%ld", GET_PASSWD(d->character), GET_IDNUM(d->character));
+        char query_buf[2048];
+#ifdef NOCRYPT
+        char prepare_quotes_buf[2048];
+        sprintf(query_buf, "UPDATE pfiles SET password='%s' WHERE idnum=%ld;",
+                prepare_quotes(prepare_quotes_buf, GET_PASSWD(d->character)), GET_IDNUM(d->character));
+#else
+        sprintf(query_buf, "UPDATE pfiles SET password='%s' WHERE idnum=%ld;", GET_PASSWD(d->character), GET_IDNUM(d->character));
+#endif
         mysql_wrapper(mysql, buf);
         SEND_TO_Q(MENU, d);
         STATE(d) = CON_MENU;

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -2325,8 +2325,7 @@ void nanny(struct descriptor_data * d, char *arg)
   case
       CON_CHPWD_GETNEW:
   case CON_QGETNEWPW:
-    if (!*arg || strlen(arg) > MAX_PWD_LENGTH || strlen(arg) < 3 ||
-        !str_cmp(arg, GET_CHAR_NAME(d->character))) {
+    if (!*arg || strlen(arg) < 3 || !str_cmp(arg, GET_CHAR_NAME(d->character))) {
       SEND_TO_Q("\r\nIllegal password.\r\n", d);
       SEND_TO_Q("Password: ", d);
       return;

--- a/src/newdb.cpp
+++ b/src/newdb.cpp
@@ -1874,3 +1874,15 @@ void idle_delete()
 }
 
 
+void verify_db_password_column_size() {
+  // show columns in pfiles like 'password';
+  mysql_wrapper(mysql, "SHOW COLUMNS IN `pfiles` LIKE 'password';");
+  MYSQL_RES *res = mysql_use_result(mysql);
+  MYSQL_ROW row = mysql_fetch_row(res);
+  if (strncmp(row[1], "varchar(200)", sizeof("varchar(200)")) != 0) {
+    log("FATAL ERROR: Your pfiles table's password column needs to be reconfigured.");
+    log("Execute this command on your database:  ALTER TABLE `pfiles` MODIFY `Password` VARCHAR(200);");
+    exit(1);
+  }
+  mysql_free_result(res);
+}

--- a/src/security.cpp
+++ b/src/security.cpp
@@ -5,6 +5,7 @@
 #include "utils.h"
 #include "structs.h"
 #include "comm.h"
+#include "newdb.h"
 #include "security.h"
 
 #ifdef NOCRYPT

--- a/src/security.cpp
+++ b/src/security.cpp
@@ -107,8 +107,12 @@ void hash_and_store_password(const char* password, char* array_to_write_to) {
 // Returns TRUE on match, FALSE otherwise.
 bool validate_password(const char* password, const char* hashed_password) {
   // If this is a new-style argon2, verify with the correct algorithm.
-  if (strstr(hashed_password, ARGON2_HASH_PREFIX) != NULL)
+  if (strstr(hashed_password, ARGON2ID_HASH_PREFIX) != NULL)
     return crypto_pwhash_str_verify(hashed_password, password, strlen(password)) == 0;
+  else if (strstr(hashed_password, ARGON2_HASH_PREFIX) != NULL) {
+    log("WARNING: You are not using the currently-recommended Argon2id() hashing algorithm. Your game will probably still function, but your passwords will not be a secure as they could be.");
+    return crypto_pwhash_str_verify(hashed_password, password, strlen(password)) == 0;
+  }
   
   // Otherwise, we're dealing with an old crypt() password.
   else

--- a/src/security.cpp
+++ b/src/security.cpp
@@ -1,0 +1,60 @@
+#include <time.h>
+#include <string.h>
+#include <sodium.h>
+
+#include "utils.h"
+#include "structs.h"
+#include "comm.h"
+#include "security.h"
+
+
+// Insecure test password is used for crypto tests.
+#define INSECURE_TEST_PASSWORD "8h4engowo)(WTWerhio*"
+bool run_crypto_tests() {
+  char hashed_password[crypto_pwhash_STRBYTES];
+  char message_buf[2048];
+  struct timeval start, end;
+  
+  log("Testing hashing and verifying reproducibility of output.");
+  gettimeofday(&start, (struct timezone *) 0);
+  
+  // Hash our test password.
+  hash_password(INSECURE_TEST_PASSWORD, hashed_password);
+  
+  // Output for entertainment.
+  log(hashed_password);
+  
+  // Check if our test password passes verification (is it reproducible).
+  if (!validate_password(INSECURE_TEST_PASSWORD, hashed_password))
+    return FALSE;
+  
+  gettimeofday(&end, (struct timezone *) 0);
+  long elapsed = ((end.tv_sec - start.tv_sec) * 1000000L + end.tv_usec) - start.tv_usec;
+  long elapsed_secs = (int) (elapsed / 1000000L);
+  sprintf(message_buf, "Reproducibility tests completed in %ld microseconds (approx ~%ld sec).",
+          elapsed, elapsed_secs);
+  log(message_buf);
+  
+  if (elapsed > (long) (ACCEPTABLE_HASH_TIME_IN_SECONDS * 1000000L)) {
+    log("FATAL ERROR: Hashing time exceeded the allowable threshold. Modify security.h to increase your threshold, or lower your OPSLIMIT and MEMLIMIT values. WARNING: CHANGING OPSLIMIT OR MEMLIMIT WILL BREAK ALL YOUR OLD PASSWORDS.");
+    exit(1);
+  }
+  
+  return TRUE;
+}
+#undef INSECURE_TEST_PASSWORD
+
+// hash_password(): Hashing is dead simple now.
+void hash_password(const char* password, char* array_to_write_to) {
+  if (crypto_pwhash_str
+      (array_to_write_to, password, strlen(password), CRYPTO_OPSLIMIT, CRYPTO_MEMLIMIT) != 0) {
+        /* out of memory */
+        log("ERROR: We ran out of memory while hashing a password. Full stop.");
+        exit(1);
+      }
+}
+
+// validate_password(): Check if a password matches the given hash.
+bool validate_password(const char* password, const char* hashed_password) {
+  return crypto_pwhash_str_verify(hashed_password, password, strlen(password)) == 0;
+}

--- a/src/security.cpp
+++ b/src/security.cpp
@@ -35,9 +35,6 @@ bool run_crypto_tests() {
   // Hash our test password.
   hash_and_store_password(INSECURE_TEST_PASSWORD, hashed_password);
   
-  // Output for entertainment.
-  log(hashed_password);
-  
   // Check if our test password passes verification (is it reproducible).
   if (!validate_password(INSECURE_TEST_PASSWORD, hashed_password)) {
     log("FATAL ERROR: We failed to validate the initial argon2 test password after hashing.");

--- a/src/security.cpp
+++ b/src/security.cpp
@@ -110,11 +110,19 @@ bool validate_password(const char* password, const char* hashed_password) {
   if (strstr(hashed_password, ARGON2ID_HASH_PREFIX) != NULL)
     return crypto_pwhash_str_verify(hashed_password, password, strlen(password)) == 0;
   else if (strstr(hashed_password, ARGON2_HASH_PREFIX) != NULL) {
-    log("WARNING: You are not using the currently-recommended Argon2id() hashing algorithm. Your game will probably still function, but your passwords will not be a secure as they could be.");
+    /* WARNING: You are not using the currently-recommended Argon2id() hashing algorithm.
+     Your game will probably still function, but your passwords will not be a secure as they could be. */
     return crypto_pwhash_str_verify(hashed_password, password, strlen(password)) == 0;
   }
   
   // Otherwise, we're dealing with an old crypt() password.
+  /* Maintainer's note: If you see the following error, the above check is falling through and giving a too-long string to crypt().
+   
+   Program received signal SIGSEGV, Segmentation fault.
+   __strncmp_sse42 () at ../sysdeps/x86_64/multiarch/strcmp-sse42.S:164
+   164     ../sysdeps/x86_64/multiarch/strcmp-sse42.S: No such file or directory.
+   
+   TODO: actually fix this */
   else
     return !strncmp(CRYPT(password, hashed_password), hashed_password, MAX_PWD_LENGTH);
 }

--- a/src/security.cpp
+++ b/src/security.cpp
@@ -7,6 +7,19 @@
 #include "comm.h"
 #include "security.h"
 
+#ifdef NOCRYPT
+bool run_crypto_tests() {return TRUE;}
+void hash_and_store_password(const char* password, char* array_to_write_to) {
+  strcpy(array_to_write_to, password);
+}
+bool validate_password(const char* password, const char* hashed_password) {
+  return strncmp(password, hashed_password) != NULL;
+}
+bool validate_and_update_password(const char* password, char* hashed_password) {
+  return strncmp(password, hashed_password) != NULL;
+}
+#else
+
 
 // Insecure test password is used for crypto tests.
 #define INSECURE_TEST_PASSWORD "8h4engowo)(WTWerhio*"
@@ -19,14 +32,16 @@ bool run_crypto_tests() {
   gettimeofday(&start, (struct timezone *) 0);
   
   // Hash our test password.
-  hash_password(INSECURE_TEST_PASSWORD, hashed_password);
+  hash_and_store_password(INSECURE_TEST_PASSWORD, hashed_password);
   
   // Output for entertainment.
   log(hashed_password);
   
   // Check if our test password passes verification (is it reproducible).
-  if (!validate_password(INSECURE_TEST_PASSWORD, hashed_password))
-    return FALSE;
+  if (!validate_password(INSECURE_TEST_PASSWORD, hashed_password)) {
+    log("FATAL ERROR: We failed to validate the initial argon2 test password after hashing.");
+    exit(1);
+  }
   
   gettimeofday(&end, (struct timezone *) 0);
   long elapsed = ((end.tv_sec - start.tv_sec) * 1000000L + end.tv_usec) - start.tv_usec;
@@ -40,12 +55,45 @@ bool run_crypto_tests() {
     exit(1);
   }
   
+  // Begin test of the conversion algorithms.
+  strncpy(hashed_password, CRYPT(INSECURE_TEST_PASSWORD, "TestChar"), MAX_PWD_LENGTH);
+  
+  // Validate crypt() vs password.
+  if (!validate_password(INSECURE_TEST_PASSWORD, hashed_password)) {
+    log("FATAL ERROR: validate_password() failed to match a crypt() password with its origin string.");
+    exit(1);
+  }
+  
+  // Check crypt() and update to argon2.
+  if (!validate_and_update_password(INSECURE_TEST_PASSWORD, hashed_password)) {
+    log("FATAL ERROR: validate_and_update_password() failed to validate a crypt() password.");
+    exit(1);
+  }
+  
+  // Confirm update succeeded.
+  if (strstr(hashed_password, ARGON2_HASH_PREFIX) == NULL) {
+    log("FATAL ERROR: validate_and_update_password() failed to change crypt() password to argon2.");
+    exit(1);
+  }
+  
+  // Validate argon2 vs password.
+  if (!validate_password(INSECURE_TEST_PASSWORD, hashed_password)) {
+    log("FATAL ERROR: validate_password() failed to match an argon2() password with its origin string.");
+    exit(1);
+  }
+  
+  // Validate argon2 vs password via update function.
+  if (!validate_and_update_password(INSECURE_TEST_PASSWORD, hashed_password)) {
+    log("FATAL ERROR: validate_and_update_password() failed to validate argon2() password.");
+    exit(1);
+  }
+  
   return TRUE;
 }
 #undef INSECURE_TEST_PASSWORD
 
-// hash_password(): Hashing is dead simple now.
-void hash_password(const char* password, char* array_to_write_to) {
+// hash_and_store_password(): Hashing is dead simple now. Writes out to second argument's array.
+void hash_and_store_password(const char* password, char* array_to_write_to) {
   if (crypto_pwhash_str
       (array_to_write_to, password, strlen(password), CRYPTO_OPSLIMIT, CRYPTO_MEMLIMIT) != 0) {
         /* out of memory */
@@ -55,6 +103,30 @@ void hash_password(const char* password, char* array_to_write_to) {
 }
 
 // validate_password(): Check if a password matches the given hash.
+// Returns TRUE on match, FALSE otherwise.
 bool validate_password(const char* password, const char* hashed_password) {
-  return crypto_pwhash_str_verify(hashed_password, password, strlen(password)) == 0;
+  // If this is a new-style argon2, verify with the correct algorithm.
+  if (strstr(hashed_password, ARGON2_HASH_PREFIX) != NULL)
+    return crypto_pwhash_str_verify(hashed_password, password, strlen(password)) == 0;
+  
+  // Otherwise, we're dealing with an old crypt() password.
+  else
+    return !strncmp(CRYPT(password, hashed_password), hashed_password, MAX_PWD_LENGTH);
 }
+
+// validate_and_update_password(): Check if a password matches the given hash. Re-hash to argon2 if needed.
+// Returns TRUE on match, FALSE otherwise.
+bool validate_and_update_password(const char* password, char* hashed_password) {
+  // If the passwords don't match, we aren't going to re-hash.
+  if (!validate_password(password, (const char*) hashed_password)) {
+    return FALSE;
+  }
+  
+  // If the password is in the old crypt format, re-hash.
+  if (strstr(hashed_password, ARGON2_HASH_PREFIX) == NULL) {
+    hash_and_store_password(password, hashed_password);
+  }
+  
+  return TRUE;
+}
+#endif // #ifdef NOCRYPT's #else

--- a/src/security.h
+++ b/src/security.h
@@ -9,7 +9,8 @@
 #define CRYPTO_MEMLIMIT crypto_pwhash_MEMLIMIT_MODERATE
 
 // The prefix string used to identify whether a password is argon2 or crypt().
-#define ARGON2_HASH_PREFIX "$argon2id$"
+#define ARGON2ID_HASH_PREFIX "$argon2id$"
+#define ARGON2_HASH_PREFIX "$argon2"
 
 bool run_crypto_tests();
 

--- a/src/security.h
+++ b/src/security.h
@@ -1,0 +1,19 @@
+#ifndef _security_h_
+#define _security_h_
+#ifdef USE_ARGON2_FOR_HASHING
+
+// Change this value to determine how many seconds you're willing to have the MUD hang for each hash.
+#define ACCEPTABLE_HASH_TIME_IN_SECONDS 1.5
+
+// VVV  WARNING: IF YOU CHANGE THESE, YOUR OLD PASSWORD HASHES WILL NOT WORK.  VVV
+#define CRYPTO_OPSLIMIT crypto_pwhash_OPSLIMIT_MODERATE
+#define CRYPTO_MEMLIMIT crypto_pwhash_MEMLIMIT_MODERATE
+// ^^^  WARNING: IF YOU CHANGE THESE, YOUR OLD PASSWORD HASHES WILL NOT WORK.  ^^^
+
+bool run_crypto_tests();
+
+void hash_password(const char* password, char* array_to_write_to);
+bool validate_password(const char* password, const char* hashed_password);
+
+#endif // #ifndef USE_ARGON2_FOR_HASHING
+#endif // #ifndef _security_h_

--- a/src/security.h
+++ b/src/security.h
@@ -4,9 +4,9 @@
 // Change this value to determine how many seconds you're willing to have the MUD hang for each hash.
 #define ACCEPTABLE_HASH_TIME_IN_SECONDS 1.5
 
-// Warning: Changing these will not affect the hashing speed of old password hashes.
-#define CRYPTO_OPSLIMIT crypto_pwhash_OPSLIMIT_MODERATE
-#define CRYPTO_MEMLIMIT crypto_pwhash_MEMLIMIT_MODERATE
+// Warning: Changing these will not affect the hashing speed of old password hashes. It may also break old hashes, this has not been tested.
+#define CRYPTO_OPSLIMIT crypto_pwhash_OPSLIMIT_INTERACTIVE
+#define CRYPTO_MEMLIMIT crypto_pwhash_MEMLIMIT_INTERACTIVE
 
 // The prefix string used to identify whether a password is argon2 or crypt().
 #define ARGON2ID_HASH_PREFIX "$argon2id$"

--- a/src/security.h
+++ b/src/security.h
@@ -1,19 +1,20 @@
 #ifndef _security_h_
 #define _security_h_
-#ifdef USE_ARGON2_FOR_HASHING
 
 // Change this value to determine how many seconds you're willing to have the MUD hang for each hash.
 #define ACCEPTABLE_HASH_TIME_IN_SECONDS 1.5
 
-// VVV  WARNING: IF YOU CHANGE THESE, YOUR OLD PASSWORD HASHES WILL NOT WORK.  VVV
+// Warning: Changing these will not affect the hashing speed of old password hashes.
 #define CRYPTO_OPSLIMIT crypto_pwhash_OPSLIMIT_MODERATE
 #define CRYPTO_MEMLIMIT crypto_pwhash_MEMLIMIT_MODERATE
-// ^^^  WARNING: IF YOU CHANGE THESE, YOUR OLD PASSWORD HASHES WILL NOT WORK.  ^^^
+
+// The prefix string used to identify whether a password is argon2 or crypt().
+#define ARGON2_HASH_PREFIX "$argon2id$"
 
 bool run_crypto_tests();
 
-void hash_password(const char* password, char* array_to_write_to);
+void hash_and_store_password(const char* password, char* array_to_write_to);
 bool validate_password(const char* password, const char* hashed_password);
+bool validate_and_update_password(const char* password, char* hashed_password);
 
-#endif // #ifndef USE_ARGON2_FOR_HASHING
 #endif // #ifndef _security_h_

--- a/src/structs.h
+++ b/src/structs.h
@@ -298,7 +298,7 @@ struct time_data
 struct char_player_data
 {
   char *char_name;
-  char passwd[crypto_pwhash_STRBYTES];     /* character's password         */
+  char passwd[crypto_pwhash_STRBYTES + 1];     /* character's password         */
 
   text_data physical_text;
   text_data astral_text;

--- a/src/structs.h
+++ b/src/structs.h
@@ -5,6 +5,8 @@
 #include <sys/time.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sodium.h> // for crypto_pwhash_STRBYTES
+
 #include "types.h"
 #include "awake.h"
 #include "list.h"
@@ -296,7 +298,7 @@ struct time_data
 struct char_player_data
 {
   char *char_name;
-  char passwd[MAX_PWD_LENGTH+1];     /* character's password         */
+  char passwd[crypto_pwhash_STRBYTES];     /* character's password         */
 
   text_data physical_text;
   text_data astral_text;


### PR DESCRIPTION
This PR brings in [Argon2](https://en.wikipedia.org/wiki/Argon2) to replace crypt(). This increases the resistance of stored passwords to brute-forcing.

**WARNING: IF YOU UPGRADE YOUR CODEBASE TO THIS PATCH, YOU MUST ALSO MODIFY YOUR DATABASE IN ACCORDANCE WITH `SQL/migration-libsodium.sql`. FAILURE TO DO SO WILL RESULT IN PASSWORDS NO LONGER SAVING FOR ALL CHARACTERS, AND MAY BREAK NEW CHARACTERS AS WELL.**