### PR TITLE
Adds color-code based flagging to ##

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2931,6 +2931,10 @@ char *double_up_color_codes(const char *string) {
   while (*read_ptr) {
     if (*read_ptr == '^')
       *(write_ptr++) = '^';
+    else if (*read_ptr == '#') {
+      *(write_ptr++) = '^';
+      *(write_ptr++) = '^';
+    }
     *(write_ptr++) = *(read_ptr++);
   }
   *(write_ptr++) = '\0';


### PR DESCRIPTION
When you use toggle color codes in helpfiles, resends any instance of # as ^^#, which then displays as ^#.

This is to ensure builders can realize ## is within a block of text that cause sound triggers on screenreaders and not simply have to be aware of them by looking directly into game files, as they are normally invisible.

![image](https://user-images.githubusercontent.com/7409796/182294091-0b3f7c6a-c646-46ca-b828-d2382a4b4abd.png)