### PR TITLE
Fix reaction/initiative aug/magic compatibility

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -14,9 +14,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    # Update apt cache.
+    - name: Update apt cache.
+      run: sudo apt update
+
     # Install dependencies.
     - name: Install Boost filesystem and libcurl4
-      run: sudo apt install libboost-filesystem-dev libcurl4-openssl-dev 
+      run: sudo apt install -y libboost-filesystem-dev libcurl4-openssl-dev 
 
     # Populate our config file with dummy values.
     - name: Write mysql_config.cpp
@@ -27,27 +31,8 @@ jobs:
           const char *mysql_user =     "user";       \
           const char *mysql_db =       "db";       ' \
           > mysql_config.cpp
-      
-    # Restore our built artifact cache, if any available.
-    - name: Restore cached artifacts
-      id: cache-artifact-restore
-      uses: actions/cache/restore@v3
-      with:
-        path: |
-          src/*.d
-          src/*.o
-        key: cache-key-${{ github.event.number }}
-    
+
+    # Compile the game.
     - name: make
       working-directory: ./src
       run: make
-
-    # Save any compiled dependencies for next time.
-    - name: Save cached artifacts
-      id: cache-artifact-save
-      uses: actions/cache/save@v3
-      with:
-        path: |
-          src/*.d
-          src/*.o
-        key: ${{ steps.cache-artifact-restore.outputs.cache-primary-key }}

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -5599,21 +5599,7 @@ void roll_individual_initiative(struct char_data *ch)
 {
   if (AWAKE(ch))
   {
-    // While rigging, riggers receive only the modifications given them by the vehicle control rig (see Vehicles and Drones, p. 130) they are using.
-    if (IS_RIGGING(ch)) {
-      // Note: Dice don't explode in initiative rolls. This is your base value.
-      GET_INIT_ROLL(ch) = GET_REAL_REA(ch) + dice(1, 6);
-
-      for (struct obj_data *rig = ch->cyberware; rig; rig = rig->next_content) {
-        if (GET_CYBERWARE_TYPE(rig) == CYB_VCR) {
-          // Each level adds +2 to the user’s Reaction and +1D6 Initiative dice while rigging. (SR3 p301)
-          GET_INIT_ROLL(ch) += (GET_CYBERWARE_RATING(rig) * 2) + dice(GET_CYBERWARE_RATING(rig), 6);
-          break;
-        }
-      }
-    }
-    else
-      GET_INIT_ROLL(ch) = roll_default_initiative(ch);
+    GET_INIT_ROLL(ch) = roll_default_initiative(ch);
     GET_INIT_ROLL(ch) -= damage_modifier(ch, buf, sizeof(buf));
     if (AFF_FLAGGED(ch, AFF_ACTION)) {
       GET_INIT_ROLL(ch) -= 10;

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -1013,7 +1013,7 @@ void affect_total(struct char_data * ch)
     GET_CONTROL(ch) += GET_REA(ch);
 
     // also adds to initiative dice
-    mental_init += has_rig;
+    mental_init_dice += has_rig;
 
     // but reduces hacking pool
     GET_HACKING(ch) -= has_rig;

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -793,8 +793,8 @@ void affect_total(struct char_data * ch)
   }
 
   // We want the higher of either cyber+bio or magic/adept
-  sbyte aug_rea = GET_REA(ch);
-  sbyte aug_init_dice = GET_INIT_DICE(ch);
+  int aug_rea = GET_REA(ch);
+  int aug_init_dice = GET_INIT_DICE(ch);
   GET_REA(ch) = 0;
   GET_INIT_DICE(ch) = 0;
 

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -1010,7 +1010,7 @@ void affect_total(struct char_data * ch)
   if (has_rig) {
     // a VCR adds to reaction, thus control pool
     mental_rea += 2 * has_rig;
-    GET_CONTROL(ch) += GET_REA(ch);
+    GET_CONTROL(ch) += mental_rea;
 
     // also adds to initiative dice
     mental_init_dice += has_rig;

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -777,10 +777,6 @@ void affect_total(struct char_data * ch)
                       cyber->obj_flags.bitvector, TRUE);
   }
 
-  for (sust = GET_SUSTAINED(ch); sust; sust = sust->next)
-    if (!sust->caster)
-      spell_modify(ch, sust, TRUE);
-
   for (struct obj_data *bio = ch->bioware; bio; bio = bio->next_content) {
     switch (GET_BIOWARE_TYPE(bio)) {
       case BIO_PAINEDITOR:
@@ -796,12 +792,21 @@ void affect_total(struct char_data * ch)
     }
   }
 
+  // We want the higher of either cyber+bio or magic/adept
+  sbyte aug_rea = GET_REA(ch);
+  sbyte aug_init_dice = GET_INIT_DICE(ch);
+  GET_REA(ch) = 0;
+  GET_INIT_DICE(ch) = 0;
+
+  /* effects of magic */
+  for (sust = GET_SUSTAINED(ch); sust; sust = sust->next)
+    if (!sust->caster)
+      spell_modify(ch, sust, TRUE);
+
   if (GET_TRADITION(ch) == TRAD_ADEPT)
   {
-    if (GET_INIT_DICE(ch) == 0)
-      GET_INIT_DICE(ch) += MIN(3, GET_POWER(ch, ADEPT_REFLEXES));
-    if (GET_REAL_REA(ch) == GET_REA(ch))
-      GET_REA(ch) += 2*MIN(3, GET_POWER(ch, ADEPT_REFLEXES));
+    GET_INIT_DICE(ch) += MIN(3, GET_POWER(ch, ADEPT_REFLEXES));
+    GET_REA(ch) += 2*MIN(3, GET_POWER(ch, ADEPT_REFLEXES));
     GET_BOD(ch) += GET_POWER(ch, ADEPT_IMPROVED_BOD);
     GET_QUI(ch) += GET_POWER(ch, ADEPT_IMPROVED_QUI);
     GET_STR(ch) += GET_POWER(ch, ADEPT_IMPROVED_STR);
@@ -822,6 +827,10 @@ void affect_total(struct char_data * ch)
       AFF_FLAGS(ch).SetBit(AFF_VISION_MAG_3);
     }
   }
