### PR TITLE
More drug fixes

### DIFF
--- a/src/drugs.cpp
+++ b/src/drugs.cpp
@@ -37,7 +37,7 @@ ACMD_DECLARE(do_look);
 bool _process_edge_and_tolerance_changes_for_applied_dose(struct char_data *ch, int drug_id);
 bool _apply_doses_of_drug_to_char(int doses, int drug_id, struct char_data *ch, bool voluntary=TRUE);
 bool _drug_dose_exceeds_tolerance(struct char_data *ch, int drug_id);
-bool _specific_addiction_test(struct char_data *ch, int drug_id, bool is_mental, const char *test_identifier);
+bool _specific_addiction_test(struct char_data *ch, int drug_id, bool is_mental, const char *test_identifier, bool starting_guided_withdrawal_modifier=FALSE);
 bool _combined_addiction_test(struct char_data *ch, int drug_id, const char *test_identifier, bool is_starting_guided_withdrawal_check=FALSE);
 int _seek_drugs_purchase_cost(struct char_data *ch, int drug_id);
 bool seek_drugs(struct char_data *ch, int drug_id);


### PR DESCRIPTION
1. MM causes confusion by using the same terms for both Tolerance Rating (target number for tolerance tests) and tolerance level (fail the tolerance test, now you need more doses to get high). The increase in tolerance for edge_delta > 0 is supposed to be an increase in Tolerance Rating (which is already implemented by adding GET_DRUG_ADDICTION_EDGE to tests), not an increase in tolerance level. (MM pg 108 vs pg 109).

2. The tolerance test is a body test only (MM pg 109).

3. After successfully reaching the DRUG_STAGE_GUIDED_WITHDRAWAL state, the character no longer needs to pass tests (except in the unlikely event where they run out of anticraving chems), so the house rule giving a 1 TN bonus doesn't seem significant.

4. Withdrawal tests only occur on hour ticks, so  get_time_until_withdrawal_test now just reports to within 2 irl minutes. This also solves the bug where if a withdrawing character is offline, they could end up seeing a large negative number when they log in.