### PR TITLE
Improve DIE command messaging

### DIFF
--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -1058,6 +1058,17 @@ void die(struct char_data * ch)
   raw_kill(ch);
 }
 
+ACMD(do_dw_retrieve)
+{
+  // If they're ready to be docwagon'd out, save them.
+  if (PLR_FLAGGED(ch, PLR_DOCWAGON_READY)) {
+    docwagon_retrieve(ch);
+  } else {
+    send_to_char(ch, "You have not received a DocWagon trauma team confirmation! You can either wait for help, or give up by typing ^WDIE^n.\r\n");
+  }
+  return;
+}
+  
 /*
  * Lets the player give up and die if they're at 0 or less
  * physical points.

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -2432,7 +2432,7 @@ bool docwagon(struct char_data *ch)
 
   if (PLR_FLAGGED(ch, PLR_DOCWAGON_READY)) {
     send_to_char(ch, "%s^n buzzes contentedly: the automated DocWagon trauma team remains en route.\r\n", CAP(GET_OBJ_NAME(docwagon)));
-    send_to_char(ch, "^L[OOC: You can choose to wait for player assistance to arrive, or you can get picked up immediately by entering ^wDIE^L. See ^wHELP DOCWAGON^L for more details.]\r\n");
+    send_to_char(ch, "^L[OOC: Your DocWagon pickup is ready! You can type ^wCOMEGETME^L to be picked up immediately, or you can choose to wait for player assistance to arrive. See ^wHELP DOCWAGON^L for more details.]\r\n");
   } else {
     int docwagon_tn = MAX(GET_SECURITY_LEVEL(room), 4);
     int docwagon_dice = GET_DOCWAGON_CONTRACT_GRADE(docwagon) + 1;
@@ -2450,7 +2450,7 @@ bool docwagon(struct char_data *ch)
     if (successes > 0)
     {
       send_to_char(ch, "%s^n chirps cheerily: an automated DocWagon trauma team is on its way!\r\n", CAP(GET_OBJ_NAME(docwagon)));
-      send_to_char(ch, "^L[OOC: You can choose to wait for player assistance to arrive, or you can get picked up immediately by entering ^wDIE^L. See ^wHELP DOCWAGON^L for more details.]\r\n");
+      send_to_char(ch, "^L[OOC: Your DocWagon pickup is ready! You can type ^wCOMEGETME^L to be picked up immediately, or you can choose to wait for player assistance to arrive. See ^wHELP DOCWAGON^L for more details.]\r\n");
       PLR_FLAGS(ch).SetBit(PLR_DOCWAGON_READY);
     } else {
       send_to_char(ch, "%s^n vibrates, sending out a trauma call that will hopefully be answered.\r\n", CAP(GET_OBJ_NAME(docwagon)));

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -1061,11 +1061,11 @@ void die(struct char_data * ch)
 ACMD(do_dw_retrieve)
 {
   // Not mortally wounded
-  FAILURE_CASE(GET_POS(ch) != POS_MORTALLYW, "A DocWagon recon drone states, \"^YNon-critical vitals detected, moving to next...^n (fades into the distance)\"");
+  FAILURE_CASE(GET_POS(ch) != POS_MORTALLYW, "A DocWagon triage drone states, \"^YVital signs non-critical. Moving to next...^L(fades into the distance)^n\"");
   
   // No modulator
   struct obj_data *docwagon = find_best_active_docwagon_modulator(ch);
-  FAILURE_CASE(!docwagon, "A DocWagon recon drone states, \"^RNo modulator detected, cannot confirm contract status...^n (fades into the distance)\"");
+  FAILURE_CASE(!docwagon, "A DocWagon triage drone states, \"^RNo modulator detected. Cannot confirm contract...^L(fades into the distance)^n\"");
   
   // If they're ready to be docwagon'd out, save them.
   if (PLR_FLAGGED(ch, PLR_DOCWAGON_READY)) {

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -1060,6 +1060,13 @@ void die(struct char_data * ch)
 
 ACMD(do_dw_retrieve)
 {
+  // Not mortally wounded
+  FAILURE_CASE(GET_POS(ch) != POS_MORTALLYW, "A DocWagon recon drone states, \"^YNon-critical vitals detected, moving to next...^n (fades into the distance)\"");
+  
+  // No modulator
+  struct obj_data *docwagon = find_best_active_docwagon_modulator(ch);
+  FAILURE_CASE(!docwagon, "A DocWagon recon drone states, \"^RNo modulator detected, cannot confirm contract status...^n (fades into the distance)\"");
+  
   // If they're ready to be docwagon'd out, save them.
   if (PLR_FLAGGED(ch, PLR_DOCWAGON_READY)) {
     docwagon_retrieve(ch);

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -539,6 +539,7 @@ struct command_info cmd_info[] =
     { "contest"    , POS_SITTING , do_contest  , 0, 0, FALSE },
     { "control"    , POS_SITTING , do_control  , 0, 0, FALSE },
     { "combine"    , POS_RESTING , do_put      , 0, 0, FALSE },
+    { "comegetme"  , POS_DEAD    , do_die      , 0, 0, FALSE },
     { "complete"   , POS_LYING   , do_recap    , 0, 0, FALSE },
     { "copy"       , POS_SITTING , do_copy     , 0, 0, FALSE },
     { "copyover"   , POS_DEAD    , do_copyover , LVL_ADMIN, 0, FALSE },

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -1689,13 +1689,13 @@ void command_interpreter(struct char_data * ch, char *argument, const char *tcna
       case POS_MORTALLYW:
         send_to_char("You are in a pretty bad shape! You can either wait for help, or give up by typing ^WDIE^n.\r\n", ch);
         if (PLR_FLAGGED(ch, PLR_NEWBIE)) {
-          send_to_char(ch, "^L[OOC: While your TKE is less than 50, your only penalty for dying is losing your current job. See ^wHELP NEWBIE^L for more details.]\r\n");
+          send_to_char("^L[OOC: While your TKE is less than 50, your only penalty for dying is losing your current job. See ^wHELP NEWBIE^L for more details.]\r\n", ch);
         }
         break;
       case POS_STUNNED:
         send_to_char("All you can do right now is think about the stars! You can either wait to recover, or give up by typing ^WDIE^n.\r\n", ch);
         if (PLR_FLAGGED(ch, PLR_NEWBIE)) {
-          send_to_char(ch, "^L[OOC: While your TKE is less than 50, your only penalty for dying is losing your current job. See ^wHELP NEWBIE^L for more details.]\r\n");
+          send_to_char("^L[OOC: While your TKE is less than 50, your only penalty for dying is losing your current job. See ^wHELP NEWBIE^L for more details.]\r\n", ch);
         }
         break;
       case POS_SLEEPING:

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -180,6 +180,7 @@ ACMD_DECLARE(do_drive);
 ACMD_DECLARE(do_drop);
 ACMD_DECLARE(do_drugs);
 ACMD_DECLARE(do_docwagon);
+ACMD_DECLARE(do_dw_retrieve);
 ACMD_DECLARE(do_eat);
 ACMD_DECLARE(do_echo);
 ACMD_DECLARE(do_new_echo);
@@ -539,7 +540,7 @@ struct command_info cmd_info[] =
     { "contest"    , POS_SITTING , do_contest  , 0, 0, FALSE },
     { "control"    , POS_SITTING , do_control  , 0, 0, FALSE },
     { "combine"    , POS_RESTING , do_put      , 0, 0, FALSE },
-    { "comegetme"  , POS_DEAD    , do_die      , 0, 0, FALSE },
+    { "comegetme"  , POS_DEAD  , do_dw_retrieve, 0, 0, FALSE },
     { "complete"   , POS_LYING   , do_recap    , 0, 0, FALSE },
     { "copy"       , POS_SITTING , do_copy     , 0, 0, FALSE },
     { "copyover"   , POS_DEAD    , do_copyover , LVL_ADMIN, 0, FALSE },

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -1687,9 +1687,15 @@ void command_interpreter(struct char_data * ch, char *argument, const char *tcna
         break;
       case POS_MORTALLYW:
         send_to_char("You are in a pretty bad shape! You can either wait for help, or give up by typing ^WDIE^n.\r\n", ch);
+        if (PLR_FLAGGED(ch, PLR_NEWBIE)) {
+          send_to_char(ch, "^L[OOC: While your TKE is less than 50, your only penalty for dying is losing your current job. See ^wHELP NEWBIE^L for more details.]\r\n");
+        }
         break;
       case POS_STUNNED:
         send_to_char("All you can do right now is think about the stars! You can either wait to recover, or give up by typing ^WDIE^n.\r\n", ch);
+        if (PLR_FLAGGED(ch, PLR_NEWBIE)) {
+          send_to_char(ch, "^L[OOC: While your TKE is less than 50, your only penalty for dying is losing your current job. See ^wHELP NEWBIE^L for more details.]\r\n");
+        }
         break;
       case POS_SLEEPING:
         send_to_char("In your dreams, or what?\r\n", ch);


### PR DESCRIPTION
Questions on these come up often enough that I think clarification would be useful.

1. When DocWagon pickup is ready, let's make that clearer in OOC., Also, use an alias COMEGETME instead of DIE so as to reduce the confusion on whether or not typing the command is going to kill them.
2. When a newbie is mortally wounded or stunned, let them know that they don't need to be too concerned about dying.