### PR TITLE
A number of fixes.

### DIFF
--- a/src/act.informative.cpp
+++ b/src/act.informative.cpp
@@ -3710,8 +3710,24 @@ ACMD(do_cyberware)
 
   send_to_char("You have the following cyberware:\r\n", ch);
   for (obj = ch->cyberware; obj != NULL; obj = obj->next_content) {
-    snprintf(buf, sizeof(buf), "%-40s Essence: %0.2f\r\n",
-            GET_OBJ_NAME(obj), ((float)GET_OBJ_VAL(obj, 4) / 100));
+    if (GET_OBJ_VAL(obj, 0) == CYB_FINGERTIP) {
+      if (obj->contains && GET_OBJ_TYPE(obj->contains) == ITEM_WEAPON && GET_HOLSTER_READY_STATUS(obj) ) {
+        snprintf(buf, sizeof(buf), "%-32s ^Y(W) (R)^n Essence: %0.2f\r\n", GET_OBJ_NAME(obj), ((float)GET_OBJ_VAL(obj, 4) / 100));
+        send_to_char(buf, ch);
+        continue;
+      }
+      else if (obj->contains && GET_OBJ_TYPE(obj->contains) == ITEM_WEAPON && !GET_HOLSTER_READY_STATUS(obj)) {
+        snprintf(buf, sizeof(buf), "%-36s ^Y(W)^n Essence: %0.2f\r\n", GET_OBJ_NAME(obj), ((float)GET_OBJ_VAL(obj, 4) / 100));
+        send_to_char(buf, ch);
+        continue;
+      }
+      else if (obj->contains) {
+        snprintf(buf, sizeof(buf), "%-36s ^Y(F)^n Essence: %0.2f\r\n", GET_OBJ_NAME(obj), ((float)GET_OBJ_VAL(obj, 4) / 100));
+        send_to_char(buf, ch);
+        continue;
+      }
+    }
+    snprintf(buf, sizeof(buf), "%-40s Essence: %0.2f\r\n", GET_OBJ_NAME(obj), ((float)GET_OBJ_VAL(obj, 4) / 100));
     send_to_char(buf, ch);
   }
 }

--- a/src/act.informative.cpp
+++ b/src/act.informative.cpp
@@ -3710,24 +3710,24 @@ ACMD(do_cyberware)
 
   send_to_char("You have the following cyberware:\r\n", ch);
   for (obj = ch->cyberware; obj != NULL; obj = obj->next_content) {
-    if (GET_OBJ_VAL(obj, 0) == CYB_FINGERTIP) {
+    if (GET_CYBERWARE_TYPE(obj) == CYB_FINGERTIP) {
       if (obj->contains && GET_OBJ_TYPE(obj->contains) == ITEM_WEAPON && GET_HOLSTER_READY_STATUS(obj) ) {
-        snprintf(buf, sizeof(buf), "%-32s ^Y(W) (R)^n Essence: %0.2f\r\n", GET_OBJ_NAME(obj), ((float)GET_OBJ_VAL(obj, 4) / 100));
+        snprintf(buf, sizeof(buf), "%-32s ^Y(W) (R)^n Essence: %0.2f\r\n", GET_OBJ_NAME(obj), ((float)GET_CYBERWARE_ESSENCE_COST(obj) / 100));
         send_to_char(buf, ch);
         continue;
       }
       else if (obj->contains && GET_OBJ_TYPE(obj->contains) == ITEM_WEAPON && !GET_HOLSTER_READY_STATUS(obj)) {
-        snprintf(buf, sizeof(buf), "%-36s ^Y(W)^n Essence: %0.2f\r\n", GET_OBJ_NAME(obj), ((float)GET_OBJ_VAL(obj, 4) / 100));
+        snprintf(buf, sizeof(buf), "%-36s ^Y(W)^n Essence: %0.2f\r\n", GET_OBJ_NAME(obj), ((float)GET_CYBERWARE_ESSENCE_COST(obj) / 100));
         send_to_char(buf, ch);
         continue;
       }
       else if (obj->contains) {
-        snprintf(buf, sizeof(buf), "%-36s ^Y(F)^n Essence: %0.2f\r\n", GET_OBJ_NAME(obj), ((float)GET_OBJ_VAL(obj, 4) / 100));
+        snprintf(buf, sizeof(buf), "%-36s ^Y(F)^n Essence: %0.2f\r\n", GET_OBJ_NAME(obj), ((float)GET_CYBERWARE_ESSENCE_COST(obj) / 100));
         send_to_char(buf, ch);
         continue;
       }
     }
-    snprintf(buf, sizeof(buf), "%-40s Essence: %0.2f\r\n", GET_OBJ_NAME(obj), ((float)GET_OBJ_VAL(obj, 4) / 100));
+    snprintf(buf, sizeof(buf), "%-40s Essence: %0.2f\r\n", GET_OBJ_NAME(obj), ((float)GET_CYBERWARE_ESSENCE_COST(obj) / 100));
     send_to_char(buf, ch);
   }
 }
