### PR TITLE
Band-aid fix for #186.

### DIFF
--- a/src/zedit.cpp
+++ b/src/zedit.cpp
@@ -1112,6 +1112,8 @@ void zedit_parse(struct descriptor_data *d, const char *arg)
         ZON->editor_ids[2] = t[2];
         ZON->editor_ids[3] = t[3];
         ZON->editor_ids[4] = t[4];
+      } else {
+        send_to_char("That field requires five separate integers. Example: 9 123 4 0 0", CH);
       }
       zedit_disp_data_menu(d);
     }


### PR DESCRIPTION
Zedit editor list setting now informs you if you have not met the requirement for setting the zone editor IDs (i.e. not put exactly 5 separate integers in). A full fix would be a rewriting of the parser to allow any number of IDs up to five, and auto-filling the rest with zeroes.