### PR TITLE
Fix detox spell drug detection

### DIFF
--- a/src/act.offensive.cpp
+++ b/src/act.offensive.cpp
@@ -709,8 +709,8 @@ bool _sort_pairs_by_weight(std::pair<int, int> a, std::pair<int, int> b) {
 
 ACMD(do_flee)
 {
-  if (AFF_FLAGGED(ch, AFF_PRONE)) {
-    send_to_char("It's a struggle to flee while prone!\r\n", ch);
+  if (AFF_FLAGGED(ch, AFF_PRONE) || GET_POS(ch) <= POS_SITTING) {
+    send_to_char("It's a struggle to flee while not on your feet!\r\n", ch);
     return;
   }
 

--- a/src/limits.cpp
+++ b/src/limits.cpp
@@ -104,7 +104,7 @@ void mental_gain(struct char_data * ch)
     gain *= 1.5;
 
   if (GET_TRADITION(ch) == TRAD_ADEPT && GET_POWER(ch, ADEPT_HEALING) > 0)
-    gain *= ((float) GET_POWER(ch, ADEPT_HEALING) / 2 + 1);
+    gain *= (((float) GET_POWER(ch, ADEPT_HEALING) / 2) + 1);
   if (GET_BIOOVER(ch) > 0)
     gain /= GET_BIOOVER(ch);
 
@@ -184,7 +184,7 @@ void physical_gain(struct char_data * ch)
     gain *= get_drug_heal_multiplier(ch);
   }
   if (GET_TRADITION(ch) == TRAD_ADEPT && GET_POWER(ch, ADEPT_HEALING) > 0)
-    gain *= ((float) GET_POWER(ch, ADEPT_HEALING) / 2 + 1);
+    gain *= (((float) GET_POWER(ch, ADEPT_HEALING) / 2) + 1);
   if (GET_BIOOVER(ch) > 0)
     gain /= GET_BIOOVER(ch);
   GET_PHYSICAL(ch) = MIN(GET_MAX_PHYSICAL(ch), GET_PHYSICAL(ch) + gain);

--- a/src/limits.cpp
+++ b/src/limits.cpp
@@ -104,7 +104,7 @@ void mental_gain(struct char_data * ch)
     gain *= 1.5;
 
   if (GET_TRADITION(ch) == TRAD_ADEPT && GET_POWER(ch, ADEPT_HEALING) > 0)
-    gain *= ((float) 1 + GET_POWER(ch, ADEPT_HEALING) / 2);
+    gain *= ((float) GET_POWER(ch, ADEPT_HEALING) / 2 + 1);
   if (GET_BIOOVER(ch) > 0)
     gain /= GET_BIOOVER(ch);
 
@@ -184,7 +184,7 @@ void physical_gain(struct char_data * ch)
     gain *= get_drug_heal_multiplier(ch);
   }
   if (GET_TRADITION(ch) == TRAD_ADEPT && GET_POWER(ch, ADEPT_HEALING) > 0)
-    gain *= ((float) 1 + GET_POWER(ch, ADEPT_HEALING) / 2);
+    gain *= ((float) GET_POWER(ch, ADEPT_HEALING) / 2 + 1);
   if (GET_BIOOVER(ch) > 0)
     gain /= GET_BIOOVER(ch);
   GET_PHYSICAL(ch) = MIN(GET_MAX_PHYSICAL(ch), GET_PHYSICAL(ch) + gain);

--- a/src/newmagic.cpp
+++ b/src/newmagic.cpp
@@ -1663,13 +1663,15 @@ void cast_health_spell(struct char_data *ch, int spell, int sub, int force, char
       }
 
       base_target = 0;
+      bool drugged = FALSE;
       for (int i = MIN_DRUG; i < NUM_DRUGS; i++) {
         if (GET_DRUG_STAGE(vict, i) != DRUG_STAGE_UNAFFECTED) {
           base_target = MAX(base_target, drug_types[i].power);
+          drugged = TRUE;
         }
       }
 
-      if (!base_target) {
+      if (!drugged) {
         send_to_char("They aren't affected by any drugs.\r\n", ch);
         return;
       }


### PR DESCRIPTION
Previously, detox identified the presence of drugs through the drugs' power attribute. Using a bool instead lets detox apply to drugs with 0 power.
