### PR TITLE
Fix banishing magic loss and actions

### DIFF
--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -5966,7 +5966,7 @@ void perform_violence(void)
         stop_fighting(mage);
         end_spirit_existance(spirit, TRUE);
         AFF_FLAGS(mage).RemoveBit(AFF_BANISH);
-      } else if (GET_REAL_MAG(mage) - GET_TEMP_MAGIC_LOSS(mage) < 1) {
+      } else if ((GET_REAL_MAG(mage) / 100) - GET_TEMP_MAGIC_LOSS(mage) < 1) {
         send_to_char(mage, "Your magic spent from your battle with %s, you fall unconscious.\r\n", GET_NAME(spirit));
         act("$n falls unconscious, drained by magical combat.", FALSE, mage, 0, 0, TO_ROOM);
         if (damage(spirit, mage, TYPE_DRAIN, DEADLY, MENTAL)) {

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -5946,7 +5946,7 @@ void perform_violence(void)
       if (success < 0) {
         GET_EXTRA(mage) = 0;
         GET_EXTRA(spirit) = 1;
-        GET_TEMP_MAGIC_LOSS(mage) += MAX(-success, GET_MAG(mage));
+        GET_TEMP_MAGIC_LOSS(mage) += MIN(-success, GET_MAG(mage) / 100);
         send_to_char(mage, "You lock minds with %s, but are beaten back by its force!\r\n", GET_NAME(spirit));
       } else if (success == 0) {
         send_to_char(mage, "You lock minds with %s, but fail to gain any ground.\r\n",

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -5946,7 +5946,7 @@ void perform_violence(void)
       if (success < 0) {
         GET_EXTRA(mage) = 0;
         GET_EXTRA(spirit) = 1;
-        GET_TEMP_MAGIC_LOSS(mage) -= success;
+        GET_TEMP_MAGIC_LOSS(mage) += MAX(-success, GET_MAG(mage));
         send_to_char(mage, "You lock minds with %s, but are beaten back by its force!\r\n", GET_NAME(spirit));
       } else if (success == 0) {
         send_to_char(mage, "You lock minds with %s, but fail to gain any ground.\r\n",
@@ -5978,6 +5978,14 @@ void perform_violence(void)
         AFF_FLAGS(mage).RemoveBit(AFF_BANISH);
         AFF_FLAGS(spirit).RemoveBit(AFF_BANISH);
       }
+      continue;
+    }
+
+    // SR3 pg 189, when in banishment clashes, a spirit doesn't otherwise act
+    if (IS_AFFECTED(ch, AFF_BANISH)
+        && FIGHTING(ch)
+        && (IS_ANY_ELEMENTAL(ch) || IS_SPIRIT(ch)))
+    {
       continue;
     }
 

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -5946,7 +5946,7 @@ void perform_violence(void)
       if (success < 0) {
         GET_EXTRA(mage) = 0;
         GET_EXTRA(spirit) = 1;
-        GET_TEMP_MAGIC_LOSS(mage) += MIN(-success, GET_MAG(mage) / 100);
+        GET_TEMP_MAGIC_LOSS(mage) = MIN(GET_TEMP_MAGIC_LOSS(mage) - success, GET_REAL_MAG(mage) / 100);
         send_to_char(mage, "You lock minds with %s, but are beaten back by its force!\r\n", GET_NAME(spirit));
       } else if (success == 0) {
         send_to_char(mage, "You lock minds with %s, but fail to gain any ground.\r\n",
@@ -5966,7 +5966,7 @@ void perform_violence(void)
         stop_fighting(mage);
         end_spirit_existance(spirit, TRUE);
         AFF_FLAGS(mage).RemoveBit(AFF_BANISH);
-      } else if (GET_MAG(mage) < 1) {
+      } else if (GET_REAL_MAG(mage) - GET_TEMP_MAGIC_LOSS(mage) < 1) {
         send_to_char(mage, "Your magic spent from your battle with %s, you fall unconscious.\r\n", GET_NAME(spirit));
         act("$n falls unconscious, drained by magical combat.", FALSE, mage, 0, 0, TO_ROOM);
         if (damage(spirit, mage, TYPE_DRAIN, DEADLY, MENTAL)) {

--- a/src/limits.cpp
+++ b/src/limits.cpp
@@ -863,7 +863,7 @@ void process_regeneration(int half_hour)
   }
 }
 
-/* Update PCs, NPCs, and objects */
+/* Update PCs, NPCs, and objects, called every mud hour */
 void point_update(void)
 {
   PERF_PROF_SCOPE(pr_, __func__);
@@ -924,6 +924,11 @@ void point_update(void)
         send_to_char("You feel you could benefit with some time at a shooting range.\r\n", i);
       }
 #endif
+
+      // Temp magic loss (banishing) regains 1/hour, SR3 pg 189
+      if (GET_TEMP_MAGIC_LOSS(i) > 0) {
+        GET_TEMP_MAGIC_LOSS(i)--;
+      }
 
       // Geas check from focus / foci overuse.
       if (GET_MAG(i) > 0) {


### PR DESCRIPTION
(1) Temp magic loss is recovered 1 per mud hour.
(2) Cap temp magic loss.
(3) Spirits don't otherwise act when in banishment clashes.

Discussed at https://discord.com/channels/564618629467996170/1076958471288787105

- Khai