### PR TITLE
Ritualcast updates

### DIFF
--- a/src/newmagic.cpp
+++ b/src/newmagic.cpp
@@ -3746,6 +3746,8 @@ ACMD(do_release)
 bool spell_is_valid_ritual_spell(int spell) {
   switch (spell) {
     case SPELL_COMBATSENSE:
+    case SPELL_DECATTR:
+    case SPELL_DECCYATTR:
     case SPELL_DETOX:
     case SPELL_HEAL:
     case SPELL_TREAT:

--- a/src/newmagic.cpp
+++ b/src/newmagic.cpp
@@ -3902,8 +3902,8 @@ ACMD(do_cast)
     FAILURE_CASE(IS_NPC(vict), "You can only cast ritual spells on player characters.\r\n");
 
     // Charge them.
-    int cost = RITUAL_SPELL_COMPONENT_COST * spell->force * MAX(1, spells[spell->type].drainpower);
-    int time_in_ticks = (RITUAL_SPELL_BASE_TIME * spell->force * MAX(1, spells[spell->type].drainpower)) / (GET_SKILL(ch, SKILL_SORCERY) + MIN(GET_SKILL(ch, SKILL_SORCERY), GET_CASTING(ch)));
+    int cost = RITUAL_SPELL_COMPONENT_COST * force * MAX(1, spells[spell->type].drainpower);
+    int time_in_ticks = (RITUAL_SPELL_BASE_TIME * force * MAX(1, spells[spell->type].drainpower)) / (GET_SKILL(ch, SKILL_SORCERY) + MIN(GET_SKILL(ch, SKILL_SORCERY), GET_CASTING(ch)));
 
     if (GET_NUYEN(ch) < cost) {
       send_to_char(ch, "You need at least %d nuyen on hand to pay for the ritual components.\r\n", cost);
@@ -3918,7 +3918,7 @@ ACMD(do_cast)
     GET_RITUAL_COMPONENT_CASTER(components) = GET_IDNUM(ch);
     GET_RITUAL_COMPONENT_SPELL(components) = spell->type;
     GET_RITUAL_COMPONENT_SUBTYPE(components) = spell->subtype;
-    GET_RITUAL_COMPONENT_FORCE(components) = spell->force;
+    GET_RITUAL_COMPONENT_FORCE(components) = force;
     GET_RITUAL_COMPONENT_TARGET(components) = GET_IDNUM(vict);
     GET_RITUAL_TICKS_AT_START(components) = GET_RITUAL_TICKS_LEFT(components) = time_in_ticks;
 


### PR DESCRIPTION
1) Enable decrease attribute and decrease cybered attribute for ritualcast, since they can be used as buffs in order to improve the TN for subsequent increase attribute spells. They are still limited by the decrease + increase stacking penalty house rule so abuse shouldn't be a problem.
This answers: https://discord.com/channels/564618629467996170/788953927269613608/1060260644227665930

2) Let ritualcast spells be cast at specified force instead of being nailed to max force.
This answers: https://discord.com/channels/564618629467996170/788953927269613608/1060266306902962358