### PR TITLE
Various decking fixes

### DIFF
--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -411,7 +411,11 @@ int system_test(rnum_t host, struct char_data *ch, int type, int software, int m
     DECKER->tally++;
   if (DECKER->tally >= 80)
   {
+    // House rule: we don't shut down the host per Matrix pg112,
+    // Instead we just kill the problematic connection.
+    send_to_icon(PERSONA, "The sirens and lights seem to turn towards you!\r\n");
     dumpshock(PERSONA);
+    send_to_char(ch, "^y(OOC note: Your security tally hit 80+, so the host disconnected you.)^n\r\n");
     return -1;
   }
   check_trigger(host, ch);

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -2787,10 +2787,16 @@ void matrix_update()
       if (host.type == HOST_DATASTORE && host.undiscovered_paydata <= 0 && !host.payreset) {
         reset_host_paydata(rnum);
       } else {
-        // See if there are any deckers in here.
-        for (struct matrix_icon *icon = host.icons; icon; icon = icon->next_in_host) {
-          if (!ICON_IS_IC(icon)) {
-            decker = TRUE;
+        // See if there are any deckers here or in surrounding hosts.
+        // We need to check surrounding hosts to prevent SANs from re-encrypting.
+        for (struct exit_data *exit = host.exit; exit; exit = exit->next) {
+          for (struct matrix_icon *icon = real_host(exit->host).icons; icon; icon = icon->next_in_host) {
+            if (!ICON_IS_IC(icon)) {
+              decker = TRUE;
+              break;
+            }
+          }
+          if (decker) {
             break;
           }
         }

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -3561,7 +3561,7 @@ ACMD(do_matrix_max)
     send_to_char("You can't use hacking pool while running a cold ASIST.\r\n", ch);
   else {
     int i = atoi(argument);
-    int cap = MIN(GET_HACKING(ch), GET_SKILL(ch, SKILL_SORCERY));
+    int cap = MIN(GET_HACKING(ch), GET_SKILL(ch, SKILL_COMPUTER));
     if (i > cap || i < 0)
       send_to_char(ch, "You must set your max hacking pool to between 0 and %d.\r\n", cap);
     else {

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -2796,6 +2796,7 @@ void matrix_update()
             decker = TRUE;
             break;
           }        
+        }
         // We also need to check surrounding hosts to prevent SANs from re-encrypting.
         for (struct exit_data *exit = host.exit; exit && !decker; exit = exit->next) {
           for (struct matrix_icon *icon = real_host(exit->host).icons; icon; icon = icon->next_in_host) {

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -1473,10 +1473,9 @@ ACMD(do_matrix_look)
     if ((GET_OBJ_TYPE(obj) == ITEM_DECK_ACCESSORY || GET_OBJ_TYPE(obj) == ITEM_PROGRAM) && GET_DECK_ACCESSORY_FILE_FOUND_BY(obj) == PERSONA->idnum)
     {
       if (GET_DECK_ACCESSORY_FILE_WORKER_IDNUM(obj)) {
+        int percent_complete = (int) (100 * ((float) GET_DECK_ACCESSORY_FILE_REMAINING(obj) - GET_DECK_ACCESSORY_FILE_SIZE(obj)) / MAX(1, GET_DECK_ACCESSORY_FILE_SIZE(obj)));
         send_to_icon(PERSONA, "^yA file named %s floats here (Downloading - %d%%).^n\r\n",
-                     GET_OBJ_NAME(obj),
-                     (int) (GET_DECK_ACCESSORY_FILE_REMAINING(obj) - GET_DECK_ACCESSORY_FILE_SIZE(obj)) / MAX(1, GET_DECK_ACCESSORY_FILE_SIZE(obj))
-                   );
+                     GET_OBJ_NAME(obj), percent_complete);
       } else {
         send_to_icon(PERSONA, "^yA file named %s floats here.^n\r\n", GET_OBJ_NAME(obj));
       }

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -3552,8 +3552,9 @@ ACMD(do_matrix_max)
     send_to_char("You can't use hacking pool while running a cold ASIST.\r\n", ch);
   else {
     int i = atoi(argument);
-    if (i > GET_HACKING(ch) || i < 0)
-      send_to_char(ch, "You must set your max hacking pool to between 0 and %d.\r\n", GET_HACKING(ch));
+    int cap = MIN(GET_HACKING(ch), GET_SKILL(ch, SKILL_SORCERY));
+    if (i > cap || i < 0)
+      send_to_char(ch, "You must set your max hacking pool to between 0 and %d.\r\n", cap);
     else {
       GET_MAX_HACKING(ch) = i;
       send_to_char(ch, "You will now use a maximum of %d hacking pool per action.\r\n", GET_MAX_HACKING(ch));

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -2790,20 +2790,21 @@ void matrix_update()
       if (host.type == HOST_DATASTORE && host.undiscovered_paydata <= 0 && !host.payreset) {
         reset_host_paydata(rnum);
       } else {
-        // See if there are any deckers here or in surrounding hosts.
-        // We need to check surrounding hosts to prevent SANs from re-encrypting.
-        for (struct exit_data *exit = host.exit; exit; exit = exit->next) {
+        // See if there are any deckers in here.
+        for (struct matrix_icon *icon = host.icons; icon; icon = icon->next_in_host) {
+          if (!ICON_IS_IC(icon)) {
+            decker = TRUE;
+            break;
+          }        
+        // We also need to check surrounding hosts to prevent SANs from re-encrypting.
+        for (struct exit_data *exit = host.exit; exit && !decker; exit = exit->next) {
           for (struct matrix_icon *icon = real_host(exit->host).icons; icon; icon = icon->next_in_host) {
             if (!ICON_IS_IC(icon)) {
               decker = TRUE;
               break;
             }
           }
-          if (decker) {
-            break;
-          }
         }
-
         // We only reset subsystem encryption ratings if there are no deckers.
         if (!decker) {
           for (int x = 0; x < 5; x++) {

--- a/src/spec_procs.cpp
+++ b/src/spec_procs.cpp
@@ -4375,15 +4375,17 @@ SPECIAL(desktop)
   if (obj->contains) {
     send_to_char(ch, " contains:\r\n");
     for (struct obj_data *soft = obj->contains; soft; soft = soft->next_content) {
-      if (GET_OBJ_TYPE(soft) == ITEM_DESIGN)
-        send_to_char(ch, "%-40s %dMp (%dMp taken) (Design) %2.2f%% Complete\r\n", soft->restring, GET_OBJ_VAL(soft, 6),
-                     GET_OBJ_VAL(soft, 6) + (GET_OBJ_VAL(soft, 6) / 10),
+      if (GET_OBJ_TYPE(soft) == ITEM_DESIGN) {
+        char *step = (GET_OBJ_VAL(soft, 3) || GET_OBJ_VAL(soft, 5)) ? "Programming" : "Design";
+        send_to_char(ch, "%-40s %dMp (%dMp taken) (%s) %2.2f%% Complete\r\n", soft->restring, GET_OBJ_VAL(soft, 6),
+                     GET_OBJ_VAL(soft, 6) + (GET_OBJ_VAL(soft, 6) / 10), step,
                      GET_OBJ_TIMER(soft) ? (GET_OBJ_VAL(soft, 5) ?
                                             ((float)(GET_OBJ_TIMER(soft) - GET_OBJ_VAL(soft, 5)) / (GET_OBJ_TIMER(soft) != 0 ? GET_OBJ_TIMER(soft) : 1)) * 100 :
                                             ((float)(GET_OBJ_TIMER(soft) - GET_OBJ_VAL(soft, 4)) / (GET_OBJ_TIMER(soft) != 0 ? GET_OBJ_TIMER(soft) : 1)) * 100) : 0);
-      else
+      } else {
         send_to_char(ch, "%-40s %dMp (%dMp taken) (Completed) Rating %d\r\n", soft->restring ? soft->restring :
                      soft->text.name, GET_OBJ_VAL(soft, 2), GET_OBJ_VAL(soft, 2), GET_OBJ_VAL(soft, 1));
+      }
     }
   } else
     send_to_char(ch, " is empty.\r\n");


### PR DESCRIPTION
Just a set of small fixes and messaging clarifications for decking.

1. The maximum number of Hacking Pool dice that can be added to any test is equal to the base number of skill dice in use. (SR3, pg 44).

2. When attempting to logon to an adjacent host, the System Access Node (SAN) may be encrypted, and may be decrypted by targeting the exit's name.  In the mud, this is handled as the destination host's access subsystem being encrypted. When a decker is attempting to pass through the SAN during the midnight hour, in order to prevent the SAN from being repeatedly re-encrypted by matrix_update, we need the destination host to check for the presence of deckers in surrounding hosts.

3. Add messaging for decker dump at 80 security tally. This is in response to https://discord.com/channels/564618629467996170/788953927269613608/1056307563924299989

4.  Fix truncation of matrix download percentage. This is in response to https://discord.com/channels/564618629467996170/788953927269613608/1056394519052034088

5. Clarify whether on the programming or design step when listing software on a computer. This is in response to https://discord.com/channels/564618629467996170/788953927269613608/1056348875335667773

Related to 1, but which I have not been able to figure out, is why GET_MAX_HACKING seems to be running into an unusually low cap every mud hour. See https://discord.com/channels/564618629467996170/1055553152230899792