### PR TITLE
MacOS instructions for Boost

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Previously tested on (it worked there in the past, but is not guaranteed to now)
 - With Cygwin, you can also use Eclipse CPP IDE, just create a Cygwin-C++ project and point the directory to where your AwakeMUD is located, play around with build settings to ensure it is using your Makefile in src. Debugging/Running works.
 
 ### Additional OSX Installation Notes
+- To install the Boost library:
+    - `brew install boost`
 - To install mysql@5.7 and mysql-client@5.7:
     - `brew install mysql@5.7`
     - `brew install mysql-client@5.7`

--- a/src/Makefile
+++ b/src/Makefile
@@ -34,7 +34,7 @@ LIBS = -lcrypt -L/usr/local/lib $(COMMON_FLAGS) $(BOOST_FLAGS) -lnsl -lcurl
 MYFLAGS = -DNOCRYPT -Dlinux -I /usr/local/include/ -Wall -Wextra -Wno-unused-parameter
 
 # OSX? Uncomment these:
-#LIBS = -L/usr/local/lib $(COMMON_FLAGS) -lsodium -lcurl
+#LIBS = -L/usr/local/lib $(COMMON_FLAGS) $(BOOST_FLAGS) -lsodium -lcurl
 #MYFLAGS = -DUSE_MEMORY_CANARIES -DDEBUG -DSELFADVANCE -Dosx -I /usr/local/include/ -Wall -Wextra -Wno-unused-parameter -std=c++11 -DSUPPRESS_MOB_SKILL_ERRORS -DACCELERATE_FOR_TESTING -D_GLIBCXX_DEBUG
 
 # Linux / others? Uncomment these:


### PR DESCRIPTION
Adds instructions for installing boost and modifies the Makefile `LIBS` to use it, for Mac