### PR TITLE
Fix to foot anchor vs knockdown

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -4470,7 +4470,8 @@ bool perform_knockdown_test(struct char_data *ch, int initial_tn, int successes_
         has_aug = TRUE;
         break;
       case CYB_FOOTANCHOR:
-        tn_modifiers += GET_CYBERWARE_RATING(cyb);
+        if (!GET_CYBERWARE_IS_DISABLED(cyb)):
+          tn_modifiers += -1;
         buf_mod(rbuf, sizeof(rbuf), "foot anchors", GET_CYBERWARE_RATING(cyb));
         break;
     }


### PR DESCRIPTION
In db.cpp line 6460, cyb_footanchor is set to 0 rating, so the existing code ends up having no effect on knockdown tests. This fixes foot anchors to match MM pg 29: when anchored, each foot anchor reduces the TN to resist knockdown by 1.

- Khai