### PR TITLE
WIP: Implement Player Cyberdocs

### DIFF
--- a/lib/world/obj/0.obj
+++ b/lib/world/obj/0.obj
@@ -802,6 +802,22 @@ Material:	paper
 [VALUES]
 	Val0:	25000
 BREAK
+#83
+Keywords:	shopcontainer container
+Name:	a generic shopcontainer
+RoomDesc:$
+A bundle of goods from a shop has been set aside here.~
+LookDesc:$
+It's carefully packaged up in opaque anti-static plastic, protecting the 'ware
+inside it from the elements. See ^WHELP CYBERDOC^n for instructions on what to do
+with it! 
+~
+Type:	Shop Container
+WearFlags:	1
+Material:	metal
+[POINTS]
+	Barrier:	32
+BREAK
 #100
 Keywords:	credstick plastic
 Name:	a plastic credstick
@@ -1176,10 +1192,10 @@ Material:	concrete
 	Barrier:	32
 BREAK
 #121
-Keywords:	metal ammo ammunition box normal edged weapon 10-round rounds
-Name:	a 10-round box of normal edged weapon ammunition
+Keywords:	metal ammo ammunition box nondescript
+Name:	a nondescript box of ammunition
 RoomDesc:$
-A metal box of normal edged weapon rounds has been left here.~
+A metal box of ammunition has been left here.~
 LookDesc:$
 A hefty box of ammunition, banded in metal and secured with flip-down hasps for transportation and storage.~
 Type:	Ammo Box

