### PR TITLE
Update comm.cpp

### DIFF
--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -1410,6 +1410,9 @@ int make_prompt(struct descriptor_data * d)
               else
                 strcpy(str, "@v");
               break;
+            case 'V':       // Vision penalties in theory
+              sprintf(str, sizeof(str), "%d", calculate_vision_penalty(d->character));
+              break;
             case '@':
               strcpy(str, "@");
               break;

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -1410,8 +1410,8 @@ int make_prompt(struct descriptor_data * d)
               else
                 strcpy(str, "@v");
               break;
-            case 'V':       // Vision penalties in theory
-              sprintf(str, sizeof(str), "%d", calculate_vision_penalty(d->character));
+            case 'V':       // Current vision penalties of player
+              snprintf(str, sizeof(str), "%d", calculate_vision_penalty(d->character));
               break;
             case '@':
               strcpy(str, "@");


### PR DESCRIPTION
Theoretically should throw current vision penalties into the prompt, although it ignores such things as defender's invisibility, stealth, etcetrta.