### PR TITLE
Make handling of perma/temp attribute modifiers consistent, also fix troll dermal bonus

### DIFF
--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -721,7 +721,7 @@ void affect_total(struct char_data * ch)
   }
 
   if (GET_RACE(ch) == RACE_TROLL || GET_RACE(ch) == RACE_MINOTAUR)
-    GET_IMPACT(ch)++;
+    GET_BOD(ch)++;
 
   /* effects of cyberware */
   for (cyber = ch->cyberware; cyber; cyber = cyber->next_content)


### PR DESCRIPTION
Previously, some permanent bonuses (i.e., those that are untimed) were not subject to caps, and some temporary bonuses (i.e., those with time limits and typically have some type of crash effect when the boost wears off) were subject to caps. This makes it so that all permanent modifiers are calculated before caps and all temporary modifiers are calculated after caps.

This fixes nerve strike so that it can now disable somebody that has adept improved quickness.

This does negatively impact troll/giant/cyclops adepts that could previously reach 21/22/23 permanent strength (adept improved strength 6, muscle augmentation 4, and a suprathyroid gland), but would now be capped to 20. Question: do we want to increase the cap to support these character types?

While we're at it, this also fixes the troll/minotaur dermal skin bonus, which should provide +1 body, not impact (SR3, pg 56).