### PR TITLE
Fixed gettimeofday() related linking issues on cutting edge distros…

### DIFF
--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -22,6 +22,7 @@
 #include <new>
 #include <time.h>
 #include <iostream>
+#include <chrono>
 using namespace std;
 
 #if defined(WIN32) && !defined(__CYGWIN__)
@@ -175,13 +176,12 @@ void set_descriptor_canaries(struct descriptor_data *newd);
 void check_memory_canaries();
 #endif
 
-#if (defined(WIN32) && !defined(__CYGWIN__))
-void gettimeofday(struct timeval *t, struct timezone *dummy)
+#if (!defined(_AIX) && !defined(__hpux) && !defined(MIPS_OS) && !defined(NeXT) && !defined(sequent) && !defined(sun) && !defined(ultrix))
+int gettimeofday(struct timeval *t, struct timezone *dummy)
 {
-  DWORD millisec = GetTickCount();
-  
-  t->tv_sec = (int) (millisec / 1000);
-  t->tv_usec = (millisec % 1000) * 1000;
+  t->tv_usec =   std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+  t->tv_sec = (int) (t->tv_usec / 1000);
+  return 0;
 }
 #endif
 

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -176,14 +176,12 @@ void set_descriptor_canaries(struct descriptor_data *newd);
 void check_memory_canaries();
 #endif
 
-#if (!defined(_AIX) && !defined(__hpux) && !defined(MIPS_OS) && !defined(NeXT) && !defined(sequent) && !defined(sun) && !defined(ultrix))
 int gettimeofday(struct timeval *t, struct timezone *dummy)
 {
   t->tv_usec =   std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
   t->tv_sec = (int) (t->tv_usec / 1000);
   return 0;
 }
-#endif
 
 /* *********************************************************************
  *  main game loop and related stuff                                    *
@@ -2379,7 +2377,7 @@ void termsig(int Empty)
  // This code is ANCIENT and does not work on Ubuntu. -- LS.
 
 
-#if defined(NeXT) || defined(sun386) || (defined(WIN32) && !defined(__CYGWIN__))
+#if (defined(WIN32) && !defined(__CYGWIN__))
 #define my_signal(signo, func) signal(signo, func)
 #else
 sigfunc *my_signal(int signo, sigfunc * func)
@@ -2389,17 +2387,13 @@ sigfunc *my_signal(int signo, sigfunc * func)
   act.sa_handler = func;
   sigemptyset(&act.sa_mask);
   act.sa_flags = 0;
-#ifdef SA_INTERRUPT
-  
-  act.sa_flags |= SA_INTERRUPT; /* SunOS */
-#endif
   
   if (sigaction(signo, &act, &oact) < 0)
     return SIG_ERR;
   
   return oact.sa_handler;
 }
