### PR TITLE
Cyberware/bioware incompatibilities

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2054,10 +2054,18 @@ bool biocyber_compatibility(struct obj_data *obj1, struct obj_data *obj2, struct
   else if (bio1 && bio2) {
     switch (GET_BIOWARE_TYPE(bio2)) {
       case BIO_CALCITONIN:
-        INCOMPATIBLE_BIO(BIO_PLATELETFACTORY, "Calcitonin treatments are incompatible with platelet factories..");
+        INCOMPATIBLE_BIO(BIO_PLATELETFACTORY, "Calcitonin treatments are incompatible with platelet factories.");
         break;
       case BIO_PLATELETFACTORY:
         INCOMPATIBLE_BIO(BIO_CALCITONIN, "Platelet factories are incompatible with calcitonin treatments.");
+        break;
+      case BIO_METABOLICARRESTER:
+        INCOMPATIBLE_BIO(BIO_ADRENALPUMP, "Metabolic arresters are incompatible with adrenal pumps.");
+        INCOMPATIBLE_BIO(BIO_SUPRATHYROIDGLAND, "Metabolic arresters are incompatible with suprathyroid glands.");
+        break;
+      case BIO_ADRENALPUMP:
+      case BIO_SUPRATHYROIDGLAND:
+        INCOMPATIBLE_BIO(BIO_METABOLICARRESTER, "Adrenal pumps and suprathyroid glands are incompatible with metabolic arresters.");
         break;
     }
   }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1829,12 +1829,6 @@ bool biocyber_compatibility(struct obj_data *obj1, struct obj_data *obj2, struct
             return FALSE;
           }
           break;
-        case CYB_DATAJACK:
-          if (GET_CYBERWARE_TYPE(cyber2) == CYB_EYES && IS_SET(GET_CYBERWARE_FLAGS(cyber2), EYE_DATAJACK)) {
-            send_to_char("You already have an eye datajack installed.\r\n", ch);
-            return FALSE;
-          }
-          break;
         case CYB_VCR:
           if (GET_CYBERWARE_TYPE(cyber2) == CYB_BOOSTEDREFLEXES) {
             send_to_char("Vehicle Control Rigs are not compatible with Boosted reflexes.\r\n", ch);
@@ -1947,10 +1941,6 @@ bool biocyber_compatibility(struct obj_data *obj1, struct obj_data *obj2, struct
           }
           break;
       }
-    if (GET_CYBERWARE_TYPE(cyber1) == CYB_EYES && IS_SET(GET_CYBERWARE_FLAGS(cyber1), EYE_DATAJACK) && GET_CYBERWARE_TYPE(cyber2) == CYB_DATAJACK) {
-      send_to_char("You already have a datajack installed.\r\n", ch);
-      return FALSE;
-    }
     if (GET_CYBERWARE_TYPE(cyber2) == CYB_EYES && GET_CYBERWARE_TYPE(cyber1) == CYB_EYES)
       for (int bit = EYE_CAMERA; bit <= EYE_ULTRASOUND; bit *= 2) {
         if (IS_SET(GET_CYBERWARE_FLAGS(cyber2), bit) && IS_SET(GET_CYBERWARE_FLAGS(cyber1), bit)) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1829,6 +1829,12 @@ bool biocyber_compatibility(struct obj_data *obj1, struct obj_data *obj2, struct
             return FALSE;
           }
           break;
+        case CYB_DATAJACK:
+          if (GET_CYBERWARE_TYPE(cyber2) == CYB_EYES && IS_SET(GET_CYBERWARE_FLAGS(cyber2), EYE_DATAJACK)) {
+            send_to_char("You already have an eye datajack installed.\r\n", ch);
+            return FALSE;
+          }
+          break;
         case CYB_VCR:
           if (GET_CYBERWARE_TYPE(cyber2) == CYB_BOOSTEDREFLEXES) {
             send_to_char("Vehicle Control Rigs are not compatible with Boosted reflexes.\r\n", ch);
@@ -1941,6 +1947,10 @@ bool biocyber_compatibility(struct obj_data *obj1, struct obj_data *obj2, struct
           }
           break;
       }
+    if (GET_CYBERWARE_TYPE(cyber1) == CYB_EYES && IS_SET(GET_CYBERWARE_FLAGS(cyber1), EYE_DATAJACK) && GET_CYBERWARE_TYPE(cyber2) == CYB_DATAJACK) {
+      send_to_char("You already have a datajack installed.\r\n", ch);
+      return FALSE;
+    }
     if (GET_CYBERWARE_TYPE(cyber2) == CYB_EYES && GET_CYBERWARE_TYPE(cyber1) == CYB_EYES)
       for (int bit = EYE_CAMERA; bit <= EYE_ULTRASOUND; bit *= 2) {
         if (IS_SET(GET_CYBERWARE_FLAGS(cyber2), bit) && IS_SET(GET_CYBERWARE_FLAGS(cyber1), bit)) {


### PR DESCRIPTION
Add guard for metabolic arrester incompatibilities. According to MM pg 67, the metabolic arrester is not compatible with the adrenal pump or suprathyroid gland.

Remove guard preventing datajack + eye datajack. Multiple datajacks is not unusual in canon (SR3 pg 298), and the `get_datajack` function is able to handle multiple datajacks.