### PR TITLE
Partial fix for #168.

### DIFF
--- a/src/newdb.cpp
+++ b/src/newdb.cpp
@@ -712,6 +712,15 @@ bool load_char(const char *name, char_data *ch, bool logon)
             }
         inside = atoi(row[17]);
         GET_OBJ_TIMER(obj) = atoi(row[19]);
+        
+        // row 20: extra flags. We want to retain the proto's flags but also persist anti-cheat flags.
+        Bitfield temp_extra_flags;
+        temp_extra_flags.FromString(row[20]);
+        if (temp_extra_flags.IsSet(ITEM_WIZLOAD))
+          GET_OBJ_EXTRA(obj).SetBit(ITEM_WIZLOAD);
+        if (temp_extra_flags.IsSet(ITEM_IMMLOAD))
+          GET_OBJ_EXTRA(obj).SetBit(ITEM_IMMLOAD);
+        
         GET_OBJ_ATTEMPT(obj) = atoi(row[21]);
         GET_OBJ_CONDITION(obj) = atoi(row[22]);
         if (inside > 0) {
@@ -774,6 +783,15 @@ bool load_char(const char *name, char_data *ch, bool logon)
             }
         inside = atoi(row[17]);
         GET_OBJ_TIMER(obj) = atoi(row[18]);
+        
+        // row 19: extra flags. We want to retain the proto's flags but also persist anti-cheat flags.
+        Bitfield temp_extra_flags;
+        temp_extra_flags.FromString(row[19]);
+        if (temp_extra_flags.IsSet(ITEM_WIZLOAD))
+          GET_OBJ_EXTRA(obj).SetBit(ITEM_WIZLOAD);
+        if (temp_extra_flags.IsSet(ITEM_IMMLOAD))
+          GET_OBJ_EXTRA(obj).SetBit(ITEM_IMMLOAD);
+        
         GET_OBJ_ATTEMPT(obj) = atoi(row[20]);
         GET_OBJ_CONDITION(obj) = atoi(row[21]);
         if (inside > 0) {


### PR DESCRIPTION
Remaining: bioware and cyberware, which currently don't retain extra flags.