### PR TITLE
Quick fixes

### DIFF
--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -2950,7 +2950,7 @@ bool raw_damage(struct char_data *ch, struct char_data *victim, int dam, int att
   // Damage compensators disable trauma dampers unless the character is being damaged past the DC's ability to compensate.
   int current_health = is_physical ? GET_PHYSICAL(real_body) : GET_MENTAL(real_body);
   int expected_total_damage = (dam * 100) + (1000 - current_health);
-  if (comp && expected_total_damage > comp) {
+  if (comp && expected_total_damage <= comp) {
     act("(damper disabled - dcomp)", FALSE, victim, NULL, NULL, TO_ROLLS);
     trauma = FALSE;
   }

--- a/src/newfight.cpp
+++ b/src/newfight.cpp
@@ -417,8 +417,8 @@ bool hit_with_multiweapon_toggle(struct char_data *attacker, struct char_data *v
       snprintf(rbuf, sizeof(rbuf), "Too tall, so will roll just %d dice... ", att->ranged->dice);
     }
 #else
-    att->ranged->dice += bonus_if_not_too_tall;
     snprintf(rbuf, sizeof(rbuf), "^JAttack: Rolling %d + %d dice VS TN %d... ", att->ranged->dice, bonus_if_not_too_tall, att->ranged->tn);
+    att->ranged->dice += bonus_if_not_too_tall;
 #endif
 
     att->ranged->successes = success_test(att->ranged->dice, att->ranged->tn);

--- a/src/newmagic.cpp
+++ b/src/newmagic.cpp
@@ -1740,7 +1740,6 @@ void cast_health_spell(struct char_data *ch, int spell, int sub, int force, char
     case SPELL_INCREF1:
     case SPELL_INCREF2:
     case SPELL_INCREF3:
-    case SPELL_INCREA:
       {
         int int_with_just_bioware = GET_REAL_INT(vict);
         int qui_with_just_bioware = GET_REAL_QUI(vict);
@@ -1807,6 +1806,9 @@ void cast_health_spell(struct char_data *ch, int spell, int sub, int force, char
         send_to_char(FAILED_CAST, ch);
       spell_drain(ch, spell, force, 0, direct_sustain);
       break;
+    case SPELL_INCREA:
+      sub = REA;
+      // fall through
     case SPELL_DECATTR:
     case SPELL_DECCYATTR:
     case SPELL_INCATTR:

--- a/src/newmagic.cpp
+++ b/src/newmagic.cpp
@@ -1740,6 +1740,7 @@ void cast_health_spell(struct char_data *ch, int spell, int sub, int force, char
     case SPELL_INCREF1:
     case SPELL_INCREF2:
     case SPELL_INCREF3:
+    case SPELL_INCREA:
       {
         int int_with_just_bioware = GET_REAL_INT(vict);
         int qui_with_just_bioware = GET_REAL_QUI(vict);
@@ -1806,9 +1807,6 @@ void cast_health_spell(struct char_data *ch, int spell, int sub, int force, char
         send_to_char(FAILED_CAST, ch);
       spell_drain(ch, spell, force, 0, direct_sustain);
       break;
-    case SPELL_INCREA:
-      sub = REA;
-      // fall through
     case SPELL_DECATTR:
     case SPELL_DECCYATTR:
     case SPELL_INCATTR:

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -248,7 +248,7 @@ int system_test(rnum_t host, struct char_data *ch, int type, int software, int m
     }
   }
 
-  detect += DECKER->masking;
+  detect += DECKER->masking + 1; // +1 because we round up
   detect = detect / 2;
   detect -= DECKER->res_det;
 


### PR DESCRIPTION
A few quick fixes:
- Previously, do_matrix_score was changed to round-up the calculation of a decker's detection factor to match the core rules, but this wasn't propagated to the actual tests. This adds the proper rounding to the system_test function.

- Fixed damage compensators conditional.

- Increase Reaction spell should have the same bioware compatibilities as the Increase Reflexes +X spells.

Khai/Azazel