### PR TITLE
Allow login->delete of hardcore characters

### DIFF
--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -2627,12 +2627,6 @@ void nanny(struct descriptor_data * d, char *arg)
         d->character = playerDB.LoadChar(tmp_name, TRUE);
         d->character->desc = d;
 
-        if (PRF_FLAGGED(d->character, PRF_HARDCORE) && PLR_FLAGGED(d->character, PLR_JUST_DIED)) {
-          SEND_TO_Q("The Reaper has claimed this one...\r\n", d);
-          STATE(d) = CON_CLOSE;
-          return;
-        }
-
         snprintf(buf, sizeof(buf), "Welcome back. Enter your password. Not %s? Enter 'abort' to try a different name. ", CAP(tmp_name));
         SEND_TO_Q(buf, d);
         echo_off(d);


### PR DESCRIPTION
There already exists a check->disconnect for dead hardcore characters when selecting the "Enter the game" option from the login menu. On the death of a hardcore character, the player does reach this menu and so has the option to delete the character immediately after death.

Removing the additional check at the login prompt allows the player to decide to delete the character at a later time instead of only being able to do so immediately after death.

Khai