### PR TITLE
Fix racial_attribute_modifier compile error

### DIFF
--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -1657,7 +1657,7 @@ int racial_limits[][2][6] = {
                               {{ 6, 8, 6, 8, 6, 6 },{ 9, 12, 9, 12, 9, 9 }} // night one
                             };
 
-char racial_attribute_modifiers[][6] = {
+int racial_attribute_modifiers[][6] = {
 //  BOD QUI STR CHA INT WIL
   {  0,  0,  0,  0,  0,  0  }, // undef
   {  0,  0,  0,  0,  0,  0  }, // undef

--- a/src/constants.h
+++ b/src/constants.h
@@ -74,7 +74,7 @@ extern struct program_data programs[];
 extern int attack_multiplier[];
 extern const char *positions[];
 extern int racial_limits[][2][6];
-extern char racial_attribute_modifiers[][6];
+extern int racial_attribute_modifiers[][6];
 extern const char *attributes[];
 extern const char *short_attributes[];
 extern struct drug_data drug_types[];


### PR DESCRIPTION
Switch _char_ to _int_ to fix a compiling error on ubuntu 18.04:

```
clang  -DDEBUG_CRYPTO -DDEBUG -DSELFADVANCE -DIDLEDELETE_DRYRUN -Dlinux -I /usr/local/include/ -Wall -Wextra -Wno-unused-parameter -g                                                        gdb  -c -o constants.o constants.cpp
constants.cpp:1667:17: error: constant expression evaluates to -1 which cannot be narrowed to type 'char' [-Wc++11-narrowing]
  {  3,  0,  2, -1, -1,  0  }, // ork
                ^~
constants.cpp:1667:17: note: insert an explicit cast to silence this issue
  {  3,  0,  2, -1, -1,  0  }, // ork
                ^~
                static_cast<char>( )

```
~~

```
constants.cpp:1679:17: error: constant expression evaluates to -1 which cannot be narrowed to type 'char' [-Wc++11-narrowing]
  {  4, -1,  3, -1, -1,  0  }, // minotaur
                ^~
constants.cpp:1679:17: note: insert an explicit cast to silence this issue
  {  4, -1,  3, -1, -1,  0  }, // minotaur
                ^~
                static_cast<char>( )
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
<builtin>: recipe for target 'constants.o' failed
make: *** [constants.o] Error 1
```