### PR TITLE
Update spec_assign.cpp

### DIFF
--- a/src/spec_assign.cpp
+++ b/src/spec_assign.cpp
@@ -42,8 +42,9 @@ struct teach_data metamagict[] = {
                          { 10010, { META_ANCHORING, META_CENTERING, META_CLEANSING, META_INVOKING, META_MASKING, META_POSSESSING, META_QUICKENING, META_REFLECTING, META_SHIELDING }, "", 0},
                          { 35538, { META_MASKING, 0 0, 0, 0, 0, 0, 0, 0, 0 }, "", 0},
                          { 27426, { META_REFLECTING, 0, 0, 0, 0, 0, 0, 0 }, "", 0},
-                         // NERP metamagic trainer
-                         { 94313, { META_ANCHORING, META_CENTERING, META_INVOKING, META_POSESSING, META_QUICKENING, META_SHIELDING, 0, 0 }, "", 0},
+#ifdef USE_PRIVATE_CE_WORLD
+                         { 94313, { META_ANCHORING, META_CENTERING, META_INVOKING, META_POSESSING, META_QUICKENING, META_SHIELDING, 0, 0 }, "", 0}, // NERP metamagic trainer
+#ifdef USE_PRIVATE_CE_WORLD
                          { 0, { 0, 0, 0, 0, 0, 0, 0, 0, 0 }, "", 0}
                        };
 

--- a/src/spec_assign.cpp
+++ b/src/spec_assign.cpp
@@ -42,6 +42,8 @@ struct teach_data metamagict[] = {
                          { 10010, { META_ANCHORING, META_CENTERING, META_CLEANSING, META_INVOKING, META_MASKING, META_POSSESSING, META_QUICKENING, META_REFLECTING, META_SHIELDING }, "", 0},
                          { 35538, { META_MASKING, 0 0, 0, 0, 0, 0, 0, 0, 0 }, "", 0},
                          { 27426, { META_REFLECTING, 0, 0, 0, 0, 0, 0, 0 }, "", 0},
+                         // NERP metamagic trainer
+                         { 94313, { META_ANCHORING, META_CENTERING, META_INVOKING, META_POSESSING, META_QUICKENING, META_SHIELDING, 0, 0 }, "", 0},
                          { 0, { 0, 0, 0, 0, 0, 0, 0, 0, 0 }, "", 0}
                        };
 

--- a/src/spec_assign.cpp
+++ b/src/spec_assign.cpp
@@ -44,7 +44,7 @@ struct teach_data metamagict[] = {
                          { 27426, { META_REFLECTING, 0, 0, 0, 0, 0, 0, 0 }, "", 0},
 #ifdef USE_PRIVATE_CE_WORLD
                          { 94313, { META_ANCHORING, META_CENTERING, META_INVOKING, META_POSESSING, META_QUICKENING, META_SHIELDING, 0, 0 }, "", 0}, // NERP metamagic trainer
-#ifdef USE_PRIVATE_CE_WORLD
+#endif
                          { 0, { 0, 0, 0, 0, 0, 0, 0, 0, 0 }, "", 0}
                        };
 


### PR DESCRIPTION
Gives a new spell trainer all the appropriate specprops for NERP metamagic.
Wanted to also give him NERP adept abilities, but couldn't understand how that array works.