### PR TITLE
Fix adept/spell reaction/initiative compatibility

### DIFF
--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -806,8 +806,10 @@ void affect_total(struct char_data * ch)
 
   if (GET_TRADITION(ch) == TRAD_ADEPT)
   {
-    GET_INIT_DICE(ch) += MIN(3, GET_POWER(ch, ADEPT_REFLEXES));
-    GET_REA(ch) += 2*MIN(3, GET_POWER(ch, ADEPT_REFLEXES));
+    // Adept Improved Reflexes doesn't stack with other magical increases to rea/init (SR3 pg 169)
+    // Let the char have the higher modifier for each
+    GET_INIT_DICE(ch) = MAX(GET_INIT_DICE(ch), MIN(3, GET_POWER(ch, ADEPT_REFLEXES)));
+    GET_REA(ch) = MAX(GET_REA(ch), 2*MIN(3, GET_POWER(ch, ADEPT_REFLEXES)));
     GET_BOD(ch) += GET_POWER(ch, ADEPT_IMPROVED_BOD);
     GET_QUI(ch) += GET_POWER(ch, ADEPT_IMPROVED_QUI);
     GET_STR(ch) += GET_POWER(ch, ADEPT_IMPROVED_STR);


### PR DESCRIPTION
Missed a rule in the previous PR: the adept improved reflexes power doesn't stack with other magical increases to reaction/initiative. This PR interprets that as letting the character have whichever bonus is higher for reaction and initiative independently, e.g. if an adept has the increase reflexes +3 spell cast on them (+3d6 init) and then activates adept improved reflexes 2 (+4 rea +2d6 init), then their total bonuses are +4 rea +3d6 init.  