### PR TITLE
Caribbean League Transport Update

### DIFF
--- a/src/act.other.cpp
+++ b/src/act.other.cpp
@@ -2271,14 +2271,14 @@ ACMD(do_astral)
   GET_PHYSICAL(astral) = GET_PHYSICAL(ch);
   GET_MENTAL(astral) = GET_MENTAL(ch);
 
-  GET_REAL_STR(astral) = GET_REAL_CHA(ch);
-  GET_STR(astral) = GET_REAL_CHA(ch);
-  GET_REAL_QUI(astral) = GET_REAL_INT(ch);
-  GET_QUI(astral) = GET_REAL_INT(ch);
-  GET_REAL_BOD(astral) = GET_REAL_WIL(ch);
-  GET_BOD(astral) = GET_REAL_WIL(ch);
-  GET_REAL_REA(astral) = GET_REAL_INT(ch);
-  GET_REA(astral) = GET_REAL_INT(ch);
+  GET_REAL_STR(astral) = GET_CHA(ch);
+  GET_STR(astral) = GET_CHA(ch);
+  GET_REAL_QUI(astral) = GET_INT(ch);
+  GET_QUI(astral) = GET_INT(ch);
+  GET_REAL_BOD(astral) = GET_WIL(ch);
+  GET_BOD(astral) = GET_WIL(ch);
+  GET_REAL_REA(astral) = GET_INT(ch);
+  GET_REA(astral) = GET_INT(ch);
   astral->real_abils.mag = GET_MAG(ch);
   GET_MAG(astral) = GET_MAG(ch);
   GET_REAL_INT(astral) = GET_INT(ch);

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -117,7 +117,7 @@ extern const char *CHARACTER_DELETED_NAME_FOR_SQL;
 #define MAX_GRIDGUIDE_ROOMS_PER_PULSE                          10
 
 // How often do NPCs press elevator buttons? 1:x ratio, where X is the number you put here.
-#define ELEVATOR_BUTTON_PRESS_CHANCE                           20
+#define ELEVATOR_BUTTON_PRESS_CHANCE                           200
 
 // Wizlock message.
 #define WIZLOCK_MSG "Sorry, the game is currently locked. While you wait for it to open, feel free to join our Discord at https://discord.gg/q5VCMkv!"

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -1683,7 +1683,7 @@ float power_multiplier(int type, int material)
           return 2.0;
         case 10:
         case 11:
-          return 5.0;
+          return 2.0;
         default:
           return 0.7;
       }
@@ -1692,7 +1692,7 @@ float power_multiplier(int type, int material)
       switch (material) {
         case 10:
         case 11:
-          return 3.0;
+          return 2.0;
         default:
           return 0.5;
       }
@@ -1706,7 +1706,7 @@ float power_multiplier(int type, int material)
         case 13:
           return 1.3;
         case 2:
-          return 3.0;
+          return 2.0;
         default:
           return 1.1;
       }
@@ -1714,7 +1714,7 @@ float power_multiplier(int type, int material)
     case DAMOBJ_PROJECTILE:
       switch (material) {
         case 2:
-          return 3.0;
+          return 2.0;
         case 10:
         case 11:
           return 1.1;
@@ -1729,7 +1729,7 @@ float power_multiplier(int type, int material)
         case 7:
           return 1.4;
         case 2:
-          return 4.0;
+          return 2.0;
         case 5:
         case 14:
         case 15:

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -2717,6 +2717,66 @@ void process_grenada_plane(void)
   where++;
 }
 
