### PR TITLE
has_kit refactoring and related code

### DIFF
--- a/src/act.drive.cpp
+++ b/src/act.drive.cpp
@@ -1151,7 +1151,8 @@ ACMD(do_repair)
 {
   struct obj_data *obj, *shop = NULL;
   struct veh_data *veh;
-  int target = 4, skill = 0, success, mod = 0;
+  int target = 4, skill = 0, success = 0;
+  bool kit = FALSE;
 
   skip_spaces(&argument);
   if (IS_ASTRAL(ch)) {
@@ -1182,12 +1183,7 @@ ACMD(do_repair)
   target += modify_target(ch);
 
   if (!access_level(ch, LVL_ADMIN)) {
-    for (obj = ch->carrying; obj && !mod; obj = obj->next_content)
-      if (GET_OBJ_TYPE(obj) == ITEM_WORKSHOP && GET_WORKSHOP_TYPE(obj) == TYPE_VEHICLE && GET_WORKSHOP_GRADE(obj) == TYPE_KIT)
-        mod = TYPE_KIT;
-    for (int i = 0; i < NUM_WEARS && !mod; i++)
-      if ((obj = GET_EQ(ch, i)) && GET_OBJ_TYPE(obj) == ITEM_WORKSHOP && GET_WORKSHOP_TYPE(obj) == TYPE_VEHICLE && GET_WORKSHOP_GRADE(obj) == TYPE_KIT)
-        mod = TYPE_KIT;
+    kit = has_kit(ch, TYPE_VEHICLE);
     shop = find_workshop(ch, TYPE_VEHICLE);
     if (!shop) {
       if (veh->damage >= VEH_DAMAGE_NEEDS_WORKSHOP) {
@@ -1197,9 +1193,11 @@ ACMD(do_repair)
       target += 2;
     }
 
-    if (shop && GET_WORKSHOP_GRADE(shop) == TYPE_FACILITY) {
-      target -= 2;
-    } else if (mod == TYPE_KIT) {
+    if (shop) {
+      if (GET_WORKSHOP_GRADE(shop) == TYPE_FACILITY) {
+        target -= 2;
+      } // if TYPE_WORKSHOP, no target modifier
+    } else if (kit) {
       target += 2;
     } else {
       target += 4;

--- a/src/act.other.cpp
+++ b/src/act.other.cpp
@@ -2070,7 +2070,8 @@ ACMD(do_treat)
 {
   struct char_data *vict;
   struct obj_data *obj;
-  int target = 0, i, found = 0, shop = 0;
+  int target = 0, skill = 0;
+  bool kit = FALSE, shop = FALSE;
 
   if (subcmd && (!IS_NPC(ch) || !(GET_MOB_SPEC(ch) || GET_MOB_SPEC2(ch))))
     return;
@@ -2135,17 +2136,14 @@ ACMD(do_treat)
   }
   if (vict->in_room && ROOM_FLAGGED(vict->in_room, ROOM_STERILE))
     target -= 2;
-  i = get_skill(ch, SKILL_BIOTECH, target);
+  skill = get_skill(ch, SKILL_BIOTECH, target);
 
   if (find_workshop(ch, TYPE_MEDICAL))
-    shop = 1;
-  for (obj = ch->carrying; obj && !found; obj = obj->next_content)
-    if (GET_OBJ_TYPE(obj) == ITEM_WORKSHOP && GET_OBJ_VAL(obj, 1) == 0 && GET_OBJ_VAL(obj, 0) == 6)
-      found = 1;
-  for (i = 0; !found && i < (NUM_WEARS - 1); i++)
-    if ((obj = GET_EQ(ch, i)) && GET_OBJ_TYPE(obj) == ITEM_WORKSHOP && GET_OBJ_VAL(obj, 1) == 0 && GET_OBJ_VAL(obj, 0) == 6)
-      found = 1;
-  if (!found && !subcmd && !shop)
+    shop = TRUE;
+
+  kit = has_kit(ch, TYPE_MEDICAL);
+
+  if (!kit && !subcmd && !shop)
     target += 4;
 
   if (!shop)
@@ -2165,7 +2163,7 @@ ACMD(do_treat)
   } else {
     act("$n begins to treat $N.", TRUE, ch, 0, vict, TO_NOTVICT);
   }
-  if (success_test(i, target) > 0) {
+  if (success_test(skill, target) > 0) {
     act("$N appears better.", FALSE, ch, 0, vict, TO_CHAR);
     if (ch == vict) {
       send_to_char(ch, "The pain seems significantly better.\r\n");

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1950,23 +1950,20 @@ void magic_loss(struct char_data *ch, int magic, bool msg)
 // Note: some kits may still have workshop grade of 0 instead of TYPE_KIT.
 #define IS_KIT(obj, type) ( GET_OBJ_TYPE((obj)) == ITEM_WORKSHOP && GET_WORKSHOP_TYPE((obj)) == type && (GET_WORKSHOP_GRADE((obj)) == TYPE_KIT || GET_WORKSHOP_GRADE((obj)) == 0) )
 bool has_kit(struct char_data * ch, int type)
-{
-  struct obj_data *obj;
-  bool found = FALSE;
-  
-  for (obj = ch->carrying; obj && !found; obj = obj->next_content) {
+{  
+  for (struct obj_data *obj = ch->carrying; obj; obj = obj->next_content) {
     if (IS_KIT(obj, type)) {
-      found = TRUE;
+      return TRUE;
     }
   }
 
-  for (int i = 0; !found && i < (NUM_WEARS - 1); i++) {
+  for (int i = 0; i < (NUM_WEARS - 1); i++) {
     if (GET_EQ(ch, i) && IS_KIT(GET_EQ(ch, i), type)) {
-      found = TRUE;
+      return TRUE;
     }
   }
-
-  return found;
+  
+  return FALSE;
 }
 
 // Return true if the character has a key of the given number, false otherwise.

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1960,7 +1960,7 @@ bool has_kit(struct char_data * ch, int type)
     }
   }
 
-  for (i = 0; !found && i < (NUM_WEARS - 1); i++) {
+  for (int i = 0; !found && i < (NUM_WEARS - 1); i++) {
     if (GET_EQ(ch, i) && IS_KIT(GET_EQ(ch, i), type)) {
       found = TRUE;
     }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1947,17 +1947,26 @@ void magic_loss(struct char_data *ch, int magic, bool msg)
 }
 
 // Return true if the character has a kit of the given type, false otherwise.
-#define IS_KIT(obj, type) (GET_OBJ_TYPE((obj)) == ITEM_WORKSHOP && GET_WORKSHOP_TYPE((obj)) == type && GET_WORKSHOP_GRADE((obj)) == TYPE_KIT)
+// Note: some kits may still have workshop grade of 0 instead of TYPE_KIT.
+#define IS_KIT(obj, type) ( GET_OBJ_TYPE((obj)) == ITEM_WORKSHOP && GET_WORKSHOP_TYPE((obj)) == type && (GET_WORKSHOP_GRADE((obj)) == TYPE_KIT || GET_WORKSHOP_GRADE((obj)) == 0) )
 bool has_kit(struct char_data * ch, int type)
 {
-  for (struct obj_data *o = ch->carrying; o; o = o->next_content)
-    if (IS_KIT(o, type))
-      return TRUE;
+  struct obj_data *obj;
+  bool found = FALSE;
+  
+  for (obj = ch->carrying; obj && !found; obj = obj->next_content) {
+    if (IS_KIT(obj, type)) {
+      found = TRUE;
+    }
+  }
 
-  if (GET_EQ(ch, WEAR_HOLD) && IS_KIT(GET_EQ(ch, WEAR_HOLD), type))
-    return TRUE;
+  for (i = 0; !found && i < (NUM_WEARS - 1); i++) {
+    if (GET_EQ(ch, i) && IS_KIT(GET_EQ(ch, i), type)) {
+      found = TRUE;
+    }
+  }
 
-  return FALSE;
+  return found;
 }
 
 // Return true if the character has a key of the given number, false otherwise.


### PR DESCRIPTION
Modified has_kit to search all worn slots instead of just hold. When updating related code, also found and fixed two bugs:

- In do_treat, the variable _i_ was first set as biotech skill, and then used as a counter to search equipment for a kit, before finally being used for the success test.
- In do_repair, using a vehicle workshop that is not a facility would result in a +4 TN penalty (as if the ch had no tools at all).