+
+  // We want the higher of either cyber+bio or magic/adept
+  GET_REA(ch) = (GET_REA(ch) > aug_rea) ? GET_REA(ch) : aug_rea;
+  GET_INIT_DICE(ch) = (GET_INIT_DICE(ch) > aug_init_dice) ? GET_INIT_DICE(ch) : aug_init_dice;
 
   apply_drug_modifiers_to_ch(ch);
 

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -200,8 +200,9 @@ void roll_matrix_init(struct matrix_icon *icon)
   int init_dice = 1;
   if (icon->decker && icon->decker->ch)
   {
-    icon->initiative = GET_REA(icon->decker->ch) + (icon->decker->response * 2) + (icon->decker->reality ? 2 : 0);
-    init_dice += GET_INIT_DICE(icon->decker->ch) + icon->decker->response + (icon->decker->reality ? 1 : 0);
+    // Matrix pg 18 & 24, available bonuses are response increase, reality filter, and hot asist
+    icon->initiative = GET_REA(icon->decker->ch) + (icon->decker->response * 2) + (icon->decker->reality ? 2 : 0) + (icon->decker->asist[0] ? 2 : 0);
+    init_dice += GET_INIT_DICE(icon->decker->ch) + icon->decker->response + (icon->decker->reality ? 1 : 0) + (icon->decker->asist[0] ? 1 : 0);
   } else
   {
     icon->initiative = icon->ic.rating;

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -197,19 +197,19 @@ bool spawn_ic(struct matrix_icon *target, vnum_t ic_vnum, int triggerstep) {
 
 void roll_matrix_init(struct matrix_icon *icon)
 {
-  int x = 1;
+  int init_dice = 1;
   if (icon->decker && icon->decker->ch)
   {
-    icon->initiative = GET_REAL_REA(icon->decker->ch) + (icon->decker->response * 2) + (icon->decker->reality ? 2 : 0);
-    x += icon->decker->response + (icon->decker->reality ? 1 : 0);
+    icon->initiative = GET_REA(icon->decker->ch) + (icon->decker->response * 2) + (icon->decker->reality ? 2 : 0);
+    init_dice += GET_INIT_DICE(icon->decker->ch) + icon->decker->response + (icon->decker->reality ? 1 : 0);
   } else
   {
     icon->initiative = icon->ic.rating;
     if (matrix[icon->in_host].shutdown)
       icon->initiative--;
-    x += matrix[icon->in_host].color;
+    init_dice += matrix[icon->in_host].color;
   }
-  icon->initiative += dice(x, 6);
+  icon->initiative += dice(init_dice, 6);
   icon->initiative -= matrix[icon->in_host].pass * 10;
 }
 


### PR DESCRIPTION
M&M pg79:
> Magic effects, such as adept powers and spells, are usually complementary to bioware effects.

Further down the page:
> If Reaction/Initiative-boosting bioware is used in conjunction with adept powers or spells that boost Reaction and Initiative, only the highest bonus applies.

So, this PR does the following:
1. Muscle toner and cerebral boosters, while they affect the reaction calculation, do not directly augment the reaction stat, thus they should be compatible with reaction increasing magics.
2. The higher of either total reaction augmentations -or- reaction magic should be applied.
3. The higher of either total initiative dice augmentations -or- initiative dice magic should be applied.