### PR TITLE
Handle persona programs in store-bought decks like components

### DIFF
--- a/src/act.obj.cpp
+++ b/src/act.obj.cpp
@@ -981,9 +981,11 @@ void perform_get_from_container(struct char_data * ch, struct obj_data * obj,
           return;
         }
 
-        if (GET_OBJ_TYPE(obj) == ITEM_PROGRAM ||
-            (GET_OBJ_TYPE(obj) == ITEM_DECK_ACCESSORY && GET_DECK_ACCESSORY_TYPE(obj) == TYPE_FILE))
-          GET_OBJ_VAL(cont, 5) -= GET_DECK_ACCESSORY_FILE_SIZE(obj);
+        // Subtract program size from storage, but a persona program on a store-bought deck doesn't use storage
+        if (((GET_OBJ_TYPE(obj) == ITEM_PROGRAM) && !((GET_OBJ_TYPE(cont) == ITEM_CYBERDECK) && (GET_PROGRAM_TYPE(obj) <= SOFT_SENSOR)))
+            || (GET_OBJ_TYPE(obj) == ITEM_DECK_ACCESSORY && GET_DECK_ACCESSORY_TYPE(obj) == TYPE_FILE)) {
+          GET_CYBERDECK_USED_STORAGE(cont) -= GET_DECK_ACCESSORY_FILE_SIZE(obj);
+        }
 
         if (GET_OBJ_TYPE(obj) == ITEM_PART) {
           if (GET_OBJ_VAL(obj, 0) == PART_STORAGE) {

--- a/src/act.obj.cpp
+++ b/src/act.obj.cpp
@@ -268,7 +268,12 @@ void perform_put_cyberdeck(struct char_data * ch, struct obj_data * obj,
 
     int space_required = 0;
     if (GET_OBJ_TYPE(obj) == ITEM_PROGRAM) {
-      space_required = GET_PROGRAM_SIZE(obj);
+      // Persona programs don't take up storage memory in store-bought decks
+      if ((GET_OBJ_TYPE(cont) == ITEM_CYBERDECK) && (GET_PROGRAM_TYPE(obj) <= SOFT_SENSOR)) {
+        space_required = 0;
+      } else {
+        space_required = GET_PROGRAM_SIZE(obj);
+      }
     } else {
       space_required = (int) GET_DESIGN_SIZE(obj) * 1.1;
     }

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -2156,7 +2156,9 @@ ACMD(do_load)
         }
       }
 
-      if (subcmd == SCMD_SWAP && GET_OBJ_VAL(soft, 2) > DECKER->active) {
+      if (subcmd == SCMD_SWAP && (GET_PROGRAM_TYPE(soft) <= SOFT_SENSOR)) {
+        send_to_icon(PERSONA, "Persona programs are loaded at time of connection.\r\n");
+      } else if (subcmd == SCMD_SWAP && GET_OBJ_VAL(soft, 2) > DECKER->active) {
         send_to_icon(PERSONA, "You don't have enough active memory to load that program.\r\n");
       } else if (subcmd == SCMD_SWAP && GET_OBJ_VAL(soft, 1) > DECKER->mpcp) {
         send_to_icon(PERSONA, "Your deck is not powerful enough to run that program.\r\n");
@@ -2547,7 +2549,7 @@ void send_storage_program_list(struct char_data *ch) {
   send_to_icon(PERSONA, "\r\nStorage Memory Total:(^G%d^n) Free:(^R%d^n):\r\n", GET_OBJ_VAL(DECKER->deck, 3),
                GET_OBJ_VAL(DECKER->deck, 3) - GET_OBJ_VAL(DECKER->deck, 5));
   for (struct obj_data *soft = DECKER->deck->contains; soft; soft = soft->next_content)
-    if (GET_OBJ_TYPE(soft) == ITEM_PROGRAM)
+    if (GET_OBJ_TYPE(soft) == ITEM_PROGRAM && (GET_PROGRAM_TYPE(soft) > SOFT_SENSOR))
       send_to_icon(PERSONA, "%-30s^n Rating: %2d\r\n", GET_OBJ_NAME(soft), GET_OBJ_VAL(soft, 1));
     else if (GET_OBJ_TYPE(soft) == ITEM_DECK_ACCESSORY && GET_OBJ_VAL(soft, 0) == TYPE_FILE)
       send_to_icon(PERSONA, "%s^n\r\n", GET_OBJ_NAME(soft));
@@ -2671,14 +2673,16 @@ ACMD(do_software)
     strcpy(buf, "^cOther Software:^n\r\n");
     if (GET_OBJ_TYPE(cyberdeck) == ITEM_CUSTOM_DECK) {
       strcpy(buf2, "^cCustom Components:^n\r\n");
+    } else {
+      strcpy(buf2, "^cPersona Programs:^n\r\n");
     }
 
     bool has_other_software = FALSE;
-    bool has_custom_components = FALSE;
+    bool has_components = FALSE;
 
     const char *defaulted_string = PRF_FLAGGED(ch, PRF_SCREENREADER) ? "(defaulted)" : "*";
     for (struct obj_data *soft = cyberdeck->contains; soft; soft = soft->next_content) {
-      if (GET_OBJ_TYPE(soft) == ITEM_PROGRAM) {
+      if (GET_OBJ_TYPE(soft) == ITEM_PROGRAM && (GET_PROGRAM_TYPE(soft) > SOFT_SENSOR)) {
         has_other_software = TRUE;
         snprintf(ENDOF(buf), sizeof(buf) - strlen(buf), "%s^n Rating: %2d %s\r\n",
                  get_obj_name_with_padding(soft, 40),
@@ -2688,17 +2692,22 @@ ACMD(do_software)
         has_other_software = TRUE;
         snprintf(ENDOF(buf), sizeof(buf) - strlen(buf), "%s^n\r\n", GET_OBJ_NAME(soft));
       } else if (GET_OBJ_TYPE(soft) == ITEM_PART) {
-        has_custom_components = TRUE;
+        has_components = TRUE;
         snprintf(ENDOF(buf2), sizeof(buf2) - strlen(buf2), "%s Type: ^c%-24s^n (rating ^c%d^n)\r\n",
                 get_obj_name_with_padding(soft, 40),
                 parts[GET_PART_TYPE(soft)].name,
                 GET_PART_RATING(soft));
-      }
+      } else if ((GET_OBJ_TYPE(cyberdeck) == ITEM_CYBERDECK) && (GET_OBJ_TYPE(soft) == ITEM_PROGRAM) && (GET_PROGRAM_TYPE(soft) <= SOFT_SENSOR))
+        // Persona programs in store-bought decks are handled here as components
+        has_components = TRUE;
+        snprintf(ENDOF(buf), sizeof(buf) - strlen(buf), "%s^n Rating: %2d\r\n",
+                 get_obj_name_with_padding(soft, 40),
+                 GET_PROGRAM_RATING(soft);
     }
 
     if (has_other_software)
       send_to_char(buf, ch);
-    if (has_custom_components && GET_OBJ_TYPE(cyberdeck) == ITEM_CUSTOM_DECK)
+    if (has_components)
       send_to_char(buf2, ch);
   }
 }


### PR DESCRIPTION
In store-bought decks, persona programs were being displayed like regular programs. This has led to confusion, with several newbie deckers believing that persona programs aren't being loaded because they can't be set to default, but can be manually loaded once connected to the matrix. Persona programs in store-bought decks are actually used to set matrix attributes at the time of connection to the matrix, and so manually loading persona programs do nothing but use up active memory space.

This pull request makes the following changes:
1. persona programs in store-bought decks do not take up memory space
2. do not permit persona programs to be manually loaded when in the matrix
3. do not display persona programs with other software (instead, list them separately like components)

-Khai