+struct transport_type sauteurs[2] =
+  {
+    { 8899, NORTH, 8897, SOUTH },
+    { 8899, SOUTH, 8898, NORTH },
+  };
+
+void sauteurs_extend(int bus, int to, int room, int from)
+{
+  create_linked_exit(bus, to, room, from, "sauteurs_extend");
+
+  send_to_room("The Lockheed C-260 Transport plane docks with the platform and begins loading passengers and cargo.\r\n", &world[room]);
+  send_to_room("The Lockheed C-260 Transport plane docks with the platform and begins loading passengers and cargo.\r\n", &world[bus]);
+}
+
+void sauteurs_retract(int bus, int to, int room, int from)
+{
+  delete_linked_exit(bus, to, room, from, "sauteurs_retract");
+
+  send_to_room("The transport plane taxis into position on the runway before throttling up and taking off.\r\n", &world[room]);
+  send_to_room("The transport plane taxis into position on the runway before throttling up and taking off.\r\n", &world[bus]);
+}
+
+void process_sauteurs_plane(void)
+{
+  static int where = 0;
+  int bus, stop, ind;
+
+  if (where >= 168)
+    where = 0;
+
+  ind = (where >= 84 ? 1 : 0);
+
+  bus = real_room(sauteurs[ind].transport);
+  stop = real_room(sauteurs[ind].room);
+
+  switch (where) {
+  case 0:
+  case 84:
+    send_to_room("A Lockheed C-260 Transport plane lands on the auxiliary runway and moves towards the cargo dock.\r\n", &world[stop]);
+    break;
+  case 4:
+  case 92:
+    sauteurs_extend(bus, sauteurs[ind].to, stop, sauteurs[ind].from);
+    break;
+  case 32:
+  case 112:
+    sauteurs_retract(bus, sauteurs[ind].to, stop, sauteurs[ind].from);
+    break;
+  case 72:
+    send_to_room("The gruff voice of the pilot speaks over the intercom, "
+                 "\"We'll be landing in Grenada shortly ladies and gentlemen.\"\r\n", &world[bus]);
+    break;
+  case 152:
+    send_to_room("The gruff voice of the pilot speaks over the intercom, "
+                 "\"We'll be landing in Everett shortly ladies and gentlemen.\"\r\n", &world[bus]);
+    break;
+  }
+  where++;
+}
+
 // ______________________________
 //
 // external interface funcs
@@ -2740,6 +2800,7 @@ void MonorailProcess(void)
   process_grenada_plane();
   process_victoria_ferry();
   process_sugarloaf_ferry();
+  process_sauteurs_plane();
 }
 
 bool room_is_a_taxicab(vnum_t vnum) {

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -2684,32 +2684,32 @@ void process_grenada_plane(void)
   static int where = 0;
   int bus, stop, ind;
 
-  if (where >= 168)
+  if (where >= 84)
     where = 0;
 
-  ind = (where >= 84 ? 1 : 0);
+  ind = (where >= 42 ? 1 : 0);
 
   bus = real_room(grenada[ind].transport);
   stop = real_room(grenada[ind].room);
 
   switch (where) {
   case 0:
-  case 84:
+  case 42:
     send_to_room("A Hawker-Ridley HS-895 Skytruck lands on the main runway and moves towards the departure gate.\r\n", &world[stop]);
     break;
   case 4:
-  case 92:
+  case 46:
     grenada_extend(bus, grenada[ind].to, stop, grenada[ind].from);
     break;
-  case 32:
-  case 112:
+  case 16:
+  case 56:
     grenada_retract(bus, grenada[ind].to, stop, grenada[ind].from);
     break;
-  case 72:
+  case 36:
     send_to_room("The voice of the pilot speaks over the intercom, "
                  "\"We'll be landing in Grenada shortly ladies and gentlemen.\"\r\n", &world[bus]);
     break;
-  case 152:
+  case 76:
     send_to_room("The voice of the pilot speaks over the intercom, "
                  "\"We'll be landing in Everett shortly ladies and gentlemen.\"\r\n", &world[bus]);
     break;


### PR DESCRIPTION
Halved the times involved with the visa required flight, added a second public-use plane to transport both passengers/vehicles that utilizes the old transports wait times. 

Timing cases might need some tweaking.

Also...

Astral Projection attributes now calculate from modified attributes instead of GET_REAL references, as per canon noted below.

SR3 Core, page 173: "Modifications to your Mental Attributes from spells, cyberware and other sources do affect the abilities of your astral form."

Also...

Lowered the extreme DAMOBJ type multipliers vs object materials, capped them at a 2x multiplier, electronics now have a fighting chance against lightning bolts instead of being vaporized by every spark. 