### PR TITLE
Some radio code refactoring to fix conflicts

### DIFF
--- a/src/act.comm.cpp
+++ b/src/act.comm.cpp
@@ -707,12 +707,12 @@ ACMD(do_radio)
   int *crypt = 0;
   int max_crypt = 0;
   if (cyberware) {
-    *freq = &GET_CYBERWARE_SETTABLE1(radio);
-    *crypt = &GET_CYBERWARE_SETTABLE2(radio);
+    *freq = &GET_CYBERWARE_RADIO_FREQ(radio);
+    *crypt = &GET_CYBERWARE_RADIO_CRYPT(radio);
     max_crypt = GET_CYBERWARE_RADIO_MAX_CRYPT(radio);
   } else if (vehicle) {
-    *freq = &GET_VEHICLE_MOD_SETTABLE1(radio);
-    *crypt = &GET_VEHICLE_MOD_SETTABLE2(radio);
+    *freq = &GET_VEHICLE_MOD_RADIO_FREQ(radio);
+    *crypt = &GET_VEHICLE_MOD_RADIO_CRYPT(radio);
     max_crypt = GET_VEHICLE_MOD_RADIO_MAX_CRYPT(radio);
   } else {
     *freq = &GET_RADIO_CENTERED_FREQUENCY(radio);
@@ -883,11 +883,11 @@ ACMD(do_broadcast)
   } else {
     // Player character with radio
     if (cyberware) {
-      frequency = GET_CYBERWARE_SETTABLE1(radio);
-      crypt_lvl = GET_CYBERWARE_SETTABLE2(radio);
+      frequency = GET_CYBERWARE_RADIO_FREQ(radio);
+      crypt_lvl = GET_CYBERWARE_RADIO_CRYPT(radio);
     } else if (vehicle) {
-      frequency = GET_VEHICLE_MOD_SETTABLE1(radio);
-      crypt_lvl = GET_VEHICLE_MOD_SETTABLE2(radio);
+      frequency = GET_VEHICLE_MOD_RADIO_FREQ(radio);
+      crypt_lvl = GET_VEHICLE_MOD_RADIO_CRYPT(radio);
     } else {
       frequency = GET_RADIO_CENTERED_FREQUENCY(radio);
       crypt_lvl = GET_RADIO_CURRENT_CRYPT(radio);
@@ -972,11 +972,11 @@ ACMD(do_broadcast)
             to_room = 1;
           */
           if (cyberware) {
-            rec_freq = GET_CYBERWARE_SETTABLE1(radio);
+            rec_freq = GET_CYBERWARE_RADIO_FREQ(radio);
             rec_range = GET_CYBERWARE_RATING(radio);
             decrypt = GET_CYBERWARE_RADIO_MAX_CRYPT(radio);
           } else if (vehicle) {
-            rec_freq = GET_VEHICLE_MOD_SETTABLE1(radio);
+            rec_freq = GET_VEHICLE_MOD_RADIO_FREQ(radio);
             rec_range = GET_VEHICLE_MOD_RATING(radio);
             decrypt = GET_VEHICLE_MOD_RADIO_MAX_CRYPT(radio);
           } else {

--- a/src/act.informative.cpp
+++ b/src/act.informative.cpp
@@ -3518,7 +3518,7 @@ void do_probe_object(struct char_data * ch, struct obj_data * j) {
         // radio range 0-5
         snprintf(ENDOF(buf), sizeof(buf) - strlen(buf), "\r\nIt has a ^c%d/5^n range and can encrypt and decrypt signals up to crypt level ^c%d^n.",
                  GET_VEHICLE_MOD_RATING(j),
-                 GET_VEHICLE_MOD_RADIO_CRYPT(j));
+                 GET_VEHICLE_MOD_RADIO_MAX_CRYPT(j));
       } else {
         snprintf(ENDOF(buf), sizeof(buf) - strlen(buf), "\r\nIt functions at rating ^c%d^n.", GET_VEHICLE_MOD_RATING(j));
       }

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -1051,8 +1051,9 @@ bool WEAPON_FOCUS_USABLE_BY(struct obj_data *focus, struct char_data *ch);
 #define GET_CYBERWARE_LACING_TYPE(cyberware)      (GET_OBJ_VAL((cyberware), 3)) // Yes, this is also value 3. Great design here.
 #define GET_CYBERWARE_ESSENCE_COST(cyberware)     (GET_OBJ_VAL((cyberware), 4))
 #define GET_CYBERWARE_RADIO_MAX_CRYPT(cyberware)  (GET_OBJ_VAL((cyberware), 5))
-#define GET_CYBERWARE_SETTABLE1(cyberware)        (GET_OBJ_VAL((cyberware), 7)) // Settable by player 
-#define GET_CYBERWARE_SETTABLE2(cyberware)        (GET_OBJ_VAL((cyberware), 8)) // Settable by player
+#define GET_CYBERWARE_RADIO_FREQ(cyberware)       (GET_OBJ_VAL((cyberware), 6)) // Settable by player
+#define GET_CYBERWARE_RADIO_CRYPT(cyberware)      (GET_OBJ_VAL((cyberware), 7)) // Settable by player
+// Cyberware phones use 6, 7, and 8 for... stuff?
 #define GET_CYBERWARE_IS_DISABLED(cyberware)      (GET_OBJ_VAL((cyberware), 9))
 
 // ITEM_CYBERDECK convenience defines
@@ -1163,8 +1164,8 @@ bool WEAPON_FOCUS_USABLE_BY(struct obj_data *focus, struct char_data *ch);
 #define GET_VEHICLE_MOD_DESIGNED_FOR_FLAGS(mod)             (GET_OBJ_VAL((mod), 4))
 #define GET_VEHICLE_MOD_ENGINE_BITS(mod)                    (GET_OBJ_VAL((mod), 5))
 #define GET_VEHICLE_MOD_LOCATION(mod)                       (GET_OBJ_VAL((mod), 6))
-#define GET_VEHICLE_MOD_SETTABLE1(mod)                      (GET_OBJ_VAL((mod), 7)) // Settable by player
-#define GET_VEHICLE_MOD_SETTABLE2(mod)                      (GET_OBJ_VAL((mod), 8)) // Settable by player
+#define GET_VEHICLE_MOD_RADIO_FREQ(mod)                     (GET_OBJ_VAL((mod), 7)) // Settable by player
+#define GET_VEHICLE_MOD_RADIO_CRYPT(mod)                    (GET_OBJ_VAL((mod), 8)) // Settable by player
 
 // ITEM_HOLSTER convenience defines
 #define GET_HOLSTER_TYPE(holster)                           (GET_OBJ_VAL((holster), 0))

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -989,6 +989,9 @@ bool WEAPON_FOCUS_USABLE_BY(struct obj_data *focus, struct char_data *ch);
 
 // ITEM_RADIO convenience defines
 #define GET_RADIO_CENTERED_FREQUENCY(radio)       (GET_OBJ_VAL((radio), 0))
+#define GET_RADIO_FREQ_RANGE(radio)               (GET_OBJ_VAL((radio), 1))
+#define GET_RADIO_MAX_CRYPT(radio)                (GET_OBJ_VAL((radio), 2))
+#define GET_RADIO_CURRENT_CRYPT(radio)            (GET_OBJ_VAL((radio), 3))
 
 // ITEM_DRINKCON convenience defines
 #define GET_DRINKCON_MAX_AMOUNT(cont)             (GET_OBJ_VAL((cont), 0))
@@ -1047,6 +1050,9 @@ bool WEAPON_FOCUS_USABLE_BY(struct obj_data *focus, struct char_data *ch);
 #define GET_CYBERWARE_FLAGS(cyberware)            (GET_OBJ_VAL((cyberware), 3)) // CYBERWEAPON_RETRACTABLE, CYBERWEAPON_IMPROVED
 #define GET_CYBERWARE_LACING_TYPE(cyberware)      (GET_OBJ_VAL((cyberware), 3)) // Yes, this is also value 3. Great design here.
 #define GET_CYBERWARE_ESSENCE_COST(cyberware)     (GET_OBJ_VAL((cyberware), 4))
+#define GET_CYBERWARE_RADIO_MAX_CRYPT(cyberware)  (GET_OBJ_VAL((cyberware), 5))
+#define GET_CYBERWARE_SETTABLE1(cyberware)        (GET_OBJ_VAL((cyberware), 7)) // Settable by player 
+#define GET_CYBERWARE_SETTABLE2(cyberware)        (GET_OBJ_VAL((cyberware), 8)) // Settable by player
 #define GET_CYBERWARE_IS_DISABLED(cyberware)      (GET_OBJ_VAL((cyberware), 9))
 
 // ITEM_CYBERDECK convenience defines
@@ -1153,10 +1159,12 @@ bool WEAPON_FOCUS_USABLE_BY(struct obj_data *focus, struct char_data *ch);
 #define GET_VEHICLE_MOD_MOUNT_TYPE(mod)                     (GET_OBJ_VAL((mod), 1))
 #define GET_VEHICLE_MOD_LOAD_SPACE_REQUIRED(mod)            (GET_OBJ_VAL((mod), 1)) // Yes, this is also value 1.
 #define GET_VEHICLE_MOD_RATING(mod)                         (GET_OBJ_VAL((mod), 2))
-#define GET_VEHICLE_MOD_RADIO_CRYPT(mod)                    (GET_OBJ_VAL((mod), 3))
+#define GET_VEHICLE_MOD_RADIO_MAX_CRYPT(mod)                (GET_OBJ_VAL((mod), 3))
 #define GET_VEHICLE_MOD_DESIGNED_FOR_FLAGS(mod)             (GET_OBJ_VAL((mod), 4))
 #define GET_VEHICLE_MOD_ENGINE_BITS(mod)                    (GET_OBJ_VAL((mod), 5))
 #define GET_VEHICLE_MOD_LOCATION(mod)                       (GET_OBJ_VAL((mod), 6))
+#define GET_VEHICLE_MOD_SETTABLE1(mod)                      (GET_OBJ_VAL((mod), 7)) // Settable by player
+#define GET_VEHICLE_MOD_SETTABLE2(mod)                      (GET_OBJ_VAL((mod), 8)) // Settable by player
 
 // ITEM_HOLSTER convenience defines
 #define GET_HOLSTER_TYPE(holster)                           (GET_OBJ_VAL((holster), 0))


### PR DESCRIPTION
Solves the issue where setting a vehicle radio's centered frequency and crypt level would overwrite the mod's designed-for flags and engine bits, discussed at https://discord.com/channels/564618629467996170/1075227777348927578 .

Also solves unreported cyberware radio issues: (1) setting centered frequency looked like it would overwrite cyberware flags (potentially exploitable), and (2) radio frequency range was using max crypt instead of rating.

-Khai