@@ -3745,7 +3745,7 @@ ACMD(do_bioware)
   for (obj = ch->bioware; obj != NULL; obj = obj->next_content) {
     snprintf(buf, sizeof(buf), "%-40s Rating: %-2d     Bioware Index: %0.2f\r\n",
             GET_OBJ_NAME(obj),
-            GET_OBJ_VAL(obj, 1), ((float)GET_OBJ_VAL(obj, 4) / 100));
+            GET_BIOWARE_RATING(obj), ((float)GET_BIOWARE_ESSENCE_COST(obj) / 100));
     send_to_char(buf, ch);
   }
 }

--- a/src/act.obj.cpp
+++ b/src/act.obj.cpp
@@ -3599,7 +3599,7 @@ ACMD(do_holster)
     send_to_char(ch, "%s is not a holsterable weapon.\r\n", capitalize(GET_OBJ_NAME(obj)));
     return;
   }
-  if (GET_OBJ_TYPE(cont) != ITEM_HOLSTER && (GET_OBJ_TYPE(cont) == ITEM_CYBERWARE && GET_OBJ_VAL(cont, 0) != CYB_FINGERTIP)) {
+  if (GET_OBJ_TYPE(cont) != ITEM_HOLSTER && (GET_OBJ_TYPE(cont) != ITEM_CYBERWARE || GET_CYBERWARE_TYPE(cont) != CYB_FINGERTIP)) {
     send_to_char(ch, "%s is not a holster.\r\n", capitalize(GET_OBJ_NAME(cont)));
     return;
   }
@@ -3610,11 +3610,8 @@ ACMD(do_holster)
 
   const char *madefor = "<error, report to staff>";
   
-  if (GET_OBJ_TYPE(cont) == ITEM_CYBERWARE && GET_OBJ_VAL(cont, 0) == CYB_FINGERTIP)
-    madefor = "monowhips";
-  else {
-    if (!holster_can_fit(cont, obj))
-      dontfit++;
+  if (GET_OBJ_TYPE(cont) == ITEM_HOLSTER && !holster_can_fit(cont, obj)) {
+    dontfit++;
     
     switch (GET_HOLSTER_TYPE(cont)) {
       case HOLSTER_TYPE_SMALL_GUNS:
@@ -3632,6 +3629,7 @@ ACMD(do_holster)
       return;
     }
   }
+
   if (GET_OBJ_SPEC(obj) == weapon_dominator) {
     dominator_mode_switch(ch, obj, DOMINATOR_MODE_PARALYZER);
   }
@@ -3669,7 +3667,7 @@ ACMD(do_ready)
       return;
     }
   }