-#endif /* NeXT */
+#endif
 
 void signal_setup(void)
 {

--- a/src/comm.h
+++ b/src/comm.h
@@ -74,10 +74,6 @@ int setsockopt(int s, int level, int optname, void *optval, int optlen);
 int socket(int domain, int type, int protocol);
 #endif
 
-#if defined(apollo)
-#include <unistd.h>
-#endif
-
 #if defined(__hpux)
 int accept(int s, void *addr, int *addrlen);
 int bind(int s, const void *addr, int addrlen);
@@ -95,64 +91,12 @@ int socket(int domain, int type, int protocol);
 #include <sys/fcntl.h>
 #endif
 
-#if     defined(linux)
+#if  (defined(linux) || defined(freebsd))
 #include <sys/time.h>
 int getpeername(int s, struct sockaddr * name, int *namelen);
 int getsockname(int s, struct sockaddr * name, int *namelen);
 int gettimeofday(struct timeval * tp, struct timezone * tzp);
 int socket(int domain, int type, int protocol);
-#endif
-
-#if  defined(freebsd)
-int getpeername(int s, struct sockaddr * name, int *namelen);
-int getsockname(int s, struct sockaddr * name, int *namelen);
-int gettimeofday(struct timeval * tp, struct timezone * tzp);
-int socket(int domain, int type, int protocol);
-#endif
-
-#if     defined(MIPS_OS)
-extern int errno;
-#endif
-
-#if     defined(NeXT)
-int close(int fd);
-int chdir(const char *path);
-int fcntl(int fd, int cmd, int arg);
-#if     !defined(htons)
-u_short htons(u_short hostshort);
-#endif
-#if     !defined(ntohl)
-u_long ntohl(u_long hostlong);
-u_long htonl(u_long hostlong);
-#endif
-int read(int fd, char *buf, int nbyte);
-int select(int width, fd_set * readfds, fd_set * writefds,
-           fd_set * exceptfds, struct timeval * timeout);
-int write(int fd, char *buf, int nbyte);
-#endif
-
-#if     defined(sequent)
-int accept(int s, struct sockaddr * addr, int *addrlen);
-int bind(int s, struct sockaddr * name, int namelen);
-int close(int fd);
-int fcntl(int fd, int cmd, int arg);
-int getpeername(int s, struct sockaddr * name, int *namelen);
-int getsockname(int s, struct sockaddr * name, int *namelen);
-int gettimeofday(struct timeval * tp, struct timezone * tzp);
-#if     !defined(htons)
-u_short htons(u_short hostshort);
-#endif
-int listen(int s, int backlog);
-#if     !defined(ntohl)
-u_long ntohl(u_long hostlong);
-#endif
-int read(int fd, char *buf, int nbyte);
-int select(int width, fd_set * readfds, fd_set * writefds,
-           fd_set * exceptfds, struct timeval * timeout);
-int setsockopt(int s, int level, int optname, caddr_t optval,
-               int optlen);
-int socket(int domain, int type, int protocol);
-int write(int fd, char *buf, int nbyte);
 #endif
 
 /*
@@ -176,24 +120,7 @@ int setsockopt(int s, int level, int optname, const char *optval,
 int socket(int domain, int type, int protocol);
 #endif
 
-#if defined(ultrix)
-void bzero(char *b1, int length);
-int setitimer(int which, struct itimerval *value, struct itimerval *ovalue);
-int accept(int s, struct sockaddr * addr, int *addrlen);
-int bind(int s, struct sockaddr * name, int namelen);
-int close(int fd);
-int getpeername(int s, struct sockaddr * name, int *namelen);
-int getsockname(int s, struct sockaddr * name, int *namelen);
-int gettimeofday(struct timeval * tp, struct timezone * tzp);
-int listen(int s, int backlog);
-int select(int width, fd_set * readfds, fd_set * writefds,
-           fd_set * exceptfds, struct timeval * timeout);
-int setsockopt(int s, int level, int optname, void *optval,
-               int optlen);
-int socket(int domain, int type, int protocol);
-#endif
-
-#if !defined(NeXT) && (!defined(WIN32) || defined(__CYGWIN__))
+#if (!defined(WIN32) || defined(__CYGWIN__))
 #include <unistd.h>
 #endif
 

--- a/src/comm.h
+++ b/src/comm.h
@@ -96,6 +96,7 @@ int socket(int domain, int type, int protocol);
 #endif
 
 #if     defined(linux)
+#include <sys/time.h>
 int getpeername(int s, struct sockaddr * name, int *namelen);
 int getsockname(int s, struct sockaddr * name, int *namelen);
 int gettimeofday(struct timeval * tp, struct timezone * tzp);

--- a/src/pro_create.cpp
+++ b/src/pro_create.cpp
@@ -684,7 +684,7 @@ void update_buildrepair(void)
               send_to_char(CH, "This spell would have been the profane bridge that brought the Horrors to the Sixth World. However, they were thoroughly unimpressed with your work. You failed to design %s.\r\n", GET_OBJ_NAME(PROG));
               break;
             case 3:  
-              send_to_char(CH, "You draw the Magus of the Eternal Gods, Lord of the Wild and Fertile Lands, and the Ten of Spades. Go fish. You failed to design %s.\r\n", GET_OBJ_NAME(PROG))
+              send_to_char(CH, "You draw the Magus of the Eternal Gods, Lord of the Wild and Fertile Lands, and the Ten of Spades. Go fish. You failed to design %s.\r\n", GET_OBJ_NAME(PROG));
               break;
             case 4:  
               send_to_char(CH, "You finished programming a Carrot Top reality filter for your cyberdeck - wait, what?!? You realise you have lost your inspiration for %s\r\n", GET_OBJ_NAME(PROG));

--- a/src/spec_assign.cpp
+++ b/src/spec_assign.cpp
@@ -40,7 +40,7 @@ struct teach_data metamagict[] = {
                          { 4250, { META_CLEANSING, 0, 0, 0, 0, 0, 0, 0 }, "", 0 },
                          { 4251, { META_MASKING, 0, 0, 0, 0, 0, 0, 0 }, "", 0 },
                          { 10010, { META_ANCHORING, META_CENTERING, META_CLEANSING, META_INVOKING, META_MASKING, META_POSSESSING, META_QUICKENING, META_REFLECTING, META_SHIELDING }, "", 0},
-                         { 35538, { META_MASKING, 0 0, 0, 0, 0, 0, 0, 0, 0 }, "", 0},
+                         { 35538, { META_MASKING, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, "", 0},
                          { 27426, { META_REFLECTING, 0, 0, 0, 0, 0, 0, 0 }, "", 0},
                          { 0, { 0, 0, 0, 0, 0, 0, 0, 0, 0 }, "", 0}
                        };


### PR DESCRIPTION
… by making the function a wrapper around std::chrono::systemclock::now() which is available on Linux, OSX and Windows

Fixed typos introduced by PRs 573 and 575

Second commit:
Pretty sure AwakeMUD won't compile, no matter what, on the following:
NeXT, Ultrix, MIPS OS, Sequent, Apollo (Domain/OS)

As they have been deprecated since the 90s and compiling C++11 on
them... So may as well cleanup the code and deprecate them
officially. By the Makefile it seems that only Linux, OSX and Cygwin are
currently officially supported but it will probably compile fine on
FreeBSD, AIX and HP-UX as well, albeit with a bit of tweaking on the
Makefile.

I plan to do a bit more cleaning up and also fix compilation with
`CXX = g++` as well.