### PR TITLE
Fix geas handling

### DIFF
--- a/src/act.informative.cpp
+++ b/src/act.informative.cpp
@@ -313,7 +313,9 @@ void show_obj_to_char(struct obj_data * object, struct char_data * ch, int mode)
       strlcat(buf, " (Plan)", sizeof(buf));
     if (GET_OBJ_VNUM(object) == 108 && !GET_OBJ_TIMER(object))
       strlcat(buf, " (Uncooked)", sizeof(buf));
-    if (GET_OBJ_TYPE(object) == ITEM_FOCUS && GET_FOCUS_BOND_TIME_REMAINING(object) == GET_IDNUM(ch))
+    if (GET_OBJ_TYPE(object) == ITEM_FOCUS && GET_FOCUS_GEAS(object) == GET_IDNUM(ch))
+      strlcat(buf, " ^Y(Geas)^n", sizeof(buf));
+    if (GET_OBJ_TYPE(object) == ITEM_WEAPON && WEAPON_IS_FOCUS(object) && GET_WEAPON_FOCUS_GEAS(object) == GET_IDNUM(ch))
       strlcat(buf, " ^Y(Geas)^n", sizeof(buf));
     if (GET_OBJ_TYPE(object) == ITEM_GUN_AMMO
         || (GET_OBJ_TYPE(object) == ITEM_DECK_ACCESSORY && GET_DECK_ACCESSORY_TYPE(object) == TYPE_PARTS))
@@ -372,8 +374,18 @@ void show_obj_to_char(struct obj_data * object, struct char_data * ch, int mode)
     else if (GET_OBJ_TYPE(object) == ITEM_FOCUS) {
       if (GET_FOCUS_ACTIVATED(object))
         strlcat(buf, " ^m(Activated Focus)^n", sizeof(buf));
-      if (GET_FOCUS_BONDED_TO(object) == GET_IDNUM(ch) && GET_FOCUS_BOND_TIME_REMAINING(object) == GET_IDNUM(ch))
+      if (GET_FOCUS_BONDED_TO(object) == GET_IDNUM(ch) && GET_FOCUS_GEAS(object) == GET_IDNUM(ch))
         strlcat(buf, " ^Y(Geas)^n", sizeof(buf));
+    }
+    else if (GET_OBJ_TYPE(object) == ITEM_WEAPON && WEAPON_IS_FOCUS(object) && WEAPON_FOCUS_USABLE_BY(object, ch)) {
+      if (GET_WEAPON_FOCUS_GEAS(object) == GET_IDNUM(ch))
+        strlcat(buf, " ^Y(Geas)^n", sizeof(buf));
+      
+      struct obj_data *wielded = NULL;
+      if (wielded = GET_EQ(ch, WEAR_WIELD) && wielded->item_number == object->item_number)
+        strlcat(buf, " ^m(Activated Focus)^n", sizeof(buf));
+      if (wielded = GET_EQ(ch, WEAR_HOLD) && wielded->item_number == object->item_number)
+        strlcat(buf, " ^m(Activated Focus)^n", sizeof(buf));
     }
 
     if (GET_OBJ_CONDITION(object) * 100 / MAX(1, GET_OBJ_BARRIER(object)) < 100)

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -83,7 +83,7 @@ extern bool player_is_dead_hardcore(long id);
 
 extern bool House_can_enter_by_idnum(long idnum, vnum_t house);
 
-extern void auto_repair_obj(struct obj_data *obj);
+extern void auto_repair_obj(struct obj_data *obj, idnum_t owner);
 
 // transport.cpp
 extern void boot_escalators();
@@ -5717,7 +5717,7 @@ void load_saved_veh()
 
         // Don't auto-repair cyberdecks until they're fully loaded.
         if (GET_OBJ_TYPE(obj) != ITEM_CYBERDECK)
