### PR TITLE
Show room on gridguide arrival

### DIFF
--- a/src/act.drive.cpp
+++ b/src/act.drive.cpp
@@ -1996,6 +1996,10 @@ void process_autonav(void)
         return;
       }
       if (veh->in_room == veh->dest) {
+        // QoL - show destination room to vehicle occupants on arrival
+        for (struct char_data *ch = veh->people; ch; ch = ch->next_in_veh)
+          if (!IS_NPC(npc))
+            look_at_room(ch, 0, 0)
         send_to_veh("Having reached its destination, the autonav shuts off.\r\n", veh, 0, TRUE);
         veh->cspeed = SPEED_OFF;
         veh->dest = NULL;

--- a/src/act.drive.cpp
+++ b/src/act.drive.cpp
@@ -2037,6 +2037,7 @@ ACMD(do_switch)
   ch->vfront = !ch->vfront;
   snprintf(buf, sizeof(buf), "$n climbs into the %s.", ch->vfront ? "front" : "back");
   act(buf, TRUE, ch, 0, 0, TO_ROOM);
+  look_at_room(ch, 0, 0)
   send_to_char(ch, "You climb into the %s.\r\n", ch->vfront ? "front" : "back");
 }
 

--- a/src/act.drive.cpp
+++ b/src/act.drive.cpp
@@ -1997,9 +1997,11 @@ void process_autonav(void)
       }
       if (veh->in_room == veh->dest) {
         // QoL - show destination room to vehicle occupants on arrival
-        for (struct char_data *ch = veh->people; ch; ch = ch->next_in_veh)
-          if (!IS_NPC(npc))
+        for (struct char_data *ch = veh->people; ch; ch = ch->next_in_veh) {
+          if (!IS_NPC(ch)) {
             look_at_room(ch, 0, 0)
+          }
+        }
         send_to_veh("Having reached its destination, the autonav shuts off.\r\n", veh, 0, TRUE);
         veh->cspeed = SPEED_OFF;
         veh->dest = NULL;

--- a/src/act.drive.cpp
+++ b/src/act.drive.cpp
@@ -1998,7 +1998,7 @@ void process_autonav(void)
       if (veh->in_room == veh->dest) {
         // QoL - show destination room to vehicle occupants on arrival
         for (struct char_data *ch = veh->people; ch; ch = ch->next_in_veh) {
-          if (!IS_NPC(ch)) {
+          if (!IS_NPC(ch) && !PRF_FLAGGED(ch, PRF_SCREENREADER)) {
             look_at_room(ch, 0, 0)
           }
         }
@@ -2037,8 +2037,10 @@ ACMD(do_switch)
   ch->vfront = !ch->vfront;
   snprintf(buf, sizeof(buf), "$n climbs into the %s.", ch->vfront ? "front" : "back");
   act(buf, TRUE, ch, 0, 0, TO_ROOM);
-  look_at_room(ch, 0, 0)
-  send_to_char(ch, "You climb into the %s.\r\n", ch->vfront ? "front" : "back");
+  if (!PRF_FLAGGED(ch, PRF_SCREENREADER)) {
+    look_at_room(ch, 0, 0)
+  }
+  send_to_char(ch, "You've climbed into the %s.\r\n", ch->vfront ? "front" : "back");
 }
 
 ACMD(do_pop)


### PR DESCRIPTION
Quality of life changes:
- When gridguide arrives at its destination, automatically show the room to vehicle occupants.
- When the character switches between the front and back of a vehicle, automatically show the room to the character.

-Khai