### PR TITLE
Fixes for adept flare comp & killing hands

### DIFF
--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -843,9 +843,6 @@ void affect_total(struct char_data * ch)
     if (GET_POWER(ch, ADEPT_THERMO)) {
       set_vision_bit(ch, VISION_THERMOGRAPHIC, VISION_BIT_IS_ADEPT_POWER);
     }
-    if (GET_POWER(ch, ADEPT_FLARE)) {
-      set_vision_bit(ch, EYE_FLARECOMP, VISION_BIT_IS_ADEPT_POWER);
-    }
     if (GET_POWER(ch, ADEPT_IMAGE_MAG)) {
       AFF_FLAGS(ch).SetBit(AFF_VISION_MAG_2);
     }

--- a/src/newfight.cpp
+++ b/src/newfight.cpp
@@ -891,7 +891,7 @@ bool hit_with_multiweapon_toggle(struct char_data *attacker, struct char_data *v
     // This also requires that the attacker is not using killing hands while unarmed, and is not using a weapon focus that they are bonded to.
     if ((IS_SPIRIT(def->ch) || IS_ANY_ELEMENTAL(def->ch))
         && !(att->weapon && GET_POWER(att->ch, ADEPT_KILLING_HANDS))
-        && !(GET_WEAPON_FOCUS_RATING(att->weapon) >= 0 && WEAPON_FOCUS_USABLE_BY(att->weapon, att->ch)))
+        && !(GET_WEAPON_FOCUS_RATING(att->weapon) > 0 && WEAPON_FOCUS_USABLE_BY(att->weapon, att->ch)))
     {
       // We require that the attack's power is greater than double the spirit's force, otherwise it takes no damage.
       // If the attack's power is greater, subtract double the level from it.

--- a/src/newfight.cpp
+++ b/src/newfight.cpp
@@ -891,7 +891,7 @@ bool hit_with_multiweapon_toggle(struct char_data *attacker, struct char_data *v
     // Namely: We require that the attack's power is greater than double the spirit's force, otherwise it takes no damage.
     // If the attack's power is greater, subtract double the level from it.
     if ((IS_SPIRIT(def->ch) || IS_ANY_ELEMENTAL(def->ch))
-        && (!att->weapon || GET_WEAPON_FOCUS_RATING(att->weapon) == 0 || !WEAPON_FOCUS_USABLE_BY(att->weapon, att->ch)))
+        && ((!att->weapon && !GET_POWER(att->ch, ADEPT_KILLING_HANDS)) || GET_WEAPON_FOCUS_RATING(att->weapon) == 0 || !WEAPON_FOCUS_USABLE_BY(att->weapon, att->ch)))
     {
       int minimum_power_to_damage_opponent = (GET_LEVEL(def->ch) * 2) + 1;
       if (att->melee->power_before_armor < minimum_power_to_damage_opponent) {

--- a/src/newfight.cpp
+++ b/src/newfight.cpp
@@ -890,8 +890,7 @@ bool hit_with_multiweapon_toggle(struct char_data *attacker, struct char_data *v
     // Handle spirits and elementals being divas, AKA having Immunity to Normal Weapons (SR3 p188, 264).
     // This also requires that the attacker is not using killing hands while unarmed, and is not using a weapon focus that they are bonded to.
     if ((IS_SPIRIT(def->ch) || IS_ANY_ELEMENTAL(def->ch))
-        && !(att->weapon && GET_POWER(att->ch, ADEPT_KILLING_HANDS))
-        && !(GET_WEAPON_FOCUS_RATING(att->weapon) > 0 && WEAPON_FOCUS_USABLE_BY(att->weapon, att->ch)))
+        && (att->weapon ? (GET_WEAPON_FOCUS_RATING(att->weapon) == 0 || !WEAPON_FOCUS_USABLE_BY(att->weapon, att->ch)) : !GET_POWER(att->ch, ADEPT_KILLING_HANDS))
     {
       // We require that the attack's power is greater than double the spirit's force, otherwise it takes no damage.
       // If the attack's power is greater, subtract double the level from it.

--- a/src/newfight.cpp
+++ b/src/newfight.cpp
@@ -888,11 +888,13 @@ bool hit_with_multiweapon_toggle(struct char_data *attacker, struct char_data *v
              GET_SHORT_WOUND_NAME(att->melee->damage_level));
 
     // Handle spirits and elementals being divas, AKA having Immunity to Normal Weapons (SR3 p188, 264).
-    // Namely: We require that the attack's power is greater than double the spirit's force, otherwise it takes no damage.
-    // If the attack's power is greater, subtract double the level from it.
+    // This also requires that the attacker is not using killing hands while unarmed, and is not using a weapon focus that they are bonded to.
     if ((IS_SPIRIT(def->ch) || IS_ANY_ELEMENTAL(def->ch))
-        && ((!att->weapon && !GET_POWER(att->ch, ADEPT_KILLING_HANDS)) || GET_WEAPON_FOCUS_RATING(att->weapon) == 0 || !WEAPON_FOCUS_USABLE_BY(att->weapon, att->ch)))
+        && !(att->weapon && GET_POWER(att->ch, ADEPT_KILLING_HANDS))
+        && !(GET_WEAPON_FOCUS_RATING(att->weapon) >= 0 && WEAPON_FOCUS_USABLE_BY(att->weapon, att->ch)))
     {
+      // We require that the attack's power is greater than double the spirit's force, otherwise it takes no damage.
+      // If the attack's power is greater, subtract double the level from it.
       int minimum_power_to_damage_opponent = (GET_LEVEL(def->ch) * 2) + 1;
       if (att->melee->power_before_armor < minimum_power_to_damage_opponent) {
         bool target_died = 0;

--- a/src/vision_overhaul.cpp
+++ b/src/vision_overhaul.cpp
@@ -504,6 +504,11 @@ void apply_vision_bits_from_implant(struct char_data *ch, struct obj_data *impla
 }
 
 bool has_flare_compensation(struct char_data *ch) {
+  // Adept flare comp.
+  if (GET_POWER(ch, ADEPT_FLARE)) {
+    return TRUE;
+  }
+    
   // Find cybernetic flare comp.
   for (struct obj_data *cyber = ch->cyberware; cyber; cyber = cyber->next_content) {
     if (GET_CYBERWARE_TYPE(cyber) == CYB_EYES && IS_SET(GET_CYBERWARE_FLAGS(cyber), EYE_FLARECOMP)) {


### PR DESCRIPTION
### Flare Comp
set_vision_bit modifies points->vision, which is declared as Bitfield vision[NUM_VISION_TYPES].

EYE_FLARECOMP is defined as (1 << 3), which has a value greater than NUM_VISION_TYPES, so set_vision_bit(ch, EYE_FLARECOMP, VISION_BIT_IS_ADEPT_POWER) might be doing something unexpected.

### Killing Hands
SR3 pg 170, killing hands ignore immunity to normal weapons.

Khai