-          auto_repair_obj(obj);
+          auto_repair_obj(obj, veh->owner);
 
         if (veh_version == VERSION_VEH_FILE) {
           // Since we're now saved the obj linked lists  in reverse order, in order to fix the stupid reordering on
@@ -5845,7 +5845,7 @@ void load_saved_veh()
         snprintf(buf, sizeof(buf), "%s/AmmoWeap", sect_name);
         GET_AMMOBOX_WEAPON(ammo) = data.GetInt(buf, 0);
         ammo->restring = str_dup(get_ammobox_default_restring(ammo));
-        auto_repair_obj(ammo);
+        auto_repair_obj(ammo, veh->owner);
         obj_to_obj(ammo, obj);
       }
       snprintf(buf, sizeof(buf), "%s/Vnum", sect_name);
@@ -5860,7 +5860,7 @@ void load_saved_veh()
           snprintf(buf, sizeof(buf), "%s/Value %d", sect_name, x);
           GET_OBJ_VAL(weapon, x) = data.GetInt(buf, GET_OBJ_VAL(weapon, x));
         }
-        auto_repair_obj(weapon);
+        auto_repair_obj(weapon, veh->owner);
         obj_to_obj(weapon, obj);
         veh->usedload += GET_OBJ_WEIGHT(weapon);
       }
@@ -6017,7 +6017,7 @@ void load_consist(void)
 
             // Don't auto-repair cyberdecks until they're fully loaded.
             if (GET_OBJ_TYPE(obj) != ITEM_CYBERDECK)
-              auto_repair_obj(obj);
+              auto_repair_obj(obj, 0);
 
             snprintf(buf, sizeof(buf), "%s/Inside", sect_name);
             inside = data.GetInt(buf, 0);

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -32,7 +32,7 @@
 extern char *cleanup(char *dest, const char *src);
 extern void ASSIGNMOB(long mob, SPECIAL(fname));
 extern void add_phone_to_list(struct obj_data *obj);
-extern void auto_repair_obj(struct obj_data *obj);
+extern void auto_repair_obj(struct obj_data *obj, idnum_t owner);
 extern void handle_weapon_attachments(struct obj_data *obj);
 extern void raw_store_mail(long to, long from_id, const char *from_name, const char *message_pointer);
 extern bool player_is_dead_hardcore(long id);
@@ -194,7 +194,7 @@ bool House_load(struct house_control_rec *house)
 
       // Don't auto-repair cyberdecks until they're fully loaded.
       if (GET_OBJ_TYPE(obj) != ITEM_CYBERDECK)
-        auto_repair_obj(obj);
+        auto_repair_obj(obj, house->owner);
 
       snprintf(buf, sizeof(buf), "%s/Inside", sect_name);
       inside = data.GetInt(buf, 0);

