### PR TITLE
Cleans up logic for vision penalties

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -413,23 +413,23 @@ int modify_target_rbuf_raw(struct char_data *ch, char *rbuf, int rbuf_len, int c
         }
         break;
       case LIGHT_PARTLIGHT:
-        if (CURRENT_VISION(ch) == NORMAL) {
-          light_target += 2;
-          buf_mod(rbuf, rbuf_len, "PartLight[N]", 2);
-        } else if (CURRENT_VISION(ch) == LOWLIGHT) {
+        if (CURRENT_VISION(ch) == LOWLIGHT) {
           if (NATURAL_VISION(ch) != LOWLIGHT) {
             light_target++;
             buf_mod(rbuf, rbuf_len, "PartLight[LL-UN]", 1);
-          }
-        } else {
-          if (NATURAL_VISION(ch) != THERMOGRAPHIC) {
-            light_target += 2;
-            buf_mod(rbuf, rbuf_len, "PartLight[TH-UN]", 2);
           } else {
-            light_target++;
-            buf_mod(rbuf, rbuf_len, "PartLight[TH-N]", 1);
-          }
-        }
+            light_target += 0;
+            buf_mod(rbuf, rbuf_len, "PartLight[LL-N]", 0);
+            }
+         }
+        else if (NATURAL_VISION(ch) == THERMOGRAPHIC && CURRENT_VISION(ch) != LOWLIGHT ) {
+               light_target++;
+               buf_mod(rbuf, rbuf_len, "PartLight[TH-N]", 1);
+         } 
+        else {
+           light_target += 2;
+           buf_mod(rbuf, rbuf_len, "PartLight", 2);
+           }
         break;
       case LIGHT_GLARE:
         if (CURRENT_VISION(ch) == NORMAL) {


### PR DESCRIPTION
Closed the previous one due to messy conflicts and how editing logic in github renders it messy.
+2 for machine thermographic/normal vision
+1 for native themographic/machine low light
0 penalty for native low light.

Logic rendered in a more visible fashion as opposed to the weird diff setup in github that makes it incomprehensible

```
      case LIGHT_PARTLIGHT:
        if (CURRENT_VISION(ch) == LOWLIGHT) {
          if (NATURAL_VISION(ch) != LOWLIGHT) {
            light_target++;
            buf_mod(rbuf, rbuf_len, "PartLight[LL-UN]", 1);
          } else {
            light_target += 0;
            buf_mod(rbuf, rbuf_len, "PartLight[LL-N]", 0);
            }
         }
        else if (NATURAL_VISION(ch) == THERMOGRAPHIC && CURRENT_VISION(ch) != LOWLIGHT ) {
               light_target++;
               buf_mod(rbuf, rbuf_len, "PartLight[TH-N]", 1);
         }
        else {
           light_target += 2;
           buf_mod(rbuf, rbuf_len, "PartLight", 2);
           }
        break;
```