### PR TITLE
Fomori Shopkeeper Buff

### DIFF
--- a/src/newshop.cpp
+++ b/src/newshop.cpp
@@ -1022,6 +1022,7 @@ void shop_buy(char *arg, size_t arg_len, struct char_data *ch, struct char_data 
         case RACE_ORK:
         case RACE_TROLL:
         case RACE_DWARF:
+        case RACE_FOMORI:
           break;
         default:
           target += 4;


### PR DESCRIPTION
You're paying extra build points to be worse than a bog-standard troll, especially considering the Charisma attribute has a smaller number of uses and is much more niche than the Body, Strength, and impact armor you give up.

Fomori are explicitly noted as 'being more attractive' and 'magically active', so now you won't have to feel baited for picking them to negotiate with merchants.

I decided that lowering the cost to be magically active is already covered by charisma and would be way too strong.