### PR TITLE
Fix get_bioover math, rebalance bioover recovery penalty

### DIFF
--- a/src/drugs.cpp
+++ b/src/drugs.cpp
@@ -169,7 +169,7 @@ bool process_drug_point_update_tick(struct char_data *ch) {
       GET_DRUG_STAGE(ch, drug_id) = DRUG_STAGE_COMEDOWN;
 
       // Apply comedown durations and instant effects (damage etc).
-      int bod_for_success_test = GET_REAL_BOD(ch) - (GET_BIOOVER(ch) / 2);
+      int bod_for_success_test = GET_REAL_BOD(ch) - ((GET_BIOOVER(ch) + 1) / 2);
       switch (drug_id) {
         case DRUG_JAZZ:
           GET_DRUG_DURATION(ch, drug_id) = 100 * dice(1,6);
@@ -268,7 +268,7 @@ bool process_drug_point_update_tick(struct char_data *ch) {
         }
 
         // How many successes did we roll to stage down the damage?
-        int resist_test_successes = success_test(GET_REAL_BOD(ch) - (GET_BIOOVER(ch) / 2), power, ch, "onset damage resist");
+        int resist_test_successes = success_test(GET_REAL_BOD(ch) - ((GET_BIOOVER(ch) + 1) / 2), power, ch, "onset damage resist");
 
         // Calculate the boxes of damage to apply.
         damage_boxes = convert_damage(stage(-resist_test_successes, damage_level));

--- a/src/limits.cpp
+++ b/src/limits.cpp
@@ -92,7 +92,7 @@ void mental_gain(struct char_data * ch)
   }
 
   if (find_workshop(ch, TYPE_MEDICAL))
-    gain = (int)(gain * 1.5);
+    gain *= 1.5;
 
 #ifdef ENABLE_HUNGER
   if ((GET_COND(ch, COND_FULL) == MIN_FULLNESS) || (GET_COND(ch, COND_THIRST) == MIN_QUENCHED))
@@ -106,11 +106,13 @@ void mental_gain(struct char_data * ch)
 
   if (GET_TRADITION(ch) == TRAD_ADEPT && GET_POWER(ch, ADEPT_HEALING) > 0)
     gain *= (((float) GET_POWER(ch, ADEPT_HEALING) / 2) + 1);
+
+  // Biosystem overstress reduces rate by 10% per point
   if (GET_BIOOVER(ch) > 0)
-    gain /= GET_BIOOVER(ch);
+    gain *= MIN(1.0, MAX(0.1, 1 - (0.1 * GET_BIOOVER(ch))));
 
+  // Prevent reaching 0 gain
   gain = MAX(1, gain);
-
   GET_MENTAL(ch) = MIN(GET_MAX_MENTAL(ch), GET_MENTAL(ch) + gain);
 
   update_pos(ch);
@@ -153,7 +155,7 @@ void physical_gain(struct char_data * ch)
 #endif
 
   if (find_workshop(ch, TYPE_MEDICAL))
-    gain = (int)(gain * 1.8);
+    gain *= 1.8;
 
   if (char_is_in_social_room(ch))
     gain *= 2;
@@ -169,10 +171,10 @@ void physical_gain(struct char_data * ch)
       if (GET_BIOWARE_TYPE(bio) == BIO_SYMBIOTES) {
         switch (GET_BIOWARE_RATING(bio)) {
           case 1:
-            gain = (int)(gain * 10/9);
+            gain *= 1.1;
             break;
           case 2:
-            gain = (int)(gain * 7/5);
+            gain *= 1.4;
             break;
           case 3:
             gain *= 2;
@@ -186,8 +188,13 @@ void physical_gain(struct char_data * ch)
   }
   if (GET_TRADITION(ch) == TRAD_ADEPT && GET_POWER(ch, ADEPT_HEALING) > 0)
     gain *= (((float) GET_POWER(ch, ADEPT_HEALING) / 2) + 1);
+
+  // Biosystem overstress reduces healing rate by 10% per point
   if (GET_BIOOVER(ch) > 0)
-    gain /= GET_BIOOVER(ch);
+    gain *= MIN(1.0, MAX(0.1, 1 - (0.1 * GET_BIOOVER(ch))));
+
+  // Prevent reaching 0 gain
+  gain = MAX(1, gain);
   GET_PHYSICAL(ch) = MIN(GET_MAX_PHYSICAL(ch), GET_PHYSICAL(ch) + gain);
   update_pos(ch);
 }
@@ -433,8 +440,8 @@ void remove_patch(struct char_data *ch)
       update_pos(ch);
       break;
     case PATCH_TRANQ:
-      stun = resisted_test(GET_OBJ_VAL(patch, 1), GET_REAL_BOD(ch) - (GET_BIOOVER(ch) > 0 ? GET_BIOOVER(ch) / 2 : 0),
-                           GET_REAL_BOD(ch) - (GET_BIOOVER(ch) > 0 ? GET_BIOOVER(ch) / 2 : 0), GET_OBJ_VAL(patch, 1));
+      stun = resisted_test(GET_OBJ_VAL(patch, 1), GET_REAL_BOD(ch) - (GET_BIOOVER(ch) > 0 ? (GET_BIOOVER(ch) + 1) / 2 : 0),
+                           GET_REAL_BOD(ch) - (GET_BIOOVER(ch) > 0 ? (GET_BIOOVER(ch) + 1) / 2 : 0), GET_OBJ_VAL(patch, 1));
       if (stun > 0) {
         act("You feel the drugs from $p take effect.", FALSE, ch, patch, 0, TO_CHAR);
         GET_MENTAL(ch) = MAX(0, GET_MENTAL(ch) - (stun * 100));
@@ -443,7 +450,7 @@ void remove_patch(struct char_data *ch)
         act("You resist the feeble effects of $p.", FALSE, ch, patch, 0, TO_CHAR);
       break;
     case PATCH_TRAUMA:
-      if (success_test(GET_REAL_BOD(ch) - (GET_BIOOVER(ch) > 0 ? GET_BIOOVER(ch) / 2 : 0), GET_OBJ_VAL(patch, 1)) > 0)
+      if (success_test(GET_REAL_BOD(ch) - (GET_BIOOVER(ch) > 0 ? (GET_BIOOVER(ch) + 1) / 2 : 0), GET_OBJ_VAL(patch, 1)) > 0)
         AFF_FLAGS(ch).RemoveBit(AFF_STABILIZE);
       break;
   }

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -460,7 +460,7 @@ extern bool PLR_TOG_CHK(char_data *ch, dword offset);
 #define GET_ESSHOLE(ch)       ((ch)->real_abils.esshole)
 #define GET_INDEX(ch)         ((ch)->real_abils.bod_index)
 #define GET_HIGHEST_INDEX(ch)      ((ch)->real_abils.highestindex)
-#define GET_BIOOVER(ch)       (-((int)((GET_ESS((ch)) + 300) - GET_INDEX((ch))) / 100))
+#define GET_BIOOVER(ch)       ((int)(GET_INDEX(ch) - (GET_ESS(ch) + 300) + 99) / 100)
 #define GET_TEMP_MAGIC_LOSS(ch)	((ch)->points.magic_loss)
 #define GET_TEMP_ESSLOSS(ch)	((ch)->points.ess_loss)
 


### PR DESCRIPTION
Per M&M pg 78, all excessive bioware penalties are based on "points (or part thereof) their Bio Index exceeds their Essence Index". So we want to round up, whereas integer division truncates towards zero. So this fixes all the get_bioover related math.

Related to this, the current recovery penalty for excessive bioware doesn't kick in until get_bioover = 2, at which point it causes a massive drop, cutting recovery in half. So with the above fix, this would cause the recovery penalty to be cut in half when at 1.01 over instead of at 2 over. This request changes the penalty calculation to be -10% per point of get_bioover, which makes for a smoother drop and more closely resembles the rules written in M&M pg 78.