--- a/src/act.informative.cpp
+++ b/src/act.informative.cpp
@@ -1459,10 +1459,11 @@ void look_at_room(struct char_data * ch, int ignore_brief, int is_quicklook)
     ROOM_FLAGS(ch->in_room).PrintBits(buf, MAX_STRING_LENGTH, room_bits, ROOM_MAX);
     send_to_char(ch, "^C[%5ld] %s [ %s ]^n\r\n", GET_ROOM_VNUM(ch->in_room), GET_ROOM_NAME(ch->in_room), buf);
   } else {
-    send_to_char(ch, "^C%s^n%s%s%s%s%s%s\r\n", GET_ROOM_NAME(ch->in_room),
+    send_to_char(ch, "^C%s^n%s%s%s%s%s%s%s\r\n", GET_ROOM_NAME(ch->in_room),
                  ROOM_FLAGGED(ch->in_room, ROOM_GARAGE) ? " (Garage)" : "",
                  ROOM_FLAGGED(ch->in_room, ROOM_STORAGE) && !ROOM_FLAGGED(ch->in_room, ROOM_CORPSE_SAVE_HACK) ? " (Storage)" : "",
                  ROOM_FLAGGED(ch->in_room, ROOM_HOUSE) ? " (Apartment)" : "",
+                 ROOM_FLAGGED(ch->in_room, ROOM_STERILE) ? " (Sterile)" : "",
                  ROOM_FLAGGED(ch->in_room, ROOM_ARENA) ? " ^y(Arena)^n" : "",
                  ch->in_room->matrix && real_host(ch->in_room->matrix) >= 1 ? " (Jackpoint)" : "",
                  ROOM_FLAGGED(ch->in_room, ROOM_ENCOURAGE_CONGREGATION) ? " ^W(Socialization Bonus)^n" : "");

--- a/src/act.informative.cpp
+++ b/src/act.informative.cpp
@@ -2393,14 +2393,29 @@ void do_probe_object(struct char_data * ch, struct obj_data * j) {
         snprintf(ENDOF(buf), sizeof(buf) - strlen(buf), " Its damage code is ^c%s^n.", wound_name[GET_OBJ_VAL(j, 3)]);
       break;
     case ITEM_BIOWARE:
-      snprintf(ENDOF(buf), sizeof(buf) - strlen(buf), "It is a ^crating-%d %s%s^n that uses ^c%.2f^n index when installed.",
-              GET_OBJ_VAL(j, 1), GET_OBJ_VAL(j, 2) || GET_OBJ_VAL(j, 0) >= BIO_CEREBRALBOOSTER ? "cultured " : "",
-              decap_bio_types[GET_OBJ_VAL(j, 0)], ((float) GET_OBJ_VAL(j, 4) / 100));
+      if (GET_BIOWARE_RATING(j) > 0) {
+        snprintf(ENDOF(buf), sizeof(buf) - strlen(buf), "It is a ^crating-%d %s%s^n that uses ^c%.2f^n index when installed.",
+                GET_BIOWARE_RATING(j), GET_BIOWARE_IS_CULTURED(j) ? "cultured " : "",
+                decap_bio_types[GET_BIOWARE_TYPE(j)], ((float) GET_BIOWARE_ESSENCE_COST(j) / 100));
+      } else {
+        snprintf(ENDOF(buf), sizeof(buf) - strlen(buf), "It is a ^c%s%s^n that uses ^c%.2f^n index when installed.",
+                GET_BIOWARE_IS_CULTURED(j) ? "cultured " : "",
+                decap_bio_types[GET_BIOWARE_TYPE(j)], ((float) GET_BIOWARE_ESSENCE_COST(j) / 100));
+      }
       break;
     case ITEM_CYBERWARE:
-      snprintf(ENDOF(buf), sizeof(buf) - strlen(buf), "It is a ^crating-%d %s-grade %s^n that uses ^c%.2f^n essence when installed.",
-              GET_OBJ_VAL(j, 1), decap_cyber_grades[GET_OBJ_VAL(j, 2)], decap_cyber_types[GET_OBJ_VAL(j, 0)],
-              ((float) GET_OBJ_VAL(j, 4) / 100));
+      if (GET_CYBERWARE_RATING(j) > 0) {
+        snprintf(ENDOF(buf), sizeof(buf) - strlen(buf), "It is a ^crating-%d %s-grade %s^n that uses ^c%.2f^n essence when installed.",
+                GET_CYBERWARE_RATING(j), decap_cyber_grades[GET_CYBERWARE_GRADE(j)], decap_cyber_types[GET_CYBERWARE_TYPE(j)],
+                ((float) GET_CYBERWARE_ESSENCE_COST(j) / 100));
+      } else {
+        snprintf(ENDOF(buf), sizeof(buf) - strlen(buf), "It is a ^c%s-grade %s^n that uses ^c%.2f^n essence when installed.",
+                decap_cyber_grades[GET_CYBERWARE_GRADE(j)], decap_cyber_types[GET_CYBERWARE_TYPE(j)],
+                ((float) GET_CYBERWARE_ESSENCE_COST(j) / 100));
+      }
+      if (IS_OBJ_STAT(j, ITEM_MAGIC_INCOMPATIBLE)) {
+        strlcat(buf, "\r\n^yIt is incompatible with magic.^n", sizeof(buf));
+      }
       break;
     case ITEM_WORKSHOP:
       snprintf(ENDOF(buf), sizeof(buf) - strlen(buf), "It is a ^c%s^n designed for ^c%s^n.",
@@ -2559,6 +2574,10 @@ void do_probe_object(struct char_data * ch, struct obj_data * j) {
     case ITEM_KEYRING:
       strlcat(buf, "Nothing stands out about this item's OOC values. Try EXAMINE it instead.", sizeof(buf));
       break;
+    case ITEM_SHOPCONTAINER:
+      send_to_char(ch, "%s is a shop container (see ^WHELP CYBERDOC^n for info). It contains:\r\n\r\n", capitalize(GET_OBJ_NAME(j)));
+      do_probe_object(ch, j->contains);
+      return;
     default:
       strncpy(buf, "This item type has no probe string. Contact the staff to request one.", sizeof(buf) - strlen(buf));
       break;

--- a/src/act.informative.cpp
+++ b/src/act.informative.cpp
@@ -4066,6 +4066,8 @@ ACMD(do_who)
         strlcat(buf1, " (AFK)", sizeof(buf1));
       if (PLR_FLAGGED(tch, PLR_RPE) && (level > LVL_MORTAL || PLR_FLAGGED(ch, PLR_RPE)))
         strlcat(buf1, " ^R(RPE)^n", sizeof(buf1));
+      if (PLR_FLAGGED(tch, PLR_CYBERDOC) && GET_LEVEL(tch) <= LVL_MORTAL)
+        strlcat(buf1, " ^c(Cyberdoc)^n", sizeof(buf1));
       
       if (PRF_FLAGGED(tch, PRF_NEWBIEHELPER) && (level > LVL_MORTAL || PRF_FLAGGED(ch, PRF_NEWBIEHELPER)))
         strlcat(buf1, " ^G(Newbie Helper)^n", sizeof(buf1));

--- a/src/act.other.cpp
+++ b/src/act.other.cpp
@@ -1137,7 +1137,9 @@ const char *tog_messages[][2] = {
                             {"You will now see pseudolanguage strings.\r\n",
                              "You will no longer see pseudolanguage strings.\r\n"},
                             {"You will now see the idle nuyen reward messages.\r\n",
-                             "You will no longer see the idle nuyen reward messages.\r\n"}
+                             "You will no longer see the idle nuyen reward messages.\r\n"},
+                            {"Player cyberdocs are no longer able to operate on you.\r\n",
+                             "Player cyberdocs are now able to operate on you. This flag will be un-set after each operation.\r\n"}
                           };
 
 ACMD(do_toggle)
@@ -1349,6 +1351,9 @@ ACMD(do_toggle)
     } else if (is_abbrev(argument, "noidlenuyenmessage") || is_abbrev(argument, "no idle nuyen message")) {
       result = PRF_TOG_CHK(ch, PRF_NO_IDLE_NUYEN_REWARD_MESSAGE);
       mode = 37;
+    } else if (is_abbrev(argument, "cyberdoc")) {
+      result = PRF_TOG_CHK(ch, PRF_TOUCH_ME_DADDY);
+      mode = 38;
     } else {
       send_to_char("That is not a valid toggle option.\r\n", ch);
       return;

--- a/src/act.other.cpp
+++ b/src/act.other.cpp
@@ -2000,6 +2000,8 @@ ACMD(do_treat)
     }
     return;
   }
+  if (vict->in_room && ROOM_FLAGGED(vict->in_room, ROOM_STERILE))
+    target -= 2;
   i = get_skill(ch, SKILL_BIOTECH, target);
 
   if (find_workshop(ch, TYPE_MEDICAL))

--- a/src/act.wizard.cpp
+++ b/src/act.wizard.cpp
@@ -4165,6 +4165,7 @@ ACMD(do_set)
                { "shotsfired", LVL_PRESIDENT, PC, NUMBER },
                { "shotstriggered", LVL_PRESIDENT, PC, NUMBER },
                { "powerpoints", LVL_PRESIDENT, PC, NUMBER },
+               { "cyberdoc", LVL_CONSPIRATOR, PC, BINARY },
                { "\n", 0, BOTH, MISC }
              };
 
@@ -4752,6 +4753,11 @@ ACMD(do_set)
     RANGE(0, 100);
     GET_PP(vict) = value;
     snprintf(buf, sizeof(buf),"%s changed %s's powerpoints to %d.", GET_CHAR_NAME(ch), GET_NAME(vict), value);
+    mudlog(buf, ch, LOG_WIZLOG, TRUE );
+    break;
+  case 79: /* cyberdoc permission */
+    SET_OR_REMOVE(PLR_FLAGS(vict), PLR_CYBERDOC);
+    snprintf(buf, sizeof(buf),"%s turned %s's cyberdoc flag %s.", GET_CHAR_NAME(ch), GET_NAME(vict), PLR_FLAGGED(vict, PLR_CYBERDOC) ? "ON" : "OFF");
     mudlog(buf, ch, LOG_WIZLOG, TRUE );
     break;
   default:

--- a/src/awake.h
+++ b/src/awake.h
@@ -304,7 +304,8 @@ enum {
 #define PLR_NO_IDLE_OUT         38 /* Player will not idle out (morts- for test chars) */
 #define PLR_TELLS_MUTED         39 /* Remove their ability to send tells. */
 #define PLR_NEWBIE_MUTED        40 /* Remove their ability to talk on the newbie channel. */
-#define PLR_MAX                 41
+#define PLR_CYBERDOC            41 /* Player may act as a cyberdoc. */
+#define PLR_MAX                 42
 
 
 
@@ -404,7 +405,8 @@ enum {
 #define PRF_NOHIGHLIGHT                  53
 #define PRF_NOPSEUDOLANGUAGE             54
 #define PRF_NO_IDLE_NUYEN_REWARD_MESSAGE 55
-#define PRF_MAX                          56
+#define PRF_TOUCH_ME_DADDY               56 /* Allows player cyberdocs to operate on you. Don't @ me. */
+#define PRF_MAX                          57
 
 /* log watch */
 
@@ -1030,6 +1032,7 @@ enum {
 #define TYPE_ACID             411
 #define TYPE_POLTERGEIST      412
 #define TYPE_ELEVATOR         413
+#define TYPE_MEDICAL_MISHAP   414
 
 #define WEAP_EDGED          0
 #define WEAP_CLUB           1
@@ -1115,7 +1118,8 @@ enum {
 #define ITEM_QUEST              41
 #define ITEM_GUN_AMMO           42
 #define ITEM_KEYRING            43
-#define NUM_ITEMS               44
+#define ITEM_SHOPCONTAINER      44
+#define NUM_ITEMS               45
 
 
 /* take/wear flags: used by obj_data.obj_flags.wear_flags */
@@ -2299,6 +2303,8 @@ enum {
 
 
 #define OBJ_OLD_BLANK_MAGAZINE_FROM_CLASSIC 601
+
+#define OBJ_SHOPCONTAINER                  83
 
 #define BOTTOM_OF_TEMPLATE_ITEMS           106
 #define OBJ_BLANK_OPTICAL_CHIP             106

--- a/src/awake.h
+++ b/src/awake.h
@@ -563,7 +563,8 @@ enum {
 #define ROOM_ELEVATOR_SHAFT         31 // Don't set this manually
 #define ROOM_ENCOURAGE_CONGREGATION 32
 #define ROOM_CORPSE_SAVE_HACK       33
-#define ROOM_MAX                    34
+#define ROOM_STERILE                34 // Gives a bonus to medical actions.
+#define ROOM_MAX                    35
 
 #define NORMAL    0
 #define LOWLIGHT  1
@@ -916,8 +917,9 @@ enum {
 #define SKILL_PHARMA              132
 #define SKILL_HEBREW              133
 #define SKILL_IROQUOIS            134
+#define SKILL_MEDICINE            135
 
-#define MAX_SKILLS      135
+#define MAX_SKILLS                136
 
 // Skill type definitions.
 #define SKILL_TYPE_ACTIVE         0

--- a/src/config.h
+++ b/src/config.h
@@ -24,44 +24,44 @@ extern const char *CANNOT_GO_THAT_WAY;
 extern const char *CHARACTER_DELETED_NAME_FOR_SQL;
 
 // What karma / nuyen multipliers do you want your game to have? This effects grind length, higher is faster.
-#define KARMA_GAIN_MULTIPLIER 2.0
-#define NUYEN_GAIN_MULTIPLIER 2.0
+#define KARMA_GAIN_MULTIPLIER                           2.0
+#define NUYEN_GAIN_MULTIPLIER                           2.0
 
 // How well should markets regenerate over time? (currently every 2 mins)
-#define MAX_PAYDATA_MARKET_INCREASE_PER_TICK 250
-#define MIN_PAYDATA_MARKET_INCREASE_PER_TICK -5
+#define MAX_PAYDATA_MARKET_INCREASE_PER_TICK            250
+#define MIN_PAYDATA_MARKET_INCREASE_PER_TICK            -5
 
 // What should the paydata markets cap out at?
-#define HOST_SECURITY_BLUE_MARKET_MAXIMUM   2000
-#define HOST_SECURITY_GREEN_MARKET_MAXIMUM  4000
-#define HOST_SECURITY_ORANGE_MARKET_MAXIMUM 6000
-#define HOST_SECURITY_RED_MARKET_MAXIMUM    8000
-#define HOST_SECURITY_BLACK_MARKET_MAXIMUM  10000
+#define HOST_SECURITY_BLUE_MARKET_MAXIMUM               2000
+#define HOST_SECURITY_GREEN_MARKET_MAXIMUM              4000
+#define HOST_SECURITY_ORANGE_MARKET_MAXIMUM             6000
+#define HOST_SECURITY_RED_MARKET_MAXIMUM                8000
+#define HOST_SECURITY_BLACK_MARKET_MAXIMUM              10000
 
-#define HOST_SECURITY_BLUE_MARKET_MINIMUM   500
-#define HOST_SECURITY_GREEN_MARKET_MINIMUM  1000
-#define HOST_SECURITY_ORANGE_MARKET_MINIMUM 1500
-#define HOST_SECURITY_RED_MARKET_MINIMUM    2000
-#define HOST_SECURITY_BLACK_MARKET_MINIMUM  2500
+#define HOST_SECURITY_BLUE_MARKET_MINIMUM               500
+#define HOST_SECURITY_GREEN_MARKET_MINIMUM              1000
+#define HOST_SECURITY_ORANGE_MARKET_MINIMUM             1500
+#define HOST_SECURITY_RED_MARKET_MINIMUM                2000
+#define HOST_SECURITY_BLACK_MARKET_MINIMUM              2500
 
 // What maximum amount of karma per action do you want PCs < 100 TKE to have?
-#define MAX_NEWCHAR_GAIN  50
+#define MAX_NEWCHAR_GAIN                                50
 
 // What maximum amount of karma per action do you want PCs < 500 TKE to have?
-#define MAX_MIDCHAR_GAIN  100
+#define MAX_MIDCHAR_GAIN                                100
 
 // What maximum amount of karma per action do you want PCs >= 500 TKE to have?
-#define MAX_OLDCHAR_GAIN  MAX(100, GET_TKE(ch) / 4)
+#define MAX_OLDCHAR_GAIN                                MAX(100, GET_TKE(ch) / 4)
 
 // What do you want the maximum skill levels to be? Reference values in awake.h.
-#define MAX_SKILL_LEVEL_FOR_MORTS  LEARNED_LEVEL
-#define MAX_SKILL_LEVEL_FOR_IMMS   100
+#define MAX_SKILL_LEVEL_FOR_MORTS                       LEARNED_LEVEL
+#define MAX_SKILL_LEVEL_FOR_IMMS                        100
 
 // What do you want the newbie karma threshold to be? Above this, you lose the newbie flag.
-#define NEWBIE_KARMA_THRESHOLD  50
+#define NEWBIE_KARMA_THRESHOLD                          50
 
 // How many syspoints should someone spend to restring an item?
-#define SYSP_RESTRING_COST  2
+#define SYSP_RESTRING_COST                              2
 
 // How long should the MUD wait for recovery before killing itself? Note that it
 // considers itself to be stuck during copyover too, so if you have a large world,
@@ -69,48 +69,48 @@ extern const char *CHARACTER_DELETED_NAME_FOR_SQL;
 #define SECONDS_TO_WAIT_FOR_HUNG_MUD_TO_RECOVER_BEFORE_KILLING_IT 30
 
 // What is the maximum cab fare in nuyen?
-#define MAX_CAB_FARE  250
+#define MAX_CAB_FARE                                    250
 
 // What should the level of new characters' starting language be?
-#define STARTING_LANGUAGE_SKILL_LEVEL  10
+#define STARTING_LANGUAGE_SKILL_LEVEL                   10
 
 // How many restring points should newbies get to use in chargen?
-#define STARTING_RESTRING_POINTS  5
+#define STARTING_RESTRING_POINTS                        5
 
 // What are the default settings of a room if not specified?
-#define DEFAULT_DIMENSIONS_X        20
-#define DEFAULT_DIMENSIONS_Y        20
-#define DEFAULT_DIMENSIONS_Z        2.5
-#define DEFAULT_EXIT_BARRIER_RATING 4
-#define DEFAULT_EXIT_MATERIAL       5
-#define DEFAULT_SECTOR_TYPE         SPIRIT_CITY
+#define DEFAULT_DIMENSIONS_X                            20
+#define DEFAULT_DIMENSIONS_Y                            20
+#define DEFAULT_DIMENSIONS_Z                            2.5
+#define DEFAULT_EXIT_BARRIER_RATING                     4
+#define DEFAULT_EXIT_MATERIAL                           5
+#define DEFAULT_SECTOR_TYPE                             SPIRIT_CITY
 
 // Bearing in mind that morts can't interact with an exit if they can't see it, what is the maximum hidden rating for an exit?
-#define MAX_EXIT_HIDDEN_RATING      10
+#define MAX_EXIT_HIDDEN_RATING                          10
 
 // Thresholds for warning builders about anomalies.
-#define ANOMALOUS_HIDDEN_RATING_THRESHOLD 10
-#define ANOMALOUS_TOTAL_STATS_THRESHOLD 60
-#define ANOMALOUS_SKILL_THRESHOLD 10
+#define ANOMALOUS_HIDDEN_RATING_THRESHOLD               10
+#define ANOMALOUS_TOTAL_STATS_THRESHOLD                 60
+#define ANOMALOUS_SKILL_THRESHOLD                       10
 
 // How often should congregation bonus points be accrued?
-#define SECONDS_BETWEEN_CONGREGATION_POOL_GAINS 60
+#define SECONDS_BETWEEN_CONGREGATION_POOL_GAINS         60
 // What is the maximum congregation bonus that can be accrued? If you change this, also take a look at score in act.informative.cpp and make sure the spacing matches up.
-#define MAX_CONGREGATION_BONUS 500
-#define CONGREGATION_MULTIPLIER 1.5
+#define MAX_CONGREGATION_BONUS                          500
+#define CONGREGATION_MULTIPLIER                         1.5
 // Note that these values are in hundredths of karma.
-#define CONGREGATION_MAX_KARMA_GAIN_PER_ACTION 25
-#define CONGREGATION_MIN_KARMA_GAIN_PER_ACTION 10
+#define CONGREGATION_MAX_KARMA_GAIN_PER_ACTION          25
+#define CONGREGATION_MIN_KARMA_GAIN_PER_ACTION          10
 // The min value must be less than the max value. It ensures people don't feel like they're wasting their karma mult if the accidentally kill a 0.01-karma mob.
 
 // How infrequently do you want your trideo units to display something?
-#define TRIDEO_TICK_DELAY 3
+#define TRIDEO_TICK_DELAY                               3
 
 // How many rooms can gridguide go at max speed? Too high, and vehicles will teleport.
-#define MAX_GRIDGUIDE_ROOMS_PER_PULSE 10
+#define MAX_GRIDGUIDE_ROOMS_PER_PULSE                   10
 
 // How often do NPCs press elevator buttons? 1:x ratio, where X is the number you put here.
-#define ELEVATOR_BUTTON_PRESS_CHANCE 20
+#define ELEVATOR_BUTTON_PRESS_CHANCE                    20
 
 // Wizlock message.
 #define WIZLOCK_MSG "Sorry, the game is currently locked. While you wait for it to open, feel free to join our Discord at https://discord.gg/q5VCMkv!"
@@ -119,20 +119,25 @@ extern const char *CHARACTER_DELETED_NAME_FOR_SQL;
 #define DISCORD_SERVER_URL "https://discord.gg/q5VCMkv"
 
 // Credsticks should generate every 1:X kills, and have X * kill's credits. Setting this too high will cause things like wageslaves having silver credsticks, so be cautious.
-#define CREDSTICK_RARITY_FACTOR 10
+#define CREDSTICK_RARITY_FACTOR                         10
 
 // At what point will the Marksman quest trigger?
-#define MARKSMAN_QUEST_SHOTS_FIRED_REQUIREMENT 2000
+#define MARKSMAN_QUEST_SHOTS_FIRED_REQUIREMENT          2000
 
 // How likely are you to lose stats on death? 1/X where X is this value.
-#define DEATH_PENALTY_CHANCE 25
+#define DEATH_PENALTY_CHANCE                            25
 
 // Configs for the idle nuyen reward, in nuyen and minutes respectively.
-#define IDLE_NUYEN_REWARD_AMOUNT               1000
-#define IDLE_NUYEN_REWARD_THRESHOLD_IN_MINUTES 10
-#define IDLE_NUYEN_MINUTES_BETWEEN_AWARDS      60
+#define IDLE_NUYEN_REWARD_AMOUNT                        1000
+#define IDLE_NUYEN_REWARD_THRESHOLD_IN_MINUTES          10
+#define IDLE_NUYEN_MINUTES_BETWEEN_AWARDS               60
 
 // What is the multiplier at which a cyberdoc will buy 'ware from you?
 #define CYBERDOC_MAXIMUM_SELL_TO_SHOPKEEP_MULTIPLIER    0.30
+
+// How much nuyen do you have to fork over to get an NPC to install 'ware for you?
+// Docs charge 1/factor of the price, up to the maximum configured.
+#define CYBERWARE_INSTALLATION_COST_FACTOR              10
+#define CYBERWARE_INSTALLATION_COST_MAXIMUM             10000
 
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -139,5 +139,6 @@ extern const char *CHARACTER_DELETED_NAME_FOR_SQL;
 // Docs charge 1/factor of the price, up to the maximum configured.
 #define CYBERWARE_INSTALLATION_COST_FACTOR              10
 #define CYBERWARE_INSTALLATION_COST_MAXIMUM             10000
+#define CYBERDOC_NO_INJURY_DIE_REQUIREMENT              5
 
 #endif

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -271,6 +271,7 @@ const char *room_bits[] =
     "ELEVATOR_SHAFT",
     "SOCIALIZE!",
     "CORPSE_SAVE_HACK",
+    "STERILE",
     "\n"
   };
 
@@ -1506,7 +1507,8 @@ struct skill_data skills[] =
     {"Blowgun", QUI, SKILL_TYPE_ACTIVE, FALSE},
     {"Pharmaceuticals", INT, SKILL_TYPE_ACTIVE, FALSE},
     {"Hebrew", INT, SKILL_TYPE_KNOWLEDGE, FALSE},
-    {"Iroquois", INT, SKILL_TYPE_KNOWLEDGE, FALSE}
+    {"Iroquois", INT, SKILL_TYPE_KNOWLEDGE, FALSE},
+    {"Medicine", INT, SKILL_TYPE_KNOWLEDGE, FALSE}
   };
 
 int rev_dir[] =

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -480,6 +480,7 @@ const char *player_bits[] =
     "NOIDLEOUT",
     "TELLS_MUTED",
     "NEWBIE_MUTED",
+    "CYBERDOC_PERMITTED",
     "\n"
   };
 
@@ -584,6 +585,7 @@ struct preference_bit_struct preference_bits_v2[] = {
   { "Highlights"           , TRUE , TRUE  },
   { "Pseudolanguage"       , TRUE , TRUE  },
   { "No Idle Nuyen Message", FALSE, TRUE  },
+  { "Cyberdocs Allowed"    , FALSE, TRUE  },
   { "\n"                   , 0    , 0     }
 };
 
@@ -907,6 +909,7 @@ const char *item_types[] =
     "Quest Item",
     "Ammo Box",
     "Keyring",
+    "Shop Container",
     "\n"
   };
 

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -2219,6 +2219,9 @@ void gen_death_msg(struct char_data *ch, struct char_data *vict, int attacktype)
     case TYPE_ELEVATOR:
       WRITE_DEATH_MESSAGE("%s got crushed by a moving elevator. Ouch. {%s (%ld)}");
       break;
+    case TYPE_MEDICAL_MISHAP:
+      WRITE_DEATH_MESSAGE("%s inadvertently starred in a medical-themed snuff film. {%s (%ld)}");
+      break;
     case TYPE_CRASH:
       switch(number(0, 1)) {
         case 0:
@@ -2464,7 +2467,7 @@ bool damage(struct char_data *ch, struct char_data *victim, int dam, int attackt
       } else {
         check_killer(ch, victim);
       }
-    } else {
+    } else if (attacktype != TYPE_MEDICAL_MISHAP) {
       check_killer(ch, victim);
     }
   }

--- a/src/iedit.cpp
+++ b/src/iedit.cpp
@@ -1808,18 +1808,39 @@ void iedit_parse(struct descriptor_data * d, const char *arg)
       break;
     case IEDIT_TYPE:
       number = atoi(arg);
-      if ((number < 1) || (number > NUM_ITEMS) || (number == ITEM_CYBERWARE && !access_level(CH, LVL_ADMIN)) ||
-          (number == ITEM_BIOWARE && !access_level(CH, LVL_ADMIN))) {
-        send_to_char("That's not a valid choice!\r\n", d->character);
+      if (number < 1 || number > NUM_ITEMS) {
+        send_to_char(d->character, "That's not a valid choice! You must choose something between 1 and %d.\r\n", NUM_ITEMS);
         iedit_disp_type_menu(d);
-      } else if (number != 0 && GET_OBJ_TYPE(d->edit_obj) != number) {
+        return;
+      }
+      
+      switch (number) {
+        case ITEM_CYBERWARE:
+        case ITEM_BIOWARE:
+          if (!access_level(CH, LVL_ADMIN)) {
+            send_to_char("Sorry, only Admin and higher staff members can create those.\r\n", d->character);
+            iedit_disp_type_menu(d);
+            return;
+          }
+          break;
+        case ITEM_SHOPCONTAINER:
+          if (!access_level(CH, LVL_PRESIDENT)) {
+            send_to_char("Sorry, shopcontainers are for code use only and can't be created.\r\n", d->character);
+            iedit_disp_type_menu(d);
+            return;
+          }
+          send_to_char("WARNING: Shopcontainers are for code use only! Hope you know what you're doing...\r\n", d->character);
+          break;
+        case ITEM_GUN_MAGAZINE:
+          send_to_char("Sorry, gun magazines are for code use only and can't be created.\r\n", d->character);
+          iedit_disp_type_menu(d);
+          return;
+      }
+      
+      if (number != 0 && GET_OBJ_TYPE(d->edit_obj) != number) {
         GET_OBJ_TYPE(d->edit_obj) = number;
         for (int index = 0; index < NUM_VALUES; index++)
           GET_OBJ_VAL(d->edit_obj, index) = 0;
-      }
-      
-      if (number == ITEM_GUN_MAGAZINE) {
-        send_to_char("NOTICE: Gun magazines were deprecated with the creation of the new ammo system. You probably don't need to make one.\r\n", d->character);
       }
       
       iedit_disp_menu(d);

--- a/src/limits.cpp
+++ b/src/limits.cpp
@@ -91,6 +91,8 @@ void mental_gain(struct char_data * ch)
 
   if (ch->in_room && ROOM_FLAGGED(ch->in_room, ROOM_ENCOURAGE_CONGREGATION))
     gain *= 2;
+  else if (ch->in_room && ROOM_FLAGGED(ch->in_room, ROOM_STERILE))
+    gain *= 1.5;
   
   if (GET_TRADITION(ch) == TRAD_ADEPT)
     gain *= GET_POWER(ch, ADEPT_HEALING) + 1;

--- a/src/mobact.cpp
+++ b/src/mobact.cpp
@@ -121,6 +121,9 @@ bool mob_is_aggressive(struct char_data *ch, bool include_base_aggression) {
            
   act(buf2, FALSE, ch, NULL, NULL, TO_ROOM);
 #endif
+
+  if (is_escortee(ch))
+    return FALSE;
   
   if (include_base_aggression && MOB_FLAGS(ch).IsSet(MOB_AGGRESSIVE))
     return TRUE;
@@ -403,6 +406,9 @@ bool mobact_process_in_vehicle_guard(struct char_data *ch) {
   struct char_data *vict = NULL;
   struct room_data *in_room;
   
+  if (is_escortee(ch))
+    return FALSE;
+  
   // Precondition: Vehicle must exist, we must be manning or driving, and we must not be astral.
   if (!ch->in_veh || !(AFF_FLAGGED(ch, AFF_PILOT) || AFF_FLAGGED(ch, AFF_MANNING)) || IS_ASTRAL(ch)) {
 #ifdef MOBACT_DEBUG
@@ -511,6 +517,9 @@ bool mobact_process_in_vehicle_aggro(struct char_data *ch) {
   struct char_data *vict = NULL;
   struct room_data *in_room;
   
+  if (is_escortee(ch))
+    return FALSE;
+    
   // Precondition: Vehicle must exist, we must be manning or driving, and we must not be astral.
   if (!ch->in_veh || !(AFF_FLAGGED(ch, AFF_PILOT) || AFF_FLAGGED(ch, AFF_MANNING)) || IS_ASTRAL(ch)) {
 #ifdef MOBACT_DEBUG
@@ -621,6 +630,9 @@ bool mobact_process_in_vehicle_aggro(struct char_data *ch) {
 bool mobact_process_aggro(struct char_data *ch, struct room_data *room) {
   struct char_data *vict = NULL;
   struct veh_data *veh = NULL;
+  
+  if (is_escortee(ch))
+    return FALSE;
   
   // Conjured spirits and elementals are never aggressive.
   if ((IS_ELEMENTAL(ch) || IS_SPIRIT(ch)) && GET_ACTIVE(ch))
@@ -753,6 +765,9 @@ void send_mob_aggression_warnings(struct char_data *pc, struct char_data *mob) {
 bool mobact_process_memory(struct char_data *ch, struct room_data *room) {
   struct char_data *vict = NULL;
   
+  if (is_escortee(ch))
+    return FALSE;
+  
   /* Mob Memory */
   if (MOB_FLAGGED(ch, MOB_MEMORY) && GET_MOB_MEMORY(ch)) {
     for (vict = room->people; vict; vict = vict->next_in_room) {
@@ -775,6 +790,9 @@ bool mobact_process_memory(struct char_data *ch, struct room_data *room) {
 
 bool mobact_process_helper(struct char_data *ch) {
   struct char_data *vict = NULL;
+  
+  if (is_escortee(ch))
+    return FALSE;
   
   /* Helper Mobs - guards are always helpers */
   if (MOB_FLAGGED(ch, MOB_HELPER) || MOB_FLAGGED(ch, MOB_GUARD)) {
@@ -854,6 +872,9 @@ bool vehicle_is_valid_mob_target(struct veh_data *veh, bool alarmed) {
 bool mobact_process_guard(struct char_data *ch, struct room_data *room) {
   struct char_data *vict = NULL;
   struct veh_data *veh = NULL;
+  
+  if (is_escortee(ch))
+    return FALSE;
   
   // Conjured spirits and elementals are never aggressive.
   if ((IS_ELEMENTAL(ch) || IS_SPIRIT(ch)) && GET_ACTIVE(ch))
@@ -1019,6 +1040,9 @@ int get_push_command_index() {
 
 bool mobact_process_movement(struct char_data *ch) {
   int door;
+  
+  if (is_escortee(ch))
+    return FALSE;
   
   if (MOB_FLAGGED(ch, MOB_SENTINEL) || CH_IN_COMBAT(ch))
     return FALSE;

--- a/src/newdb.cpp
+++ b/src/newdb.cpp
@@ -1635,7 +1635,8 @@ vnum_t get_highest_idnum_in_use() {
     snprintf(buf, sizeof(buf), "SELECT idnum FROM %s ORDER BY idnum DESC LIMIT 1;", tables[i]);
     vnum_t new_number = get_one_number_from_query(buf);
     if (highest_pfiles_idnum < new_number) {
-      mudlog("^RSYSERR: SQL database corruption (pfiles idnum lower than supporting table idnum). Will attempt to recover.^g", NULL, LOG_SYSLOG, TRUE);
+      snprintf(buf3, sizeof(buf3), "^RSYSERR: SQL database corruption (pfiles idnum %ld lower than '%s' idnum %ld). Auto-correcting.^g", highest_pfiles_idnum, tables[i], new_number);
+      mudlog(buf3, NULL, LOG_SYSLOG, TRUE);
       highest_pfiles_idnum = new_number;
     }
   }

--- a/src/newdb.cpp
+++ b/src/newdb.cpp
@@ -401,6 +401,9 @@ bool load_char(const char *name, char_data *ch, bool logon)
   AFF_FLAGS(ch).FromString(row[6]);
   PLR_FLAGS(ch).FromString(row[7]);
   PRF_FLAGS(ch).FromString(row[8]);
+  
+  // Unset the cyberdoc flag on load.
+  PRF_FLAGS(ch).RemoveBit(PRF_TOUCH_ME_DADDY);
 
   ch->player.physical_text.room_desc = str_dup(row[9]);
   ch->player.background = str_dup(row[10]);

--- a/src/redit.cpp
+++ b/src/redit.cpp
@@ -898,8 +898,19 @@ void redit_parse(struct descriptor_data * d, const char *arg)
 
         if (ROOM->room_flags.IsSet(number-1)) {
           ROOM->room_flags.RemoveBit(number-1);
-        } else
+          if (number-1 == ROOM_STERILE) {
+            send_to_char("Automatically removing sterile aura.\r\n", d->character);
+            d->edit_room->background[CURRENT_BACKGROUND_COUNT] = d->edit_room->background[PERMANENT_BACKGROUND_COUNT] = 0;
+            d->edit_room->background[CURRENT_BACKGROUND_TYPE] = d->edit_room->background[PERMANENT_BACKGROUND_TYPE] = 0;
+          }
+        } else {
           ROOM->room_flags.SetBit(number-1);
+          if (number-1 == ROOM_STERILE) {
+            send_to_char("Automatically setting sterile aura.\r\n", d->character);
+            d->edit_room->background[CURRENT_BACKGROUND_COUNT] = d->edit_room->background[PERMANENT_BACKGROUND_COUNT] = 1;
+            d->edit_room->background[CURRENT_BACKGROUND_TYPE] = d->edit_room->background[PERMANENT_BACKGROUND_TYPE] = AURA_STERILITY;
+          }
+        }
         redit_disp_flag_menu(d);
       }
     }

--- a/src/spec_assign.cpp
+++ b/src/spec_assign.cpp
@@ -807,6 +807,7 @@ void assign_objects(void)
   SPECIAL(restoration_button);
   SPECIAL(nerpcorpolis_button);
   SPECIAL(floor_usable_radio);
+  SPECIAL(medical_workshop);
 
   ASSIGNOBJ(3, gen_board);  /* Rift's Board */
   ASSIGNOBJ(4, gen_board);  /* Pook's Board */
@@ -917,6 +918,10 @@ void assign_objects(void)
   ASSIGNOBJ(OBJ_CARIBBEAN_TAXI_SIGN, taxi_sign);
   
   ASSIGNOBJ(10005, weapon_dominator);
+  
+  ASSIGNOBJ(15811, medical_workshop);
+  ASSIGNOBJ(16242, medical_workshop);
+  ASSIGNOBJ(70611, medical_workshop);
   
   WSPEC(monowhip);
 

--- a/src/spec_assign.cpp
+++ b/src/spec_assign.cpp
@@ -922,6 +922,9 @@ void assign_objects(void)
   ASSIGNOBJ(15811, medical_workshop);
   ASSIGNOBJ(16242, medical_workshop);
   ASSIGNOBJ(70611, medical_workshop);
+#ifdef USE_PRIVATE_CE_WORLD
+  ASSIGNOBJ(10039, medical_workshop);
+#endif
   
   WSPEC(monowhip);
 

--- a/src/spec_assign.cpp
+++ b/src/spec_assign.cpp
@@ -93,11 +93,11 @@ struct teach_data teachers[] = {
   { 788, { SKILL_CORPORATE_ETIQUETTE, SKILL_ELF_ETIQUETTE, SKILL_MEDIA_ETIQUETTE, SKILL_NEGOTIATION,
     SKILL_STREET_ETIQUETTE, SKILL_TRIBAL_ETIQUETTE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
     "You spend a long time learning how to make small talk and directing conversations.\r\n", ADVANCED },
-  { 790, { SKILL_ATHLETICS, SKILL_BIOTECH, SKILL_POLICE_PROCEDURES, SKILL_STEALTH,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+  { 790, { SKILL_ATHLETICS, SKILL_BIOTECH, SKILL_POLICE_PROCEDURES, SKILL_STEALTH, SKILL_MEDICINE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
     "After hours of study and physical practice, you feel like you've learned\r\nsomething.\r\n.", ADVANCED },
 #endif
                       
-                       { 2508, { SKILL_BIOTECH, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, "After hours of medical research and instruction, you begin "
+                       { 2508, { SKILL_BIOTECH, SKILL_MEDICINE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, "After hours of medical research and instruction, you begin "
                          "to\r\nunderstand more of the basic biotech procedures.\r\n", AMATEUR },
                        { 2701, { SKILL_ATHLETICS, SKILL_STEALTH, SKILL_UNARMED_COMBAT, SKILL_EDGED_WEAPONS,
                          SKILL_WHIPS_FLAILS, SKILL_PROJECTILES, SKILL_THROWING_WEAPONS, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
@@ -180,7 +180,7 @@ struct teach_data teachers[] = {
     "Lucy runs through the proper decorum to use in certain situations, you feel like you've learned something.\r\n", NEWBIE},
   
   { 60534, { SKILL_ATHLETICS, SKILL_BIOTECH, SKILL_POLICE_PROCEDURES, SKILL_STEALTH,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    SKILL_MEDICINE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
     "Steve roughly throws you a text book and tells you to read it, you feel like you've learned something.\r\n", NEWBIE},
   // End newbie teachers.
   
@@ -195,7 +195,7 @@ struct teach_data teachers[] = {
    { 14608, { SKILL_PILOT_CAR, SKILL_MACHINE_GUNS, SKILL_ASSAULT_CANNON, SKILL_PILOT_BIKE, SKILL_PILOT_TRUCK, SKILL_GUNNERY, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
      "Hal shows you a trick or two, and the rest just falls into place.\r\n", AMATEUR },
      
-   { 14638, { SKILL_COMPUTER, SKILL_ELECTRONICS, SKILL_BR_COMPUTER, SKILL_BIOTECH, SKILL_BR_DRONE, SKILL_PROGRAM_SPECIAL, SKILL_PROGRAM_OPERATIONAL, SKILL_DATA_BROKERAGE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, "Gargamel looks at you, hands you some parts, drops you a clue, and you get it.\r\n", AMATEUR},
+   { 14638, { SKILL_COMPUTER, SKILL_ELECTRONICS, SKILL_BR_COMPUTER, SKILL_BR_DRONE, SKILL_PROGRAM_SPECIAL, SKILL_PROGRAM_OPERATIONAL, SKILL_DATA_BROKERAGE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, "Gargamel looks at you, hands you some parts, drops you a clue, and you get it.\r\n", AMATEUR},
 
    { 7223, { SKILL_UNARMED_COMBAT, SKILL_STEALTH, SKILL_ATHLETICS, SKILL_CYBER_IMPLANTS, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, "Shing gives you a work out like none you've ever had, "
      "but\r\nyou feel like you've learned something.\r\n", AMATEUR },
@@ -228,8 +228,8 @@ struct teach_data teachers[] = {
      "various lifestyle books for a while.\r\n", LIBRARY },
      
    { 18312, { SKILL_COMPUTER, SKILL_ELECTRONICS, SKILL_BR_COMPUTER, SKILL_CYBERTERM_DESIGN,
-              SKILL_BR_ELECTRONICS, SKILL_DATA_BROKERAGE, SKILL_PROGRAM_CYBERTERM, SKILL_PROGRAM_SPECIAL, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
-     "You read through various technological journals.\r\n", LIBRARY },
+              SKILL_BR_ELECTRONICS, SKILL_DATA_BROKERAGE, SKILL_PROGRAM_CYBERTERM, SKILL_PROGRAM_SPECIAL, SKILL_BIOTECH, SKILL_MEDICINE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+     "You read through various academic journals.\r\n", LIBRARY },
      
      { 18313, { SKILL_ARABIC, SKILL_CHINESE, SKILL_CROW, SKILL_ENGLISH, SKILL_FRENCH, SKILL_GAELIC, SKILL_GERMAN,
        SKILL_ITALIAN, SKILL_JAPANESE, SKILL_KOREAN, SKILL_LATIN, SKILL_MAKAW, SKILL_NAVAJO, SKILL_ORZET,

--- a/src/spec_procs.cpp
+++ b/src/spec_procs.cpp
@@ -6139,17 +6139,13 @@ SPECIAL(medical_workshop) {
       send_to_char(ch, "You aren't carrying anything called '%s'.\r\n", argument);
       return TRUE;
     }
-  } else {
-    if (!(ware = get_obj_in_list_vis(ch, argument, ch->cyberware)) && !(ware = get_obj_in_list_vis(ch, argument, ch->bioware))) {
-      send_to_char(ch, "%s doesn't have anything called '%s' installed.\r\n", GET_CHAR_NAME(found_char), argument);
-      return TRUE;
-    }
     
     if (GET_OBJ_TYPE(ware) != ITEM_SHOPCONTAINER) {
-      send_to_char(ch, "Sorry, you can only %sinstall 'ware while standing in a medical %s-- %s doesn't count.\r\n", 
-                   mode_is_install ? "" : "un", 
+      send_to_char(ch, "You're standing in a medical %s, so you can only %sinstall 'ware! %s doesn't count.\r\n", 
                    GET_WORKSHOP_GRADE(workshop) == TYPE_WORKSHOP ? "workshop" : "facility",
+                   mode_is_install ? "" : "un", 
                    GET_OBJ_NAME(ware));
+      return TRUE;
     } else {
       if (!ware->contains) {
         send_to_char(ch, "Something went wrong! Please alert staff.\r\n");
@@ -6157,13 +6153,18 @@ SPECIAL(medical_workshop) {
       }
       ware = ware->contains;
     }
+  } else {
+    if (!(ware = get_obj_in_list_vis(ch, argument, found_char->cyberware)) && !(ware = get_obj_in_list_vis(ch, argument, found_char->bioware))) {
+      send_to_char(ch, "%s doesn't have anything called '%s' installed.\r\n", GET_CHAR_NAME(found_char), argument);
+      return TRUE;
+    }
   }
   
   // Reject operations on anything that isn't 'ware.'
   if (GET_OBJ_TYPE(ware) != ITEM_BIOWARE && GET_OBJ_TYPE(ware) != ITEM_CYBERWARE) {
-    send_to_char(ch, "Sorry, you can only %sinstall 'ware while standing in a medical %s-- %s doesn't count.\r\n", 
-                 mode_is_install ? "" : "un", 
+    send_to_char(ch, "You're standing in a medical %s, so you can only %sinstall 'ware! %s doesn't count.\r\n", 
                  GET_WORKSHOP_GRADE(workshop) == TYPE_WORKSHOP ? "workshop" : "facility",
+                 mode_is_install ? "" : "un", 
                  GET_OBJ_NAME(ware));
     return TRUE;
   }

--- a/src/spec_procs.cpp
+++ b/src/spec_procs.cpp
@@ -6118,6 +6118,21 @@ SPECIAL(medical_workshop) {
     return TRUE;
   }
   
+  if (IS_NPC(found_char) || IS_ASTRAL(found_char) || IS_PROJECT(found_char)) {
+    send_to_char("Not on NPCs.\r\n", ch);
+    return TRUE;
+  }
+  
+  if (!found_char->desc) {
+    send_to_char("They're disconnected right now, try again later.", ch);
+    return TRUE;
+  }
+  
+  if (GET_LEVEL(found_char) > GET_LEVEL(ch)) {
+    send_to_char("Operating on staff is a terrible idea.\r\n", ch);
+    return TRUE;
+  }
+  
   // Ensure we have the target's permission.
   if (!PRF_FLAGGED(found_char, PRF_TOUCH_ME_DADDY)) {
     send_to_char(ch, "You can't operate on %s-- they need to use the ^WTOGGLE CYBERDOC^n command.\r\n", GET_CHAR_NAME(found_char));

--- a/src/spec_procs.cpp
+++ b/src/spec_procs.cpp
@@ -6199,7 +6199,7 @@ SPECIAL(medical_workshop) {
     damage(ch, found_char, SERIOUS, TYPE_MEDICAL_MISHAP, PHYSICAL);
     
     // Victim obviously doesn't trust you anymore, so revoke permission.
-    send_to_char("(System notice: Automatically disabling your 'toggle cyberdoc' permission.)\r\n", found_char);
+    send_to_char("(System notice: Automatically disabling your ^WTOGGLE CYBERDOC^n permission.)\r\n", found_char);
     PRF_TOG_CHK(ch, PRF_TOUCH_ME_DADDY);
     
     return TRUE;
@@ -6229,7 +6229,7 @@ SPECIAL(medical_workshop) {
   }
   
   // Automatically revoke permission.
-  send_to_char("(System notice: Automatically disabling your 'toggle cyberdoc' permission.)\r\n", found_char);
+  send_to_char("(System notice: Automatically disabling your ^WTOGGLE CYBERDOC^n permission.)\r\n", found_char);
   PRF_TOG_CHK(ch, PRF_TOUCH_ME_DADDY);
   
   return TRUE;

--- a/src/utils.h
+++ b/src/utils.h
@@ -867,13 +867,17 @@ bool WEAPON_FOCUS_USABLE_BY(struct obj_data *focus, struct char_data *ch);
 
 // ITEM_BIOWARE convenience defines
 
-#define GET_BIOWARE_TYPE(bioware)          (GET_OBJ_VAL((bioware), 0))
+#define GET_BIOWARE_TYPE(bioware)              (GET_OBJ_VAL((bioware), 0))
+#define GET_BIOWARE_RATING(bioware)            (GET_OBJ_VAL((bioware), 1))
+#define GET_BIOWARE_IS_CULTURED(bioware)       (GET_OBJ_VAL((bioware), 2) || GET_BIOWARE_TYPE((bioware)) >= BIO_CEREBRALBOOSTER)
+#define GET_BIOWARE_ESSENCE_COST(bioware)      (GET_OBJ_VAL((bioware), 4))
 
 // ITEM_FOUNTAIN convenience defines
 
 // ITEM_CYBERWARE convenience defines
 #define GET_CYBERWARE_TYPE(cyberware)          (GET_OBJ_VAL((cyberware), 0))
 #define GET_CYBERWARE_RATING(cyberware)        (GET_OBJ_VAL((cyberware), 1))
+#define GET_CYBERWARE_GRADE(cyberware)         (GET_OBJ_VAL((cyberware), 2))
 #define GET_CYBERWARE_FLAGS(cyberware)         (GET_OBJ_VAL((cyberware), 3)) // CYBERWEAPON_RETRACTABLE, CYBERWEAPON_IMPROVED
 #define GET_CYBERWARE_LACING_TYPE(cyberware)   (GET_OBJ_VAL((cyberware), 3)) // Yes, this is also value 3. Great design here.
 #define GET_CYBERWARE_ESSENCE_COST(cyberware)  (GET_OBJ_VAL((cyberware), 4))


### PR DESCRIPTION
This patch adds the following changes:
- NPC doctors no longer install 'ware, and instead hand it to you (exception: Chargen docs install)
- You can have an NPC doc install or uninstall ware for 10% of the ware's cost, up to 10k nuyen
- Players can be given the Cyberdoc permission by staff. This permission allows them to act as a cyberdoc. This permission shows up in the wholist.
- If you're in the same room as an unpacked medical workshop or facility, and you have the cyberdoc flag, you can INSTALL or UNINSTALL cyberware from players who have toggled their operations pref on.
- Patients can choose to TOGGLE CYBERDOC to allow cyberdocs to operate on them. This defaults to off, and is re-set to off every time they log in, as well as after every operation.
- Added medicine skill. You need both medicine and biotech at skill 4 to operate on someone.

Additional things done:
- Added a STERILE roomflag, which improves medical outcomes in that room.
- Probe strings for cyber/bio now drop ratings if the rating is not set.
- Centering and enchantment now learnable at 12 for mages.
- Made it so escorts are less likely to pick fights.