### PR TITLE
creates a visibility flag system for players

### DIFF
--- a/src/act.informative.cpp
+++ b/src/act.informative.cpp
@@ -5457,7 +5457,7 @@ void perform_mortal_where(struct char_data * ch, char *arg)
       struct char_data *i = (d->original ? d->original : d->character);
 
       // Skip them if they aren't in a social-bonus room.
-      if (!i || !i->in_room || !ROOM_FLAGGED(i->in_room, ROOM_ENCOURAGE_CONGREGATION))
+      if (!i || !i->in_room || !AFF_FLAGGED(ch, PRF_VISIBLE))
         continue;
 
       // Skip them if you can't see them for various reasons.

--- a/src/act.informative.cpp
+++ b/src/act.informative.cpp
@@ -5457,7 +5457,7 @@ void perform_mortal_where(struct char_data * ch, char *arg)
       struct char_data *i = (d->original ? d->original : d->character);
 
       // Skip them if they aren't in a social-bonus room.
-      if (!i || !i->in_room || !AFF_FLAGGED(ch, PRF_VISIBLE))
+      if (!i || !i->in_room || !AFF_FLAGGED(ch, PRF_HIDDEN_FROM_WHERE))
         continue;
 
       // Skip them if you can't see them for various reasons.

--- a/src/act.other.cpp
+++ b/src/act.other.cpp
@@ -1408,7 +1408,10 @@ ACMD(do_toggle)
         if (ch->desc->pProtocol)
           ch->desc->pProtocol->do_coerce_ansi_capable_colors_to_ansi = FALSE;
       }
-    } else {
+    } else if (is_abbrev(argument, "RP") || is_abbrev(argument, "RPING") || is_abbrev(argument, "roleplay") || is_abbrev(argument, "visible")) {
+      result = PRF_TOG_CHK(ch, PRF_VISIBLE);
+      mode = 48;
+      } else {
       send_to_char("That is not a valid toggle option.\r\n", ch);
       return;
     }

--- a/src/act.other.cpp
+++ b/src/act.other.cpp
@@ -1408,8 +1408,8 @@ ACMD(do_toggle)
         if (ch->desc->pProtocol)
           ch->desc->pProtocol->do_coerce_ansi_capable_colors_to_ansi = FALSE;
       }
-    } else if (is_abbrev(argument, "RP") || is_abbrev(argument, "RPING") || is_abbrev(argument, "roleplay") || is_abbrev(argument, "visible")) {
-      result = PRF_TOG_CHK(ch, PRF_VISIBLE);
+    } else if (is_abbrev(argument, "nosocialization") || is_abbrev(argument, "socialization") || is_abbrev(argument, "roleplay") || is_abbrev(argument, "visible")) {
+      result = PRF_TOG_CHK(ch, PRF_HIDDEN_FROM_WHERE);
       mode = 48;
       } else {
       send_to_char("That is not a valid toggle option.\r\n", ch);

--- a/src/awake.hpp
+++ b/src/awake.hpp
@@ -439,7 +439,8 @@ enum {
 #define PRF_NO_WEATHER                   64
 #define PRF_DISABLE_XTERM                65
 #define PRF_COERCE_ANSI                  66
-#define PRF_MAX                          67
+#define PRF_VISIBLE                      67
+#define PRF_MAX                          68
 
 /* log watch */
 

--- a/src/awake.hpp
+++ b/src/awake.hpp
@@ -439,7 +439,7 @@ enum {
 #define PRF_NO_WEATHER                   64
 #define PRF_DISABLE_XTERM                65
 #define PRF_COERCE_ANSI                  66
-#define PRF_VISIBLE                      67
+#define PRF_HIDDEN_FROM_WHERE            67
 #define PRF_MAX                          68
 
 /* log watch */

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -3418,7 +3418,7 @@ bool ch_is_eligible_to_receive_socialization_bonus(struct char_data *ch) {
        || IS_AFFECTED(ch, AFF_SPELLIMPINVIS)
        || IS_AFFECTED(ch, AFF_INVISIBLE)
        || IS_AFFECTED(ch, AFF_SPELLINVIS)
-       || !AFF_FLAGGED(ch, PRF_VISIBLE))
+       || !AFF_FLAGGED(ch, PRF_HIDDEN_FROM_WHERE))
     return FALSE;
 
   // You must be present.

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -3417,7 +3417,8 @@ bool ch_is_eligible_to_receive_socialization_bonus(struct char_data *ch) {
   if (IS_AFFECTED(ch, AFF_IMP_INVIS)
        || IS_AFFECTED(ch, AFF_SPELLIMPINVIS)
        || IS_AFFECTED(ch, AFF_INVISIBLE)
-       || IS_AFFECTED(ch, AFF_SPELLINVIS))
+       || IS_AFFECTED(ch, AFF_SPELLINVIS)
+       || !AFF_FLAGGED(ch, PRF_VISIBLE))
     return FALSE;
 
   // You must be present.

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -615,6 +615,7 @@ struct preference_bit_struct preference_bits_v2[] = {
   { "No Weather"           , FALSE, TRUE  },
   { "No XTERM-256 Color"   , FALSE, TRUE  },
   { "Client-Configurable Color", FALSE, TRUE  },
+  { "Visibility on WHERE"  , FALSE, FALSE },
   { "\n"                   , 0    , 0     }
 };
 


### PR DESCRIPTION
Creates the ability for players to simply flag themselves as visible or non-visible on where, regardless of where they are.

If you aren't flagged visible you don't get socialization bonus.

This is separate from flagging yourself anonymous on where.