### PR TITLE
More drug fixes

### DIFF
--- a/src/act.informative.cpp
+++ b/src/act.informative.cpp
@@ -7116,15 +7116,15 @@ ACMD(do_status)
     }
     else if (GET_DRUG_ADDICT(targ, i) > 0) {
       if (GET_DRUG_STAGE(targ, i) == DRUG_STAGE_GUIDED_WITHDRAWAL) {
-        snprintf(ENDOF(aff_buf), sizeof(aff_buf) - strlen(aff_buf), "  ^y%s Withdrawal (Guided, Edge %d): %s remaining^n\r\n",
+        snprintf(ENDOF(aff_buf), sizeof(aff_buf) - strlen(aff_buf), "  ^y%s Withdrawal (Guided, Edge %d): %s until next test^n\r\n",
                      drug_types[i].name,
                      GET_DRUG_ADDICTION_EDGE(targ, i),
-                     get_time_until_withdrawal_ends(targ, i));
+                     get_time_until_withdrawal_test(targ, i));
       } else if (GET_DRUG_STAGE(targ, i) == DRUG_STAGE_FORCED_WITHDRAWAL) {
-        snprintf(ENDOF(aff_buf), sizeof(aff_buf) - strlen(aff_buf), "  ^Y%s Withdrawal (Forced, Edge %d): %s remaining^n\r\n",
+        snprintf(ENDOF(aff_buf), sizeof(aff_buf) - strlen(aff_buf), "  ^Y%s Withdrawal (Forced, Edge %d): %s until next test^n\r\n",
                      drug_types[i].name,
                      GET_DRUG_ADDICTION_EDGE(targ, i),
-                     get_time_until_withdrawal_ends(targ, i));
+                     get_time_until_withdrawal_test(targ, i));
       } else {
         snprintf(ENDOF(aff_buf), sizeof(aff_buf) - strlen(aff_buf), "  Addicted to %s (Edge: %d)\r\n",
                      drug_types[i].name,

--- a/src/drugs.cpp
+++ b/src/drugs.cpp
@@ -1042,7 +1042,7 @@ const char *get_time_until_withdrawal_test(struct char_data *ch, int drug_id) {
   static char time_buf[20];
 
   time_t time_since_last_fix = time(0) - GET_DRUG_LAST_FIX(ch, drug_id);
-  time_t irl_secs = time_since_last_fix - (GET_DRUG_LAST_WITHDRAWAL_TICK(ch, drug_id) * SECS_PER_MUD_DAY);
+  time_t irl_secs = (GET_DRUG_LAST_WITHDRAWAL_TICK(ch, drug_id) * SECS_PER_MUD_DAY) - time_since_last_fix;
   time_t irl_mins = (irl_secs / 60);
 
   if (irl_secs >= 60)

--- a/src/drugs.cpp
+++ b/src/drugs.cpp
@@ -1038,13 +1038,12 @@ void update_withdrawal_flags(struct char_data *ch) {
   affect_total(ch);
 }
 
-const char *get_time_until_withdrawal_ends(struct char_data *ch, int drug_id) {
+const char *get_time_until_withdrawal_test(struct char_data *ch, int drug_id) {
   static char time_buf[20];
 
-  // How many days must elapse in total before we're off the drug?
-  int ig_days = GET_DRUG_ADDICTION_EDGE(ch, drug_id);
-  int irl_secs = ig_days * SECS_PER_MUD_DAY;
-  int irl_mins = (irl_secs / 60);
+  time_t time_since_last_fix = time(0) - GET_DRUG_LAST_FIX(ch, drug_id);
+  time_t irl_secs = time_since_last_fix - (GET_DRUG_LAST_WITHDRAWAL_TICK(ch, drug_id) * SECS_PER_MUD_DAY);
+  time_t irl_mins = (irl_secs / 60);
 
   if (irl_secs >= 60)
     snprintf(time_buf, sizeof(time_buf), "%d minute%s", irl_mins, irl_mins != 1 ? "s" : "");

--- a/src/drugs.cpp
+++ b/src/drugs.cpp
@@ -302,6 +302,7 @@ bool process_drug_point_update_tick(struct char_data *ch) {
       // Onset them and set when their last fix was (used for withdrawal calculations).
       GET_DRUG_STAGE(ch, drug_id) = DRUG_STAGE_ONSET;
       GET_DRUG_LAST_FIX(ch, drug_id) = current_time;
+      GET_DRUG_LAST_WITHDRAWAL_TICK(ch, drug_id) = drug_types[drug_id].fix_factor;
 
       // Process increases to addiction and tolerance, and also deal bod damage.
       if (_process_edge_and_tolerance_changes_for_applied_dose(ch, drug_id)) {
@@ -589,8 +590,7 @@ void process_withdrawal(struct char_data *ch) {
               seek_drugs(ch, drug_id);
             }
             
-            // Took drugs, so reset timer and don't tick down edge
-            GET_DRUG_LAST_WITHDRAWAL_TICK(ch, drug_id) = drug_types[drug_id].fix_factor;
+            // Took drugs, so don't tick down edge
             continue;
           }
 
@@ -1068,7 +1068,6 @@ void _put_char_in_withdrawal(struct char_data *ch, int drug_id, bool is_guided) 
     GET_DRUG_STAGE(ch, drug_id) = DRUG_STAGE_FORCED_WITHDRAWAL;
   }
 
-  GET_DRUG_LAST_WITHDRAWAL_TICK(ch, drug_id) = drug_types[drug_id].fix_factor;
   GET_DRUG_ADDICTION_TICK_COUNTER(ch, drug_id) = 0;
   update_withdrawal_flags(ch);
 }

--- a/src/drugs.hpp
+++ b/src/drugs.hpp
@@ -11,7 +11,7 @@ void    render_drug_info_for_targ(struct char_data *ch, struct char_data *targ);
 void    process_withdrawal(struct char_data *ch);
 void    attempt_safe_withdrawal(struct char_data *ch, const char *target_arg);
 float   get_drug_heal_multiplier(struct char_data *ch);
-const char* get_time_until_withdrawal_ends(struct char_data *ch, int drug_id);
+const char* get_time_until_withdrawal_test(struct char_data *ch, int drug_id);
 
 void    reset_all_drugs_for_char(struct char_data *ch);
 void    clear_all_drug_data_for_char(struct char_data *ch);

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -836,7 +836,9 @@ void affect_total(struct char_data * ch)
   GET_REA(ch) = (GET_REA(ch) > aug_rea) ? GET_REA(ch) : aug_rea;
   GET_INIT_DICE(ch) = (GET_INIT_DICE(ch) > aug_init_dice) ? GET_INIT_DICE(ch) : aug_init_dice;
 
-  // Except for VCRs, reaction/initiative augmentations don't apply to rigging (R3 pg 27)
+  // Except for VCRs, reaction/initiative cyber/bio don't apply to rigging (R3 pg 27)
+  // R3 pg 28 says physical reaction spells apply, but they don't exist
+  //   For general magic/mundane balance, maybe better to treat spells/powers like bio 
   int rigger_rea = 0, rigger_init_dice = 0;
 
   // Let drug rea/init mods apply to rigging
@@ -888,7 +890,9 @@ void affect_total(struct char_data * ch)
   }
 
   // Matrix pg 18 & 24, assume pure DNI (thus reaction = intelligence)
-  // No direct reaction/initiative bonuses from cyber/bio apply (assume no bonuses from magic/adept either)
+  // No direct reaction/initiative bonuses from cyber/bio apply
+  // Matrix pg 28 says physical reaction spells apply, but they don't exist
+  //   For general magic/mundane balance, maybe better to treat spells/powers like bio 
   if (PLR_FLAGGED(ch, PLR_MATRIX)) {
     GET_REA(ch) = GET_INT(ch);
     GET_INIT_DICE(ch) = 0;


### PR DESCRIPTION
The previous version set edge = 2 when transitioning into addiction in order to guarantee that forced withdrawal would face at least one withdrawal test instead of automatically succeeding from edge 1. But that had the unintended consequence of also increasing the overall time to complete withdrawal. Also, because edge was always reduced in withdrawal before the withdrawal test, the removal of edge increases from forced drug use meant that a character undergoing forced withdrawal could fail every test and still successfully complete withdrawal. 

This PR fixes the above, returning to the previous edge = 1 when transitioning into addiction, and instead changes the order of operations for process_withdrawal; the test now happens first (or automatic success if in guided withdrawal), and edge is reduced only if successful.

Second, this PR now updates GET_DRUG_LAST_WITHDRAWAL_TICK alongside GET_DRUG_LAST_FIX on drug onset instead of when entering withdrawal, to more accurately reflect how Fix Factor is described in M&M pg 109.

This PR also replaces the nonfunctional time until withdrawal ends with the time until the next withdrawal test in status information.