### PR TITLE
Tactical Computer Cyberware

### DIFF
--- a/src/awake.h
+++ b/src/awake.h
@@ -1388,7 +1388,8 @@ enum {
 #define CYB_MUSCLEREP        46
 #define CYB_ARMS             47
 #define CYB_LEGS             48
-#define NUM_CYBER            49
+#define CYB_TACTICALCOMPUTER 49
+#define NUM_CYBER            50
 
 #define BIO_ADRENALPUMP    0
 #define BIO_CATSEYES    1

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -2220,7 +2220,8 @@ const char *cyber_types[] = {
   "Smartlink",
   "Muscle Replacement",
   "Paired Set of Cyber Arms",
-  "Paired Set of Cyber Legs"
+  "Paired Set of Cyber Legs",
+  "Tactical Computer"
 };
 
 const char *decap_cyber_types[] = {
@@ -2272,7 +2273,8 @@ const char *decap_cyber_types[] = {
   "smartlink",
   "muscle replacement",
   "paired set of cyber arms",
-  "paired set of cyber legs"
+  "paired set of cyber legs",
+  "tactical computer"
 };
 
 const char *bio_types[] = {

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -5933,6 +5933,25 @@ void price_cyber(struct obj_data *obj)
         GET_OBJ_AVAILDAY(obj) = MAX(GET_OBJ_AVAILDAY(obj), 1);
       }
       break;
+    case CYB_TACTICALCOMPUTER:
+      GET_CYBERWARE_ESSENCE_COST(obj) = 130 + (GET_OBJ_VAL(obj, 1) * 20);
+      GET_OBJ_AVAILTN(obj) = 12;
+      GET_OBJ_AVAILDAY(obj) = 60;
+      switch (GET_OBJ_VAL(obj, 1)) {
+        case 1:
+          GET_OBJ_COST(obj) = 400000;
+          break;
+        case 2:
+          GET_OBJ_COST(obj) = 420000;
+          break;
+        case 3:
+          GET_OBJ_COST(obj) = 440000;
+          break;
+        case 4:
+          GET_OBJ_COST(obj) = 460000;
+          break;
+      }
+      break;
   }
   switch (GET_OBJ_VAL(obj, 2)) {
     case GRADE_ALPHA:


### PR DESCRIPTION
Pretty self explanatory, it's the Tactical Computer cyberware from Man & Machine, page 22. Most of its bonuses are NERP ingame, but it's the only ware in canon that directly adds Combat Pool dice, so that's nice.