### PR TITLE
Calc Highest Bal/Imp separately

### DIFF
--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -671,8 +671,10 @@ void affect_total(struct char_data * ch)
             }
 
             // Keep track of which worn item provides the highest total value.
-            if (bal + imp > highestbal + highestimp) {
+            if (bal > highestbal) {
               highestbal = bal;
+            }
+            if (imp > highestimp) {
               highestimp = imp;
             }
 


### PR DESCRIPTION
Currently a 4/2 and a 2/4 will come to a different total of armor (either 5/4 or 4/5)  depending on how they're being layered (either at the time of equipping, or based on the order in armor slots). This change should 'normalize' the formula, giving consistent results (5/5). If the same formula is used elsewhere and needs changed, I couldn't find it.

Thanks for submitting code! It's highly recommended that you discuss changes / new features with Lucien before merging, so if you haven't done that already, please reach out to him in Discord.

Please include in this PR a description of what your code changes (e.g. "Colors all magazines bright purple for easier locating in inventory lists") or what it's intended to do. The more descriptive you can be, the easier it will be for us to review your code!
