### PR TITLE
Autodismissal of spirits at sunset

### DIFF
--- a/src/newmagic.cpp
+++ b/src/newmagic.cpp
@@ -4054,7 +4054,9 @@ ACMD(do_conjure)
 
         AFF_FLAGS(ch).SetBit(AFF_GROUP);
         AFF_FLAGS(mob).SetBit(AFF_GROUP);
-        GET_SPARE2(mob) = NUMBER_OF_IG_DAYS_FOR_SPIRIT_TO_LAST;
+        
+        // this counter is doubled because it gets decremented at both sunrise and sunset 
+        GET_SPARE2(mob) = NUMBER_OF_IG_DAYS_FOR_SPIRIT_TO_LAST * 2;
       }
     }
   }

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -106,8 +106,12 @@ void another_hour(void)
     for (ch = character_list; ch; ch = next) {
       next = ch->next;
       if (IS_SPIRIT(ch)) {
-        act("$n abruptly fades from existance.", TRUE, ch, 0, 0, TO_ROOM);
-        end_spirit_existance(ch, FALSE);
+        if (--GET_SPARE2(ch) <= 0) {
+          act("$n abruptly fades from existance.", TRUE, ch, 0, 0, TO_ROOM);
+          end_spirit_existance(ch, FALSE);
+        } else {
+          act("$n weakens as the metaphysical power of sunset ripples through it.\r\n", TRUE, ch, 0, 0, TO_ROOM);
+        }
       }
     }
     break;


### PR DESCRIPTION
Previously, autodismissal of spirits at sunrise was changed to decrement a counter, with autodismissal when that counter runs out. But sunset still had the code to immediately autodismiss, without regard to the counter. This fixes sunset to do the same thing as sunrise.

-Khai