-  if (GET_OBJ_TYPE(obj) != ITEM_HOLSTER && (GET_OBJ_TYPE(obj) == ITEM_CYBERWARE && GET_OBJ_VAL(obj, 0) != CYB_FINGERTIP)) {
+  if (GET_OBJ_TYPE(obj) != ITEM_HOLSTER && (GET_OBJ_TYPE(obj) != ITEM_CYBERWARE || GET_CYBERWARE_TYPE(obj) != CYB_FINGERTIP)) {
     send_to_char(ch, "%s is not a weapons holster.\r\n", capitalize(GET_OBJ_NAME(obj)));
     return;
   }

--- a/src/act.obj.cpp
+++ b/src/act.obj.cpp
@@ -363,7 +363,7 @@ ACMD(do_put)
   
   if (!str_cmp(arg2, "finger")) {
     for (cont = ch->cyberware; cont; cont = cont->next_content)
-      if (GET_OBJ_VAL(cont, 0) == CYB_FINGERTIP)
+      if (GET_CYBERWARE_TYPE(cont) == CYB_FINGERTIP)
         break;
     if (!cont) {
       send_to_char("You don't have a fingertip compartment.\r\n", ch);
@@ -1183,7 +1183,7 @@ ACMD(do_get)
     send_to_char(ch, "%s what?\r\n", (cyberdeck ? "Uninstall" : (download ? "Download" : "Get")));
   } else if (!str_cmp(arg1, "tooth")) {
     for (cont = ch->cyberware; cont; cont = cont->next_content)
-      if (GET_OBJ_VAL(cont, 0) == CYB_TOOTHCOMPARTMENT)
+      if (GET_CYBERWARE_TYPE(cont) == CYB_TOOTHCOMPARTMENT)
         break;
     if (!cont)
       send_to_char("You don't have a tooth compartment.\r\n", ch);
@@ -1200,7 +1200,7 @@ ACMD(do_get)
     }
   } else if (!str_cmp(arg1, "finger")) {
     for (cont = ch->cyberware; cont; cont = cont->next_content)
-      if (GET_OBJ_VAL(cont, 0) == CYB_FINGERTIP)
+      if (GET_CYBERWARE_TYPE(cont) == CYB_FINGERTIP)
         break;
     if (!cont)
       send_to_char("You don't have a fingertip compartment.\r\n", ch);
@@ -1215,7 +1215,7 @@ ACMD(do_get)
     }
   } else if (!str_cmp(arg1, "body")) {
     for (cont = ch->cyberware; cont; cont = cont->next_content)
-      if (GET_OBJ_VAL(cont, 0) == CYB_BODYCOMPART)
+      if (GET_CYBERWARE_TYPE(cont) == CYB_BODYCOMPART)
         break;
     if (!cont)
       send_to_char("You don't have a body compartment.\r\n", ch);
@@ -3454,7 +3454,7 @@ int draw_weapon(struct char_data *ch)
   //Look in fingertip first to get it out of the way.
   //At some point we need to write a mechanism to select what is drawn automatically -- Nodens
   for (potential_holster = ch->cyberware; potential_holster; potential_holster = potential_holster->next_content)
-    if (GET_OBJ_VAL(potential_holster, 0) == CYB_FINGERTIP && GET_HOLSTER_READY_STATUS(potential_holster))
+    if (GET_CYBERWARE_TYPE(potential_holster) == CYB_FINGERTIP && GET_HOLSTER_READY_STATUS(potential_holster))
       i += draw_from_readied_holster(ch, potential_holster);
 
   // Go through all the wearslots, provided that the character is not already wielding & holding things.
@@ -3508,7 +3508,7 @@ struct obj_data *find_holster_that_fits_weapon(struct char_data *ch, struct obj_
   if (obj_index[GET_OBJ_RNUM(weapon)].wfunc == monowhip) {
     struct obj_data *cont;
     for (cont = ch->cyberware; cont; cont = cont->next_content)
-      if (GET_OBJ_VAL(cont, 0) == CYB_FINGERTIP && !cont->contains)
+      if (GET_CYBERWARE_TYPE(cont) == CYB_FINGERTIP && !cont->contains)
         return cont;
   }
   // Look at their worn items. We exclude inventory here.
@@ -3659,7 +3659,7 @@ ACMD(do_ready)
   }
   
   //If we have a fingertip compartment that matches the argument, set our object to that.
-  if ((finger = get_obj_in_list_vis(ch, buf, ch->cyberware)) && GET_OBJ_VAL(finger, 0) == CYB_FINGERTIP)
+  if ((finger = get_obj_in_list_vis(ch, buf, ch->cyberware)) && GET_CYBERWARE_TYPE(finger) == CYB_FINGERTIP)
     obj = finger;
   else {
     if (!(generic_find(buf, FIND_OBJ_EQUIP, ch, &tmp_char, &obj))) {
@@ -3682,7 +3682,7 @@ ACMD(do_ready)
   } else {
     //Check if we have any fingertip compartments that are readied
     for (struct obj_data *cyber = ch->cyberware; cyber; cyber = cyber->next_content)
-      if (GET_OBJ_VAL(cyber, 0) == CYB_FINGERTIP && GET_HOLSTER_READY_STATUS(cyber))
+      if (GET_CYBERWARE_TYPE(cyber) == CYB_FINGERTIP && GET_HOLSTER_READY_STATUS(cyber))
         num++;
 
     for (int i = 0; i < NUM_WEARS; i++)

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -298,12 +298,13 @@ void set_fighting(struct char_data * ch, struct char_data * vict, ...)
   
   ch->next_fighting = combat_list;
   combat_list = ch;
+  // We set fighting before we call roll_individual_initiative() because we need the fighting target there.
+  FIGHTING(ch) = vict;
+  GET_POS(ch) = POS_FIGHTING;
+  
   roll_individual_initiative(ch);
   order_list(TRUE);
   
-  // GET_INIT_ROLL(ch) = 0;
-  FIGHTING(ch) = vict;
-  GET_POS(ch) = POS_FIGHTING;
   if (!(AFF_FLAGGED(ch, AFF_MANNING) || PLR_FLAGGED(ch, PLR_REMOTE) || AFF_FLAGGED(ch, AFF_RIG)))
   {
     if (!(GET_EQ(ch, WEAR_WIELD) && GET_EQ(ch, WEAR_HOLD)))
@@ -4468,8 +4469,6 @@ void range_combat(struct char_data *ch, char *target, struct obj_data *weapon,
 
 void roll_individual_initiative(struct char_data *ch)
 {
-  if (AFF_FLAGGED(ch, AFF_SURPRISE))
-    AFF_FLAGS(ch).RemoveBit(AFF_SURPRISE);
   if (AWAKE(ch))
   {
     // TODO: SR3: While rigging, riggers receive only the modifications given them by the vehicle control rig (see Vehicles and Drones, p. 130) they are using.
@@ -4488,19 +4487,20 @@ void roll_individual_initiative(struct char_data *ch)
       else
         GET_INIT_ROLL(ch) += 20;
     }
-    if (IS_NPC(ch)) {
-      if (GET_MOBALERT(ch) == MALERT_CALM && FIGHTING(ch) && success_test(GET_REA(ch), 4) < success_test(GET_REA(FIGHTING(ch)), 4)) {
-        GET_INIT_ROLL(ch) = 0;
-        act("You surprise $n!", TRUE, ch, 0, FIGHTING(ch), TO_VICT);
-        AFF_FLAGS(ch).SetBit(AFF_SURPRISE);
-      }
-      GET_MOBALERT(ch) = MALERT_ALARM;
-      GET_MOBALERTTIME(ch) = 30;
+    // Here we set the Surprise flag to our target if conditions are met. Clearing of flag and alert status are handled
+    // in hit_with_multi_weapon_toggle() as soon as a suprised NPC gets damaged in combat. Otherwise we can't
+    // properly enter the surprise state due to mobs being continously alert. Because we were handling this in
+    // init state and either the flag was getting stripped or the mob became alert before we ever tried to hit it.
+    // Also the no defense condition happens in the hit_with_multi_weapon_toggle() and we can't remove surprise
+    // flag until we process all that.
+    if (IS_NPC(FIGHTING(ch)) && GET_MOBALERT(FIGHTING(ch)) == MALERT_CALM && success_test(GET_REA(ch), 4) > success_test(GET_REA(FIGHTING(ch)), 4)) {
+      GET_INIT_ROLL(FIGHTING(ch)) = 0;
+      act("You surprise $n!", TRUE, FIGHTING(ch), 0, ch, TO_VICT);
+      AFF_FLAGS(FIGHTING(ch)).SetBit(AFF_SURPRISE);
     }
   }
   char rbuf[MAX_STRING_LENGTH];
-  snprintf(rbuf, sizeof(rbuf),"Init: %2d %s",
-          GET_INIT_ROLL(ch), GET_NAME(ch));
+  snprintf(rbuf, sizeof(rbuf),"Init: %2d %s", GET_INIT_ROLL(ch), GET_NAME(ch));
   act(rbuf,TRUE,ch,NULL,NULL,TO_ROLLS);
   if (AFF_FLAGGED(ch, AFF_ACID))
     AFF_FLAGS(ch).RemoveBit(AFF_ACID);
@@ -4801,7 +4801,7 @@ void perform_violence(void)
         - You both have melee weapons out (both stop charging; clash)
       */
       if (IS_AFFECTED(FIGHTING(ch), AFF_APPROACH) 
-          || GET_POS(FIGHTING(ch)) < POS_FIGHTING 
+          || GET_POS(FIGHTING(ch)) < POS_FIGHTING
           || (item_should_be_treated_as_melee_weapon(GET_EQ(ch, WEAR_WIELD)) && item_should_be_treated_as_melee_weapon(GET_EQ(FIGHTING(ch), WEAR_WIELD)))) {
         AFF_FLAGS(ch).RemoveBit(AFF_APPROACH);
         AFF_FLAGS(FIGHTING(ch)).RemoveBit(AFF_APPROACH);
@@ -4882,12 +4882,6 @@ void perform_violence(void)
           act("$n charges towards you, but you manage to keep some distance.", TRUE, ch, 0, FIGHTING(ch), TO_VICT);
           // TODO: Is it really supposed to cost an extra init pass?
           // GET_INIT_ROLL(ch) -= 10;
-          
-          // Set alert status if they can see you coming.
-          if (IS_NPC(FIGHTING(ch)) && CAN_SEE(FIGHTING(ch), ch)) {
-            GET_MOBALERTTIME(FIGHTING(ch)) = 30;
-            GET_MOBALERT(FIGHTING(ch)) = MALERT_ALARM;
-          }
           
           continue;
         }

--- a/src/newfight.cpp
+++ b/src/newfight.cpp
@@ -1050,6 +1050,13 @@ void hit_with_multiweapon_toggle(struct char_data *attacker, struct char_data *v
         
         att->melee->power -= GET_IMPACT(def->ch) / 2;
       }
+      // Because we swap att and def pointers if defender wins the clash we need to make sure attacker gets proper values
+      // if they're using a ranged weapon in clash instead of setting their melee power to the damage code of the ranged
+      // weapon as it was happening.
+      else if (IS_RANGED(att->weapon)) {
+        att->melee->power = GET_STR(att->ch);
+        att->melee->damage_level = MODERATE;
+      }
       // Non-monowhips behave normally.
       else {
         att->melee->power = GET_WEAPON_STR_BONUS(att->weapon) + GET_STR(att->ch);

--- a/src/newfight.cpp
+++ b/src/newfight.cpp
@@ -1176,7 +1176,7 @@ void hit_with_multiweapon_toggle(struct char_data *attacker, struct char_data *v
             // If the attacker dies from backlash, bail out.
             if (damage(attacker, attacker, dam_total, TYPE_RECOIL, PHYSICAL)) {
               
-              //Handle suprise attack/alertness here -- attacker didn't die.
+              //Handle suprise attack/alertness here -- attacker died.
               if (IS_NPC(def->ch) && AFF_FLAGGED(def->ch, AFF_SURPRISE))
                 AFF_FLAGS(def->ch).RemoveBit(AFF_SURPRISE);
               if (IS_NPC(def->ch)) {

--- a/src/newfight.cpp
+++ b/src/newfight.cpp
@@ -788,11 +788,13 @@ void hit_with_multiweapon_toggle(struct char_data *attacker, struct char_data *v
       target_died = damage(att->ch, def->ch, -1, att->ranged->dam_type, 0);
       
       //Handle suprise attack/alertness here -- ranged attack failed.
-      if (!target_died && AFF_FLAGGED(def->ch, AFF_SURPRISE))
-        AFF_FLAGS(def->ch).RemoveBit(AFF_SURPRISE);
+      if (!target_died && IS_NPC(def->ch)) {
+        if (AFF_FLAGGED(def->ch, AFF_SURPRISE))
+          AFF_FLAGS(def->ch).RemoveBit(AFF_SURPRISE);
            
-      GET_MOBALERT(def->ch) = MALERT_ALARM;
-      GET_MOBALERTTIME(def->ch) = 30;
+        GET_MOBALERT(def->ch) = MALERT_ALARM;
+        GET_MOBALERTTIME(def->ch) = 30;
+      }
       return;
     }
     
@@ -845,11 +847,13 @@ void hit_with_multiweapon_toggle(struct char_data *attacker, struct char_data *v
         target_died = damage(att->ch, def->ch, 0, att->ranged->dam_type, att->ranged->is_physical);
         
         //Handle suprise attack/alertness here -- spirits ranged.
-         if (!target_died && AFF_FLAGGED(def->ch, AFF_SURPRISE))
-           AFF_FLAGS(def->ch).RemoveBit(AFF_SURPRISE);
+        if (!target_died && IS_NPC(def->ch)) {
+          if (AFF_FLAGGED(def->ch, AFF_SURPRISE))
+            AFF_FLAGS(def->ch).RemoveBit(AFF_SURPRISE);
            
-        GET_MOBALERT(def->ch) = MALERT_ALERT;
-        GET_MOBALERTTIME(def->ch) = 20;
+          GET_MOBALERT(def->ch) = MALERT_ALERT;
+          GET_MOBALERTTIME(def->ch) = 20;
+        }
         return;
       } else
         att->ranged->power -= GET_LEVEL(def->ch) * 2;
@@ -1087,11 +1091,13 @@ void hit_with_multiweapon_toggle(struct char_data *attacker, struct char_data *v
         target_died = damage(att->ch, def->ch, 0, att->melee->dam_type, att->melee->is_physical);
         
         //Handle suprise attack/alertness here -- spirits melee.
-         if (!target_died && AFF_FLAGGED(def->ch, AFF_SURPRISE))
-           AFF_FLAGS(def->ch).RemoveBit(AFF_SURPRISE);
+        if (!target_died && IS_NPC(def->ch)) {
+          if (AFF_FLAGGED(def->ch, AFF_SURPRISE))
+            AFF_FLAGS(def->ch).RemoveBit(AFF_SURPRISE);
 
-        GET_MOBALERT(def->ch) = MALERT_ALARM;
-        GET_MOBALERTTIME(def->ch) = 30;
+          GET_MOBALERT(def->ch) = MALERT_ALARM;
+          GET_MOBALERTTIME(def->ch) = 30;
+        }
         return;
       } else {
         att->melee->power -= GET_LEVEL(def->ch) * 2;
@@ -1197,9 +1203,10 @@ void hit_with_multiweapon_toggle(struct char_data *attacker, struct char_data *v
         }
       }
       //Handle suprise attack/alertness here -- defender didn't die.
-      if (IS_NPC(def->ch) && AFF_FLAGGED(def->ch, AFF_SURPRISE))
-        AFF_FLAGS(def->ch).RemoveBit(AFF_SURPRISE);
       if (IS_NPC(def->ch)) {
+        if (AFF_FLAGGED(def->ch, AFF_SURPRISE))
+          AFF_FLAGS(def->ch).RemoveBit(AFF_SURPRISE);
+
         GET_MOBALERT(def->ch) = MALERT_ALERT;
         GET_MOBALERTTIME(def->ch) = 20;
       }

--- a/src/newmagic.cpp
+++ b/src/newmagic.cpp
@@ -667,15 +667,22 @@ bool conjuring_drain(struct char_data *ch, int force)
   // Physical drain.
   if (force > GET_MAG(ch) / 100) {
     // Iterate through bioware to find relevant bioware.
+    bool bPlat = FALSE;
+    bool bTraum = FALSE;
     for (struct obj_data *bio = ch->bioware; bio && drain > 0; bio = bio->next_content) {
       if (GET_OBJ_VAL(bio, 0) == BIO_PLATELETFACTORY && drain >= 3)
-        drain--;
+        bPlat = TRUE;
       
-      if (GET_OBJ_VAL(bio, 0) == BIO_TRAUMADAMPNER) {
-        drain--;
-        GET_MENTAL(ch) -= 100;
-      }
+      if (GET_OBJ_VAL(bio, 0) == BIO_TRAUMADAMPNER)
+        bTraum = TRUE;
     }
+    if (bPlat)
+      drain--;
+    if (bTraum) {
+      drain--;
+      GET_MENTAL(ch) -= 100;
+    }
+      
     if (drain <= 0)
     return FALSE;
       
@@ -781,15 +788,20 @@ bool spell_drain(struct char_data *ch, int type, int force, int damage)
   // Apply physical drain damage.
   if (force > GET_MAG(ch) / 100 || IS_PROJECT(ch)) {    
     // Iterate through bioware to find a platelet factory.
+    bool bPlat = FALSE;
+    bool bTraum = FALSE;
     struct char_data *chptr = (IS_PROJECT(ch) ? ch->desc->original : ch);
     for (struct obj_data *bio = chptr->bioware; bio && damage > 0; bio = bio->next_content) {
-      if (GET_OBJ_VAL(bio, 0) == BIO_PLATELETFACTORY && damage >= 3) {
-        damage--;
-      }
-      if (GET_OBJ_VAL(bio, 0) == BIO_TRAUMADAMPNER) {
-        damage--;
-        GET_MENTAL(chptr) -= 100;
-      }
+      if (GET_OBJ_VAL(bio, 0) == BIO_PLATELETFACTORY && damage >= 3)
+        bPlat = TRUE;
+      if (GET_OBJ_VAL(bio, 0) == BIO_TRAUMADAMPNER)
+        bTraum = TRUE;
+    }
+    if (bPlat)
+      damage--;
+    if (bTraum) {
+      damage--;
+      GET_MENTAL(chptr) -= 100;
     }
     
     if (damage <= 0)

--- a/src/pro_create.cpp
+++ b/src/pro_create.cpp
@@ -133,14 +133,31 @@ void pedit_parse(struct descriptor_data *d, const char *arg)
     }
     break;
   case PEDIT_NAME:
-    if (strlen(arg) >= LINE_LENGTH) {
+  {
+    int length_with_no_color = get_string_length_after_color_code_removal(arg, CH);
+      
+    // Silent failure: We already sent the error message in get_string_length_after_color_code_removal().
+    if (length_with_no_color == -1) {
       pedit_disp_menu(d);
       return;
     }
+    if (length_with_no_color >= LINE_LENGTH) {
+        send_to_char(CH, "That name is too long, please shorten it. The maximum length after color code removal is %d characters.\r\n", LINE_LENGTH - 1);
+        pedit_disp_menu(d);
+        return;
+    }
+  
+    if (strlen(arg) >= MAX_RESTRING_LENGTH) {
+        send_to_char(CH, "That restring is too long, please shorten it. The maximum length with color codes included is %d characters.\r\n", MAX_RESTRING_LENGTH - 1);
+        pedit_disp_menu(d);
+        return;
+    }
+
     DELETE_ARRAY_IF_EXTANT(d->edit_obj->restring);
     d->edit_obj->restring = str_dup(arg);
     pedit_disp_menu(d);
     break;
+  }
   case PEDIT_WOUND:
     if (number < 1 || number > 4)
       send_to_char(CH, "Not a valid option!\r\nEnter your choice: ");

--- a/src/pro_create.cpp
+++ b/src/pro_create.cpp
@@ -142,15 +142,15 @@ void pedit_parse(struct descriptor_data *d, const char *arg)
       return;
     }
     if (length_with_no_color >= LINE_LENGTH) {
-        send_to_char(CH, "That name is too long, please shorten it. The maximum length after color code removal is %d characters.\r\n", LINE_LENGTH - 1);
-        pedit_disp_menu(d);
-        return;
+      send_to_char(CH, "That name is too long, please shorten it. The maximum length after color code removal is %d characters.\r\n", LINE_LENGTH - 1);
+      pedit_disp_menu(d);
+      return;
     }
   
     if (strlen(arg) >= MAX_RESTRING_LENGTH) {
-        send_to_char(CH, "That restring is too long, please shorten it. The maximum length with color codes included is %d characters.\r\n", MAX_RESTRING_LENGTH - 1);
-        pedit_disp_menu(d);
-        return;
+      send_to_char(CH, "That restring is too long, please shorten it. The maximum length with color codes included is %d characters.\r\n", MAX_RESTRING_LENGTH - 1);
+      pedit_disp_menu(d);
+      return;
     }
 
     DELETE_ARRAY_IF_EXTANT(d->edit_obj->restring);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -922,6 +922,9 @@ void mudlog(const char *str, struct char_data *ch, int log, bool file)
         case LOG_ECONLOG:
           check_log = PRF_ECONLOG;
           break;
+        case LOG_RADLOG:
+          check_log = PRF_RADLOG;
+          break;
         default:
           char errbuf[500];
           snprintf(errbuf, sizeof(errbuf), "SYSERR: Attempting to display a message to log type %d, but that log type is not handled in utils.cpp's mudlog() function! Dumping to SYSLOG.", log);
@@ -3799,7 +3802,6 @@ int count_color_codes_in_string(const char *str) {
   long ptr_max = strlen(str) - 1;
 
   int sum = 0;
-  int pos = 0;
 
   while (*ptr && (ptr - str) <= ptr_max) {
     if (*ptr == '^') {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -922,9 +922,6 @@ void mudlog(const char *str, struct char_data *ch, int log, bool file)
         case LOG_ECONLOG:
           check_log = PRF_ECONLOG;
           break;
-        case LOG_RADLOG:
-          check_log = PRF_RADLOG;
-          break;
         default:
           char errbuf[500];
           snprintf(errbuf, sizeof(errbuf), "SYSERR: Attempting to display a message to log type %d, but that log type is not handled in utils.cpp's mudlog() function! Dumping to SYSLOG.", log);
@@ -3794,6 +3791,41 @@ char* get_string_after_color_code_removal(const char *str, struct char_data *ch)
     }
   }
   return  clearstr;
+}
+
+// Returns the amount of color codes in a string.
+int count_color_codes_in_string(const char *str) {
+  const char *ptr = str;
+  long ptr_max = strlen(str) - 1;
+
+  int sum = 0;
+  int pos = 0;
+
+  while (*ptr && (ptr - str) <= ptr_max) {
+    if (*ptr == '^') {
+      // Parse a single ^ character.
+      if (*(ptr+1) == '^') {
+        sum++;
+        ptr += 2;
+        continue;
+      }
+      // Count color codes.
+      // There are two types of color: Two-character tags (^g) and xterm tags (^[F123]). We must account for both.
+      // 7 for xterm tags 2 for regular tags
+      else if (*(ptr+1) == '[') {
+          ptr  += 7;
+          sum += 7;
+      }
+      else {
+        ptr += 2;
+        sum += 2;
+      }
+    }
+    //Clear character, save it.
+    else
+      ptr += 1;
+  }
+  return  sum;
 }
 
 #define CHECK_FUNC_AND_SFUNC_FOR(function) (mob_index[GET_MOB_RNUM(npc)].func == (function) || mob_index[GET_MOB_RNUM(npc)].sfunc == (function))

--- a/src/utils.h
+++ b/src/utils.h
@@ -106,6 +106,7 @@ struct  obj_data *get_obj_proto_for_vnum(vnum_t vnum);
 void    set_natural_vision_for_race(struct char_data *ch);
 int     get_string_length_after_color_code_removal(const char *str, struct char_data *ch_to_notify_of_failure_reason);
 char *  get_string_after_color_code_removal(const char *str, struct char_data *ch);
+int count_color_codes_in_string(const char *str) ;
 bool    npc_is_protected_by_spec(struct char_data *npc);
 bool    can_damage_vehicle(struct char_data *ch, struct veh_data *veh);
 char *  compose_spell_name(int type, int subtype = -1);

--- a/src/utils.h
+++ b/src/utils.h
@@ -106,7 +106,7 @@ struct  obj_data *get_obj_proto_for_vnum(vnum_t vnum);
 void    set_natural_vision_for_race(struct char_data *ch);
 int     get_string_length_after_color_code_removal(const char *str, struct char_data *ch_to_notify_of_failure_reason);
 char *  get_string_after_color_code_removal(const char *str, struct char_data *ch);
-int     count_color_codes_in_string(const char *str) ;
+int     count_color_codes_in_string(const char *str);
 bool    npc_is_protected_by_spec(struct char_data *npc);
 bool    can_damage_vehicle(struct char_data *ch, struct veh_data *veh);
 char *  compose_spell_name(int type, int subtype = -1);

--- a/src/utils.h
+++ b/src/utils.h
@@ -106,7 +106,7 @@ struct  obj_data *get_obj_proto_for_vnum(vnum_t vnum);
 void    set_natural_vision_for_race(struct char_data *ch);
 int     get_string_length_after_color_code_removal(const char *str, struct char_data *ch_to_notify_of_failure_reason);
 char *  get_string_after_color_code_removal(const char *str, struct char_data *ch);
-int count_color_codes_in_string(const char *str) ;
+int     count_color_codes_in_string(const char *str) ;
 bool    npc_is_protected_by_spec(struct char_data *npc);
 bool    can_damage_vehicle(struct char_data *ch, struct veh_data *veh);
 char *  compose_spell_name(int type, int subtype = -1);


### PR DESCRIPTION
-Program names on create program were not factoring color codes.
-Shop lists (including OLC) did not format properly with colored items.
-Cyberware shops selling cyberlimbs did not format properly due to name length of cyberlimbs.
-Fingertip compartment is now a proper sheath for monowhips. Only usable as one if it's actually empty and cyber command now displays it's actual status `(F)` for Full/having something inside `(W)` for whip, `(W) (R)` if it's actually ready to draw.
-Conjuration drain did not factor related bioware at all. Now it does.
-Surprise attacks did not work at all with multiple points of failure. Now they do. I would like to see melee surprise attacks skipping the closing distance (you surprise the mob,  you obviously do it up close instead of start charging to it from the other side of the room) but I tested this and I think it is OP because ranged mobs stay in clash and don't try to break back into ranged. Perhaps an extra stealth check there at high TN (modified by Int?) would make sense for skipping the closing in.