--- a/src/limits.cpp
+++ b/src/limits.cpp
@@ -960,13 +960,24 @@ void point_update(void)
         } else {
           if (force * 100 > GET_REAL_MAG(i) * 2 && success_test(GET_REAL_MAG(i) / 100, force / 2) < 1) {
             int num = number(1, total);
-            struct obj_data *foci = NULL;
-            for (int x = 0; x < NUM_WEARS && !foci; x++)
-              if (GET_EQ(i, x) && GET_OBJ_TYPE(GET_EQ(i, x)) == ITEM_FOCUS && GET_FOCUS_BONDED_TO(GET_EQ(i, x)) == GET_IDNUM(i) && GET_FOCUS_ACTIVATED(GET_EQ(i, x)) && !GET_FOCUS_BOND_TIME_REMAINING(GET_EQ(i, x)) && !--num)
-                foci = GET_EQ(i, x);
-            if (foci) {
+            struct obj_data *focus_geas = NULL;
+            for (int x = 0; x < NUM_WEARS && !focus_geas; x++) {
+              if (!(focus = GET_EQ(i, x)))
+                continue;
+
+              if (GET_OBJ_TYPE(focus) == ITEM_FOCUS && GET_FOCUS_BONDED_TO(focus) == GET_IDNUM(i) && GET_FOCUS_ACTIVATED(focus)
+                  && !GET_FOCUS_BOND_TIME_REMAINING(focus) && !GET_FOCUS_GEAS(focus) && !--num) {
+                focus_geas = focus;
+              }
+              else if ((x == WEAR_WIELD || x == WEAR_HOLD) && GET_OBJ_TYPE(focus) == ITEM_WEAPON && WEAPON_IS_FOCUS(focus)
+                  && WEAPON_FOCUS_USABLE_BY(focus, i) && !GET_WEAPON_FOCUS_GEAS(focus) && !--num) {
+                focus_geas = focus;
+              }
+            }
+
+            if (focus_geas) {
               send_to_char(i, "^RYou feel some of your magic becoming locked in %s!^n Quick, take off all your foci before it happens again!\r\n", GET_OBJ_NAME(foci));
-              GET_OBJ_VAL(foci, 9) = GET_IDNUM(i);
+              GET_FOCUS_GEAS(focus_geas) = GET_IDNUM(i);
               magic_loss(i, 100, FALSE);
             }
           }

--- a/src/newdb.cpp
+++ b/src/newdb.cpp
@@ -45,7 +45,7 @@ extern void handle_weapon_attachments(struct obj_data *obj);
 extern int get_deprecated_cybereye_essence_cost(struct obj_data *obj);
 extern void price_cyber(struct obj_data *obj);
 
-void auto_repair_obj(struct obj_data *obj);
+void auto_repair_obj(struct obj_data *obj, idnum_t owner);
 
 void save_adept_powers_to_db(struct char_data *player);
 void save_spells_to_db(struct char_data *player);
@@ -677,7 +677,7 @@ bool load_char(const char *name, char_data *ch, bool logon)
         */
         inside = atoi(row[17]);
 
-        auto_repair_obj(obj);
+        auto_repair_obj(obj, GET_IDNUM(ch));
 
         // Since we're now reading rows from the db in reverse order, in order to fix the stupid reordering on
         // every binary execution, the previous algorithm did not work, as it relied on getting the container obj
@@ -742,7 +742,7 @@ bool load_char(const char *name, char_data *ch, bool logon)
         }
         if (row[15] && *row[15])
           obj->restring = str_dup(row[15]);
-        auto_repair_obj(obj);
+        auto_repair_obj(obj, GET_IDNUM(ch));
         obj_to_bioware(obj, ch);
       }
     }
@@ -791,7 +791,7 @@ bool load_char(const char *name, char_data *ch, bool logon)
         GET_OBJ_ATTEMPT(obj) = atoi(row[21]);
         GET_OBJ_CONDITION(obj) = atoi(row[22]);
 
-        auto_repair_obj(obj);
+        auto_repair_obj(obj, GET_IDNUM(ch));
 
         // Since we're now reading rows from the db in reverse order, in order to fix the stupid reordering on
         // every binary execution, the previous algorithm did not work, as it relied on getting the container obj
@@ -904,7 +904,7 @@ bool load_char(const char *name, char_data *ch, bool logon)
         GET_OBJ_ATTEMPT(obj) = atoi(row[20]);
         GET_OBJ_CONDITION(obj) = atoi(row[21]);
 
-        auto_repair_obj(obj);
+        auto_repair_obj(obj, GET_IDNUM(ch));
 
         // Since we're now reading rows from the db in reverse order, in order to fix the stupid reordering on
         // every binary execution, the previous algorithm did not work, as it relied on getting the container obj
@@ -1029,12 +1029,12 @@ bool load_char(const char *name, char_data *ch, bool logon)
 
   // Self-repair their gear. Don't worry about contents- it's recursive.
   for (struct obj_data *obj = ch->carrying; obj; obj = obj->next_content) {
-    auto_repair_obj(obj);
+    auto_repair_obj(obj, GET_IDNUM(ch));
   }
 
   for (int i = 0; i < NUM_WEARS; i++) {
     if (GET_EQ(ch, i))
-      auto_repair_obj(GET_EQ(ch, i));
+      auto_repair_obj(GET_EQ(ch, i), GET_IDNUM(ch));
   }
 
   set_natural_vision_for_race(ch);
