### PR TITLE
Fix get_drug_heal_multiplier truncation

### DIFF
--- a/src/drugs.cpp
+++ b/src/drugs.cpp
@@ -768,7 +768,7 @@ float get_drug_heal_multiplier(struct char_data *ch) {
   }
 
   // Returns a value in range 0.1 ≤ X ≤ 1.0.
-  return MIN(1.0, MAX(0.1, (float) 2 / divisor));
+  return MIN(1.0, MAX(0.1, 2.0 / divisor));
 }
 
 // ----------------- Helpers

--- a/src/drugs.cpp
+++ b/src/drugs.cpp
@@ -768,7 +768,7 @@ float get_drug_heal_multiplier(struct char_data *ch) {
   }
 
   // Returns a value in range 0.1 ≤ X ≤ 1.0.
-  return MIN(1.0, MAX(0.1, 2 / divisor));
+  return MIN(1.0, MAX(0.1, (float) 2 / divisor));
 }
 
 // ----------------- Helpers


### PR DESCRIPTION
This solves the problem of near 0 recovery when only affected by a single drug (stage comedown+).