### PR TITLE
Cleaner graffiti messaging

### DIFF
--- a/src/act.informative.cpp
+++ b/src/act.informative.cpp
@@ -265,8 +265,9 @@ void show_obj_to_char(struct obj_data * object, struct char_data * ch, int mode)
   *buf = '\0';
   if ((mode == SHOW_MODE_ON_GROUND) && object->text.room_desc) {
     strlcpy(buf, CCHAR ? CCHAR : "", sizeof(buf));
-    if (object->graffiti)
+    if (object->graffiti) {
       strlcat(buf, object->graffiti, sizeof(buf));
+    }
     else {
       // Gun magazines get special consideration.
       if (GET_OBJ_TYPE(object) == ITEM_GUN_MAGAZINE && GET_MAGAZINE_BONDED_MAXAMMO(object)) {
@@ -536,9 +537,11 @@ list_obj_to_char(struct obj_data * list, struct char_data * ch, int mode,
   struct obj_data *i;
   int num = 1;
   bool found;
+  bool found_graffiti;
 
   found = FALSE;
-
+  found_graffiti = FALSE;
+  
   for (i = list; i; i = i->next_content)
   {
     if ((i->in_veh && ch->in_veh) && i->vfront != ch->vfront)
@@ -598,6 +601,10 @@ list_obj_to_char(struct obj_data * list, struct char_data * ch, int mode,
         show_obj_to_char(i, ch, mode);
       } else
         if (!corpse && !mode && !IS_OBJ_STAT(i, ITEM_EXTRA_CORPSE)) {
+          if ((GET_OBJ_VNUM(i) == OBJ_GRAFFITI) && (!found_graffiti) ) {
+            found_graffiti = TRUE;
+            send_to_char(ch, "^gSprayed here,^n\r\n");
+          }
           if (num > 1) {
             send_to_char(ch, "(%d) ", num);
           }

--- a/src/act.other.cpp
+++ b/src/act.other.cpp
@@ -4435,9 +4435,8 @@ ACMD(do_spray)
     send_to_char("What do you want to spray?\r\n", ch);
     return;
   }
-
+  int existing_graffiti_count = 0;
   {
-    int existing_graffiti_count = 0;
     struct obj_data *obj;
     FOR_ITEMS_AROUND_CH(ch, obj) {
       if (GET_OBJ_VNUM(obj) == OBJ_GRAFFITI)
@@ -4456,9 +4455,11 @@ ACMD(do_spray)
         return;
       }
       struct obj_data *paint = read_object(OBJ_GRAFFITI, VIRTUAL);
-      snprintf(buf, sizeof(buf), "a piece of graffiti that says \"%s^n\"", argument);
+      if (existing_graffiti_count => 1) {
+        snprintf(buf, sizeof(buf), "Some people have sprayed here:", argument);
+      } snprintf(buf, sizeof(buf), "   %s^n", argument);
       paint->restring = str_dup(buf);
-      snprintf(buf, sizeof(buf), "\"%s^g\" is sprayed here.", argument);
+      snprintf(buf, sizeof(buf), "   %s^n", argument);
       paint->graffiti = str_dup(buf);
       obj_to_room(paint, ch->in_room);
 

--- a/src/act.other.cpp
+++ b/src/act.other.cpp
@@ -4456,13 +4456,13 @@ ACMD(do_spray)
         return;
       }
       struct obj_data *paint = read_object(OBJ_GRAFFITI, VIRTUAL);
-      snprintf(buf, sizeof(buf), "^g   %s^n", argument);
+      snprintf(buf, sizeof(buf), "a piece of graffiti that says \"%s^n\"", argument);
       paint->restring = str_dup(buf);
       snprintf(buf, sizeof(buf), "^g   %s^n", argument);
       paint->graffiti = str_dup(buf);
       obj_to_room(paint, ch->in_room);
 
-      send_to_char("You spray graffiti into the room.\r\n", ch);
+      send_to_char("You tag the area with your spray.\r\n", ch);
       snprintf(buf, sizeof(buf), "%s sprayed graffiti: %s.", GET_CHAR_NAME(ch), GET_OBJ_NAME(paint));
       mudlog(buf, ch, LOG_GRIDLOG, TRUE);
 

--- a/src/act.other.cpp
+++ b/src/act.other.cpp
@@ -4435,8 +4435,9 @@ ACMD(do_spray)
     send_to_char("What do you want to spray?\r\n", ch);
     return;
   }
-  int existing_graffiti_count = 0;
+
   {
+    int existing_graffiti_count = 0;
     struct obj_data *obj;
     FOR_ITEMS_AROUND_CH(ch, obj) {
       if (GET_OBJ_VNUM(obj) == OBJ_GRAFFITI)
@@ -4455,14 +4456,13 @@ ACMD(do_spray)
         return;
       }
       struct obj_data *paint = read_object(OBJ_GRAFFITI, VIRTUAL);
-      if (existing_graffiti_count > 0) {
-        snprintf(buf, sizeof(buf), "Sprayed here,", argument);
-      } snprintf(buf, sizeof(buf), "   %s^n", argument);
+      snprintf(buf, sizeof(buf), "^g   %s^n", argument);
       paint->restring = str_dup(buf);
-      snprintf(buf, sizeof(buf), "   %s^n", argument);
+      snprintf(buf, sizeof(buf), "^g   %s^n", argument);
       paint->graffiti = str_dup(buf);
       obj_to_room(paint, ch->in_room);
 
+      send_to_char("You spray graffiti into the room.\r\n", ch);
       snprintf(buf, sizeof(buf), "%s sprayed graffiti: %s.", GET_CHAR_NAME(ch), GET_OBJ_NAME(paint));
       mudlog(buf, ch, LOG_GRIDLOG, TRUE);
 

--- a/src/act.other.cpp
+++ b/src/act.other.cpp
@@ -4455,7 +4455,7 @@ ACMD(do_spray)
         return;
       }
       struct obj_data *paint = read_object(OBJ_GRAFFITI, VIRTUAL);
-      if (existing_graffiti_count => 1) {
+      if (existing_graffiti_count > 0) {
         snprintf(buf, sizeof(buf), "Sprayed here,", argument);
       } snprintf(buf, sizeof(buf), "   %s^n", argument);
       paint->restring = str_dup(buf);

--- a/src/act.other.cpp
+++ b/src/act.other.cpp
@@ -4456,7 +4456,7 @@ ACMD(do_spray)
       }
       struct obj_data *paint = read_object(OBJ_GRAFFITI, VIRTUAL);
       if (existing_graffiti_count => 1) {
-        snprintf(buf, sizeof(buf), "Some people have sprayed here:", argument);
+        snprintf(buf, sizeof(buf), "Sprayed here,", argument);
       } snprintf(buf, sizeof(buf), "   %s^n", argument);
       paint->restring = str_dup(buf);
       snprintf(buf, sizeof(buf), "   %s^n", argument);


### PR DESCRIPTION
Removes quotation marks and 'is sprayed here' and replaces it with a single line at the top of the graffiti, supposedly.