@@ -2162,10 +2162,10 @@ if (proto_value != value) {                                                     
   value = proto_value;                                                                                                      \
 }
 
-void auto_repair_obj(struct obj_data *obj) {
+void auto_repair_obj(struct obj_data *obj, idnum_t owner) {
   // Go through its contents first and rectify them.
   for (struct obj_data *contents = obj->contains; contents; contents = contents->next_content) {
-    auto_repair_obj(contents);
+    auto_repair_obj(contents, owner);
   }
 
   int old_storage;
@@ -2218,6 +2218,12 @@ void auto_repair_obj(struct obj_data *obj) {
     case ITEM_FOCUS:
       FORCE_PROTO_VALUE("focus", GET_FOCUS_TYPE(obj), GET_FOCUS_TYPE(&obj_proto[rnum]));
       FORCE_PROTO_VALUE("focus", GET_FOCUS_FORCE(obj), GET_FOCUS_FORCE(&obj_proto[rnum]));
+
+      // Geas now uses its own field instead of reusing GET_FOCUS_BOND_TIME_REMAINING
+      if (GET_FOCUS_BOND_TIME_REMAINING(obj) == owner) {
+        GET_FOCUS_GEAS(obj) = owner;
+        GET_FOCUS_BOND_TIME_REMAINING(obj) = 0;
+      }
       break;
     case ITEM_MOD:
       // Mods don't ever get changed, so we clamp them aggressively.

--- a/src/newmagic.cpp
+++ b/src/newmagic.cpp
@@ -6085,7 +6085,8 @@ void disp_geas_menu(struct descriptor_data *d)
     if (GET_OBJ_TYPE(obj) == ITEM_FOCUS && GET_FOCUS_GEAS(obj) == GET_IDNUM(CH)) {
       send_to_char(CH, "%d) %s\r\n", x++, GET_OBJ_NAME(obj));
     }
-    else if ((i == WEAR_WIELD || i == WEAR_HOLD) && GET_OBJ_TYPE(obj) == ITEM_WEAPON && GET_WEAPON_FOCUS_GEAS(obj) == GET_IDNUM(CH)) {
+    else if ((i == WEAR_WIELD || i == WEAR_HOLD) && GET_OBJ_TYPE(obj) == ITEM_WEAPON
+             && WEAPON_IS_FOCUS(obj) && GET_WEAPON_FOCUS_GEAS(obj) == GET_IDNUM(CH)) {
       send_to_char(CH, "%d) %s\r\n", x++, GET_OBJ_NAME(obj));
     }
   }
@@ -6286,7 +6287,7 @@ void init_parse(struct descriptor_data *d, char *arg)
             focus_geas = obj;
           }
           else if ((i == WEAR_WIELD || i == WEAR_HOLD) && GET_OBJ_TYPE(obj) == ITEM_WEAPON
-                   && GET_WEAPON_FOCUS_GEAS(obj) == GET_IDNUM(CH) && --number < 0) {
+                   && WEAPON_IS_FOCUS(obj) && GET_WEAPON_FOCUS_GEAS(obj) == GET_IDNUM(CH) && --number < 0) {
             focus_geas = obj;
           }
         }

--- a/src/newmagic.cpp
+++ b/src/newmagic.cpp
@@ -6077,11 +6077,18 @@ void disp_geas_menu(struct descriptor_data *d)
 {
   CLS(CH);
   int x = 0;
-  for (int i = 0; i < NUM_WEARS; i++)
-    if (GET_EQ(CH, i)
-        && GET_OBJ_TYPE(GET_EQ(CH, i)) == ITEM_FOCUS
-        && GET_OBJ_VAL(GET_EQ(CH, i), 9) == GET_IDNUM(CH))
-      send_to_char(CH, "%d) %s\r\n", x++, GET_OBJ_NAME(GET_EQ(CH, i)));
+  struct obj_data *obj = NULL;
+  for (int i = 0; i < NUM_WEARS; i++) {
+    if (!(obj = GET_EQ(CH, i)))
+      continue;
+
+    if (GET_OBJ_TYPE(obj) == ITEM_FOCUS && GET_FOCUS_GEAS(obj) == GET_IDNUM(CH)) {
+      send_to_char(CH, "%d) %s\r\n", x++, GET_OBJ_NAME(obj));
+    }
+    else if ((i == WEAR_WIELD || i == WEAR_HOLD) && GET_OBJ_TYPE(obj) == ITEM_WEAPON && GET_WEAPON_FOCUS_GEAS(obj) == GET_IDNUM(CH)) {
+      send_to_char(CH, "%d) %s\r\n", x++, GET_OBJ_NAME(obj));
+    }
+  }
   send_to_char("q) Quit Initiation\r\nSelect geas to shed: ", CH);
   d->edit_mode = INIT_GEAS;
 }
@@ -6270,22 +6277,28 @@ void init_parse(struct descriptor_data *d, char *arg)
       } else if (number < 0) {
         send_to_char("Invalid Response. Select geas to shed: ", CH);
       } else {
-        for (i = 0; i < NUM_WEARS; i++)
-          if (GET_EQ(CH, i)
-              && GET_OBJ_TYPE(GET_EQ(CH, i)) == ITEM_FOCUS
-              && GET_OBJ_VAL(GET_EQ(CH, i), 9) == GET_IDNUM(CH)
-              && --number < 0) {
-            obj = GET_EQ(CH, i);
-            break;
+        struct obj_data *focus_geas = NULL;
+        for (i = 0; i < NUM_WEARS && (number >= 0); i++) {
+          if (!(obj = GET_EQ(CH, i)))
+            continue;
+
+          if (GET_OBJ_TYPE(obj) == ITEM_FOCUS && GET_FOCUS_GEAS(obj) == GET_IDNUM(CH) && --number < 0) {
+            focus_geas = obj;
           }
-        if (!obj) {
+          else if ((i == WEAR_WIELD || i == WEAR_HOLD) && GET_OBJ_TYPE(obj) == ITEM_WEAPON
+                   && GET_WEAPON_FOCUS_GEAS(obj) == GET_IDNUM(CH) && --number < 0) {
+            focus_geas = obj;
+          }
+        }
+
+        if (!focus_geas) {
           send_to_char("You don't have that many geasa. Select geas to shed: ", CH);
           return;
         }
         init_cost(CH, TRUE);
         GET_GRADE(CH)++;
         GET_SETTABLE_REAL_MAG(CH) += 100;
-        GET_OBJ_VAL(obj, 9) = 0;
+        GET_FOCUS_GEAS(focus_geas) = 0;
         if (GET_TRADITION(CH) == TRAD_ADEPT)
           GET_PP(CH) += 100;
         send_to_char(CH, "You feel your magic return from that object, once again binding to your spirit.\r\n", CH);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2078,9 +2078,18 @@ void magic_loss(struct char_data *ch, int magic, bool msg)
     snprintf(buf, sizeof(buf), "UPDATE pfiles SET Tradition=%d WHERE idnum=%ld;", TRAD_MUNDANE, GET_IDNUM(ch));
     mysql_wrapper(mysql, buf);
 
-    for (int i = 0; i < NUM_WEARS; i++)
-      if (GET_EQ(ch, i) && GET_OBJ_TYPE(GET_EQ(ch, i)) == ITEM_FOCUS && GET_OBJ_VAL(GET_EQ(ch, i), 2) == GET_IDNUM(ch))
-        GET_OBJ_VAL(GET_EQ(ch, i), 2) = GET_OBJ_VAL(GET_EQ(ch, i), 4) =  GET_OBJ_VAL(GET_EQ(ch, i), 9) = 0;
+    struct obj_data *focus;
+    for (int i = 0; i < NUM_WEARS; i++) {
+      if (!(focus = GET_EQ(ch, i)))
+        continue;
+
+      if (GET_OBJ_TYPE(focus) == ITEM_FOCUS && GET_FOCUS_BONDED_TO(focus) == GET_IDNUM(ch)) {
+        GET_FOCUS_BONDED_TO(focus) = GET_FOCUS_ACTIVATED(focus) =  GET_FOCUS_GEAS(focus) = 0;
+      }
+      else if ((x == WEAR_WIELD || x == WEAR_HOLD) && GET_OBJ_TYPE(focus) == ITEM_WEAPON && WEAPON_IS_FOCUS(focus) && GET_WEAPON_FOCUS_BONDED_BY(focus, ch)) {
+        GET_WEAPON_FOCUS_BONDED_BY(focus) = GET_WEAPON_FOCUS_GEAS(focus) = 0;
+      }
+    }
 
     struct sustain_data *nextsust;
 

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -920,6 +920,7 @@ bool CAN_SEE_ROOM_SPECIFIED(struct char_data *subj, struct char_data *obj, struc
 #define GET_WEAPON_ATTACH_UNDER_VNUM(weapon)   (GET_OBJ_VAL((weapon), 9))
 #define GET_WEAPON_FOCUS_BONDED_BY(weapon)     (GET_OBJ_VAL((weapon), 9)) /* Only melee weapons can be weapon foci, so reusing attach is OK. */
 #define GET_WEAPON_POSSIBLE_FIREMODES(weapon)  (GET_OBJ_VAL((weapon), 10))
+#define GET_WEAPON_FOCUS_GEAS(weapon)          (GET_OBJ_VAL((weapon), 10)) /* Only melee weapons can be weapon foci, same slot as GET_FOCUS_GEAS */
 #define GET_WEAPON_FIREMODE(weapon)            (GET_OBJ_VAL((weapon), 11))
 #define GET_WEAPON_INTEGRAL_RECOIL_COMP(weap)  (GET_OBJ_ATTEMPT((weap)))
 #define GET_WEAPON_FULL_AUTO_COUNT(weapon)     (GET_OBJ_TIMER((weapon)))
@@ -1121,6 +1122,7 @@ bool WEAPON_FOCUS_USABLE_BY(struct obj_data *focus, struct char_data *ch);
 #define GET_FOCUS_ACTIVATED(focus)                (GET_OBJ_VAL((focus), 4))
 #define GET_FOCUS_TRADITION(focus)                (GET_OBJ_VAL((focus), 5))
 #define GET_FOCUS_BOND_TIME_REMAINING(focus)      (GET_OBJ_VAL((focus), 9))
+#define GET_FOCUS_GEAS(focus)                     (GET_OBJ_VAL((focus), 10))
 
 // ITEM_PATCH convenience defines
 #define GET_PATCH_TYPE(patch)                      (GET_OBJ_VAL((patch), 0))


### PR DESCRIPTION
Bugfix: Using GET_FOCUS_BOND_TIME_REMAINING to track geas could cause the geas to be lost if the character accidentally targets that focus with a do_bond action. This fix moves geas tracking to a different field accessed via GET_FOCUS_GEAS.

Bugfix: In addition, geas couldn't be attached to weapon foci. Because all uses of GET_WEAPON_POSSIBLE_FIREMODES are prefaced with IS_GUN checks, we're able to reuse that field for weapon foci geas. Conveniently, we're able to use the same entry position for both worn foci and weapon foci geas (i.e., GET_FOCUS_GEAS can be used in place of GET_WEAPON_FOCUS_GEAS).

While we're at it, we should show that wielded weapon foci that are WEAPON_FOCUS_USABLE_BY the wielder are in fact activated.

- Khai