### PR TITLE
NERP metamagics get moved and removed from the MUD.

### DIFF
--- a/src/spec_assign.cpp
+++ b/src/spec_assign.cpp
@@ -36,12 +36,12 @@ struct train_data trainers[] = {
 /* if they teach < 5 skills, put a 0 in the remaining skill slots    */
 /* available levels are NEWBIE (4), AMATEUR (6/7), and ADVANCED (10/11)   */
 struct teach_data metamagict[] = { 
-                       { 24806, { META_REFLECTING, META_CLEANSING, 0, 0, 0, 0, 0, 0 }, "", 0 },
-                         { 4250, { META_ANCHORING, META_QUICKENING, 0, 0, 0, 0, 0, 0 }, "", 0 },
-                         { 4251, { META_ANCHORING, META_POSSESSING, 0, 0, 0, 0, 0, 0 }, "", 0 },
-                         { 10010, { META_ANCHORING, META_CENTERING, META_CLEANSING, META_INVOKING, META_MASKING, META_POSSESSING, META_QUICKENING, META_REFLECTING, META_SHIELDING }, "", 0},
-                         { 35538, { META_MASKING, META_CLEANSING, META_CENTERING, 0, 0, 0, 0, 0, 0 }, "", 0},
-                         { 27426, { META_SHIELDING, META_POSSESSING, META_INVOKING, META_MASKING, 0, 0, 0, 0 }, "", 0},
+                       { 24806, { META_REFLECTING, 0, 0, 0, 0, 0, 0, 0 }, "", 0 },
+                         { 4250, { META_CLEANSING, 0, 0, 0, 0, 0, 0, 0 }, "", 0 },
+                         { 4251, { META_MASKING, 0, 0, 0, 0, 0, 0, 0 }, "", 0 },
+                         { 10010, { META_ANCHORING, META_CENTERING, 0, META_INVOKING, 0, META_POSSESSING, META_QUICKENING, 0, 0 }, "", 0},
+                         { 35538, { META_MASKING, 0 0, 0, 0, 0, 0, 0, 0, 0 }, "", 0},
+                         { 27426, { META_SHIELDING, 0, 0, 0, 0, 0, 0, 0 }, "", 0},
                          { 0, { 0, 0, 0, 0, 0, 0, 0, 0, 0 }, "", 0}
                        };
 

--- a/src/spec_assign.cpp
+++ b/src/spec_assign.cpp
@@ -41,7 +41,7 @@ struct teach_data metamagict[] = {
                          { 4251, { META_MASKING, 0, 0, 0, 0, 0, 0, 0 }, "", 0 },
                          { 10010, { META_ANCHORING, META_CENTERING, META_CLEANSING, META_INVOKING, META_MASKING, META_POSSESSING, META_QUICKENING, META_REFLECTING, META_SHIELDING }, "", 0},
                          { 35538, { META_MASKING, 0 0, 0, 0, 0, 0, 0, 0, 0 }, "", 0},
-                         { 27426, { META_SHIELDING, 0, 0, 0, 0, 0, 0, 0 }, "", 0},
+                         { 27426, { META_REFLECTING, 0, 0, 0, 0, 0, 0, 0 }, "", 0},
                          { 0, { 0, 0, 0, 0, 0, 0, 0, 0, 0 }, "", 0}
                        };
 

--- a/src/spec_assign.cpp
+++ b/src/spec_assign.cpp
@@ -39,7 +39,7 @@ struct teach_data metamagict[] = {
                        { 24806, { META_REFLECTING, 0, 0, 0, 0, 0, 0, 0 }, "", 0 },
                          { 4250, { META_CLEANSING, 0, 0, 0, 0, 0, 0, 0 }, "", 0 },
                          { 4251, { META_MASKING, 0, 0, 0, 0, 0, 0, 0 }, "", 0 },
-                         { 10010, { META_ANCHORING, META_CENTERING, 0, META_INVOKING, 0, META_POSSESSING, META_QUICKENING, 0, 0 }, "", 0},
+                         { 10010, { META_ANCHORING, META_CENTERING, META_CLEANSING, META_INVOKING, META_MASKING, META_POSSESSING, META_QUICKENING, META_REFLECTING, META_SHIELDING }, "", 0},
                          { 35538, { META_MASKING, 0 0, 0, 0, 0, 0, 0, 0, 0 }, "", 0},
                          { 27426, { META_SHIELDING, 0, 0, 0, 0, 0, 0, 0 }, "", 0},
                          { 0, { 0, 0, 0, 0, 0, 0, 0, 0, 0 }, "", 0}


### PR DESCRIPTION
What is says on the tin. NERP metamagics get moved and removed.

TODO: Add a trainer that only delivers NERP magical abilities.