### PR TITLE
New util function get_string_after_color_code_removal()

### DIFF
--- a/src/deck_build.cpp
+++ b/src/deck_build.cpp
@@ -294,10 +294,25 @@ void pbuild_parse(struct descriptor_data *d, const char *arg) {
         }
         break;
     case DEDIT_NAME:
-        if (strlen(arg) >= LINE_LENGTH) {
+        int length_with_no_color = get_string_length_after_color_code_removal(arg, CH);
+      
+        // Silent failure: We already sent the error message in get_string_length_after_color_code_removal().
+        if (length_with_no_color == -1) {
+          partbuild_main_menu(d);
+          return;
+        }
+        if (length_with_no_color >= LINE_LENGTH) {
+            send_to_char(CH, "That name is too long, please shorten it. The maximum length after color code removal is %d characters.\r\n", LINE_LENGTH - 1);
             partbuild_main_menu(d);
             return;
         }
+  
+        if (strlen(arg) >= MAX_RESTRING_LENGTH) {
+            send_to_char(CH, "That restring is too long, please shorten it. The maximum length with color codes included is %d characters.\r\n", MAX_RESTRING_LENGTH - 1);
+            partbuild_main_menu(d);
+            return;
+        }
+
         DELETE_ARRAY_IF_EXTANT(PART->restring);
         PART->restring = str_dup(arg);
         partbuild_main_menu(d);
@@ -339,10 +354,25 @@ void dbuild_parse(struct descriptor_data *d, const char *arg) {
         }
         break;
     case DEDIT_NAME:
-        if (strlen(arg) >= LINE_LENGTH) {
+        int length_with_no_color = get_string_length_after_color_code_removal(arg, CH);
+      
+        // Silent failure: We already sent the error message in get_string_length_after_color_code_removal().
+        if (length_with_no_color == -1) {
+          deckbuild_main_menu(d);
+          return;
+        }
+        if (length_with_no_color >= LINE_LENGTH) {
+            send_to_char(CH, "That name is too long, please shorten it. The maximum length after color code removal is %d characters.\r\n", LINE_LENGTH - 1);
             deckbuild_main_menu(d);
             return;
         }
+  
+        if (strlen(arg) >= MAX_RESTRING_LENGTH) {
+            send_to_char(CH, "That restring is too long, please shorten it. The maximum length with color codes included is %d characters.\r\n", MAX_RESTRING_LENGTH - 1);
+            deckbuild_main_menu(d);
+            return;
+        }
+
         DELETE_ARRAY_IF_EXTANT(PART->restring);
         PART->restring = str_dup(arg);
         deckbuild_main_menu(d);

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -2692,7 +2692,7 @@ struct obj_data *get_obj_in_list_vis(struct char_data * ch, char *name, struct o
   for (i = list; i && (j <= number); i = i->next_content) {
     if (ch->in_veh && i->in_veh && i->vfront != ch->vfront)
       continue;
-    if (isname(tmp, i->text.keywords) || isname(tmp, i->text.name) || (i->restring && isname(tmp, i->restring)))
+    if (isname(tmp, i->text.keywords) || isname(tmp, i->text.name) || (i->restring && isname(tmp, get_string_after_color_code_removal(i->restring, ch))))
       if (++j == number)
         return i;
   }
@@ -2733,18 +2733,18 @@ struct obj_data *get_object_in_equip_vis(struct char_data * ch,
   strcpy(tmp, arg);
   if (!(number = get_number(&tmp)))
     return NULL;
-  
+
   for ((*j) = 0; (*j) < NUM_WEARS && i <= number; (*j)++)
     if (equipment[(*j)])
     {
       if (isname(tmp, equipment[(*j)]->text.keywords) || isname(tmp, equipment[(*j)]->text.name)  ||
-          (equipment[(*j)]->restring && isname(tmp, equipment[(*j)]->restring)))
+          (equipment[(*j)]->restring && isname(tmp, get_string_after_color_code_removal(equipment[(*j)]->restring, ch))))
         if (++i == number)
           return (equipment[(*j)]);
       if (GET_OBJ_TYPE(equipment[(*j)]) == ITEM_WORN && equipment[(*j)]->contains)
         for (struct obj_data *obj = equipment[(*j)]->contains; obj; obj = obj->next_content)
           if (isname(tmp, obj->text.keywords) || isname(tmp, obj->text.name) ||
-              (obj->restring && isname(tmp, obj->restring)))
+              (obj->restring && isname(tmp, get_string_after_color_code_removal(obj->restring, ch))))
             if (++i == number)
               return (obj);
     }

--- a/src/magcreate.cpp
+++ b/src/magcreate.cpp
@@ -128,15 +128,31 @@ void spedit_parse(struct descriptor_data *d, const char *arg)
       GET_OBJ_VAL(SPELL, 3) = number;
       spedit_disp_menu(d);
       break;
-    case SPEDIT_NAME:
-      if (strlen(arg) >= LINE_LENGTH) {
+    case SPEDIT_NAME: {
+      int length_with_no_color = get_string_length_after_color_code_removal(arg, CH);
+      
+      // Silent failure: We already sent the error message in get_string_length_after_color_code_removal().
+      if (length_with_no_color == -1) {
         spedit_disp_menu(d);
         return;
       }
+      if (length_with_no_color >= LINE_LENGTH) {
+        send_to_char(CH, "That name is too long, please shorten it. The maximum length after color code removal is %d characters.\r\n", LINE_LENGTH - 1);
+        spedit_disp_menu(d);
+        return;
+      }
+  
+      if (strlen(arg) >= MAX_RESTRING_LENGTH) {
+        send_to_char(CH, "That restring is too long, please shorten it. The maximum length with color codes included is %d characters.\r\n", MAX_RESTRING_LENGTH - 1);
+        spedit_disp_menu(d);
+        return;
+      }
+
       DELETE_ARRAY_IF_EXTANT(SPELL->restring);
       SPELL->restring = str_dup(arg);
       spedit_disp_menu(d);
       break;
+    }
     case SPEDIT_FORCE: 
       x = MIN(d->edit_number2, GET_SKILL(CH, SKILL_SPELLDESIGN) ? GET_SKILL(CH, SKILL_SPELLDESIGN) : GET_SKILL(CH, SKILL_SORCERY));
       if (number > x || number < 1)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -3744,17 +3744,24 @@ int get_string_length_after_color_code_removal(const char *str, struct char_data
 
 // Returns a string stripped of color for keyword matching or possibly other uses as well.
 // We don't need to check for color code validity because we call get_string_legth_after_color_code_removal() when the strings are initially written.
-char* get_string_after_color_code_removal(const char *str, struct char_data *ch_to_notify_of_failure_reason) {
+char* get_string_after_color_code_removal(const char *str, struct char_data *ch) {
   if (!str) {
-    mudlog("SYSERR: Null string received to get_string_after_color_code_removal().", ch_to_notify_of_failure_reason, LOG_SYSLOG, TRUE);
+    mudlog("SYSERR: Null string received to get_string_after_color_code_removal().", ch, LOG_SYSLOG, TRUE);
     return NULL;
   }
     
   const char *ptr = str;
   static char clearstr [MAX_STRING_LENGTH];
+  memset(clearstr, 0, sizeof(clearstr));
   int pos = 0;
   
   while (*ptr) {
+    // Buffer overflow failsafe.
+    if (pos == MAX_STRING_LENGTH) {
+      clearstr[pos] = '\0';
+      return clearstr;
+    }
+    
     if (*ptr == '^') {
       // Parse a single ^ character.
       if (*(ptr+1) == '^') {

--- a/src/utils.h
+++ b/src/utils.h
@@ -105,7 +105,7 @@ bool    program_can_be_copied(struct obj_data *prog);
 struct  obj_data *get_obj_proto_for_vnum(vnum_t vnum);
 void    set_natural_vision_for_race(struct char_data *ch);
 int     get_string_length_after_color_code_removal(const char *str, struct char_data *ch_to_notify_of_failure_reason);
-char *  get_string_after_color_code_removal(const char *str, struct char_data *ch_to_notify_of_failure_reason);
+char *  get_string_after_color_code_removal(const char *str, struct char_data *ch);
 bool    npc_is_protected_by_spec(struct char_data *npc);
 bool    can_damage_vehicle(struct char_data *ch, struct veh_data *veh);
 char *  compose_spell_name(int type, int subtype = -1);

--- a/src/utils.h
+++ b/src/utils.h
@@ -105,6 +105,7 @@ bool    program_can_be_copied(struct obj_data *prog);
 struct  obj_data *get_obj_proto_for_vnum(vnum_t vnum);
 void    set_natural_vision_for_race(struct char_data *ch);
 int     get_string_length_after_color_code_removal(const char *str, struct char_data *ch_to_notify_of_failure_reason);
+char *  get_string_after_color_code_removal(const char *str, struct char_data *ch_to_notify_of_failure_reason);
 bool    npc_is_protected_by_spec(struct char_data *npc);
 bool    can_damage_vehicle(struct char_data *ch, struct veh_data *veh);
 char *  compose_spell_name(int type, int subtype = -1);


### PR DESCRIPTION
allows matching keywords from named/restrung objects no matter
how they're colored. Implemented on object selector and
deck/part/spell building functions along with
get_string_length_after_color_code_removal() for limiting
string lengths on color code stripped strings.