### PR TITLE
Enables flare compensation power

### DIFF
--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -842,8 +842,12 @@ void affect_total(struct char_data * ch)
     if (GET_POWER(ch, ADEPT_THERMO)) {
       set_vision_bit(ch, VISION_THERMOGRAPHIC, VISION_BIT_IS_ADEPT_POWER);
     }
-    if (GET_POWER(ch, ADEPT_IMAGE_MAG))
+    if (GET_POWER(ch, ADEPT_FLARE)) {
+      set_vision_bit(ch, EYE_FLARECOMP, VISION_BIT_IS_ADEPT_POWER);
+    }
+    if (GET_POWER(ch, ADEPT_IMAGE_MAG)) {
       AFF_FLAGS(ch).SetBit(AFF_VISION_MAG_2);
+    }
   }
   if (!AFF_FLAGGED(ch, AFF_DETOX)) {
     if (GET_DRUG_STAGE(ch) == 1)

--- a/src/newmagic.cpp
+++ b/src/newmagic.cpp
@@ -4895,6 +4895,12 @@ bool deactivate_power(struct char_data *ch, int power)
     case ADEPT_THERMO:
       remove_vision_bit(ch, VISION_THERMOGRAPHIC, VISION_BIT_IS_ADEPT_POWER);
       break;
+    case ADEPT_FLARE:
+      remove_vision_bit(ch, EYE_FLARECOMP, VISION_BIT_IS_ADEPT_POWER);
+      break;
+    case ADEPT_IMAGE_MAG:
+      AFF_FLAGS(ch).RemoveBit(AFF_VISION_MAG_2);
+      break;
     case ADEPT_LIVINGFOCUS:
       if (GET_SUSTAINED_NUM(ch))
         adept_release_spell(ch, FALSE);


### PR DESCRIPTION
Flare compensation power is no longer NERP. Comes with bonus bugfix for adept vision magnification.