### PR TITLE
Upload and Download commands to transfer data to headware memory

### DIFF
--- a/src/act.other.cpp
+++ b/src/act.other.cpp
@@ -77,7 +77,6 @@ extern void check_quest_destroy(struct char_data *ch, struct obj_data *obj);
 extern int get_docwagon_faux_id(struct char_data *ch);
 extern unsigned int get_johnson_overall_max_rep(struct char_data *johnson);
 extern unsigned int get_johnson_overall_min_rep(struct char_data *johnson);
-extern void perform_put_cyberdeck(struct char_data * ch, struct obj_data * obj, struct obj_data * cont);
 
 extern bool restring_with_args(struct char_data *ch, char *argument, bool using_sysp);
 

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -184,6 +184,7 @@ ACMD_DECLARE(do_discord);
 ACMD_DECLARE(do_dispell);
 ACMD_DECLARE(do_display);
 ACMD_DECLARE(do_domain);
+ACMD_DECLARE(do_download_headware);
 ACMD_DECLARE(do_drag);
 ACMD_DECLARE(do_drink);
 ACMD_DECLARE(do_drive);
@@ -390,6 +391,7 @@ ACMD_DECLARE(do_ungroup);
 ACMD_DECLARE(do_unpack);
 ACMD_DECLARE(do_unsupported_command);
 ACMD_DECLARE(do_upgrade);
+ACMD_DECLARE(do_upload_headware);
 ACMD_DECLARE(do_use);
 ACMD_DECLARE(do_usenerps);
 ACMD_DECLARE(do_users);
@@ -610,6 +612,7 @@ struct command_info cmd_info[] =
     { "discord"    , POS_DEAD    , do_discord  , 0, 0, ALLOWS_IDLE_REWARD },
     { "docwagon"   , POS_LYING   , do_docwagon , 0, 0, BLOCKS_IDLE_REWARD },
     { "domain"     , POS_LYING   , do_domain   , 0, 0, BLOCKS_IDLE_REWARD },
+    { "download"   , POS_RESTING , do_download_headware, 0, 0, BLOCKS_IDLE_REWARD },
     { "donate"     , POS_RESTING , do_drop     , 0, SCMD_DONATE, BLOCKS_IDLE_REWARD },
     { "drag"       , POS_STANDING, do_drag     , 0, 0, BLOCKS_IDLE_REWARD },
     { "drink"      , POS_RESTING , do_drink    , 0, SCMD_DRINK, BLOCKS_IDLE_REWARD },
@@ -955,6 +958,7 @@ struct command_info cmd_info[] =
     { "unlearn"    , POS_DEAD    , do_forget   , 0, 0, BLOCKS_IDLE_REWARD },
     { "unfollow"   , POS_LYING   , do_unfollow , 0, 0, BLOCKS_IDLE_REWARD },
     { "upgrade"    , POS_SITTING , do_upgrade  , 0 , 0, BLOCKS_IDLE_REWARD },
+    { "upload"     , POS_RESTING , do_upload_headware, 0, 0, BLOCKS_IDLE_REWARD },
     { "uptime"     , POS_DEAD    , do_date     , 0, SCMD_UPTIME, ALLOWS_IDLE_REWARD },
     { "use"        , POS_SITTING , do_use      , 1, SCMD_USE, BLOCKS_IDLE_REWARD },
     { "usenerps"   , POS_LYING   , do_usenerps , 1, 0, BLOCKS_IDLE_REWARD },

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -1127,12 +1127,15 @@ bool WEAPON_FOCUS_USABLE_BY(struct obj_data *focus, struct char_data *ch);
 #define GET_CYBERWARE_GRADE(cyberware)            (GET_OBJ_VAL((cyberware), 2))
 #define GET_CYBERWARE_FLAGS(cyberware)            (GET_OBJ_VAL((cyberware), 3)) // CYBERWEAPON_RETRACTABLE, CYBERWEAPON_IMPROVED
 #define GET_CYBERWARE_LACING_TYPE(cyberware)      (GET_OBJ_VAL((cyberware), 3)) // Yes, this is also value 3. Great design here.
+#define GET_CYBERWARE_MEMORY_MAX(cyberware)       (GET_OBJ_VAL((cyberware), 3))
 #define GET_CYBERWARE_ESSENCE_COST(cyberware)     (GET_OBJ_VAL((cyberware), 4))
 #define GET_CYBERWARE_RADIO_MAX_CRYPT(cyberware)  (GET_OBJ_VAL((cyberware), 5))
+#define GET_CYBERWARE_MEMORY_USED(cyberware)      (GET_OBJ_VAL((cyberware), 5))
 #define GET_CYBERWARE_RADIO_FREQ(cyberware)       (GET_OBJ_VAL((cyberware), 6)) // Settable by player
 #define GET_CYBERWARE_RADIO_CRYPT(cyberware)      (GET_OBJ_VAL((cyberware), 7)) // Settable by player
 // Cyberware phones use 6, 7, and 8 for... stuff?
 #define GET_CYBERWARE_IS_DISABLED(cyberware)      (GET_OBJ_VAL((cyberware), 9))
+#define GET_CYBERWARE_MEMORY_FREE(cyberware)      (GET_CYBERWARE_MEMORY_MAX((cyberware)) - GET_CYBERWARE_MEMORY_USED((cyberware)))
 
 // ITEM_CYBERDECK convenience defines
 #define GET_CYBERDECK_MPCP(deck)                  (GET_OBJ_VAL((deck), 0))
@@ -1145,6 +1148,9 @@ bool WEAPON_FOCUS_USABLE_BY(struct obj_data *focus, struct char_data *ch);
 #define GET_CYBERDECK_IS_INCOMPLETE(deck)         (GET_OBJ_VAL((deck), 9))
 #define GET_CYBERDECK_FLAGS(deck)                 (GET_OBJ_VAL((deck), 10))
 #define GET_CYBERDECK_FREE_STORAGE(deck)          (GET_CYBERDECK_TOTAL_STORAGE((deck)) -GET_CYBERDECK_USED_STORAGE((deck)))
+#define OBJ_IS_VALID_STOREBOUGHT_CYBERDECK(deck)  ((deck) && GET_OBJ_TYPE((deck)) == ITEM_CYBERDECK && GET_CYBERDECK_MPCP((deck)) > 0)
+#define OBJ_IS_VALID_CUSTOM_CYBERDECK(deck)       ((deck) && GET_OBJ_TYPE((deck)) == ITEM_CUSTOM_DECK && GET_CYBERDECK_MPCP((deck)) > 0 && !GET_CYBERDECK_IS_INCOMPLETE((deck)))
+#define OBJ_IS_VALID_CYBERDECK(deck)              (OBJ_IS_VALID_CUSTOM_CYBERDECK((deck)) || OBJ_IS_VALID_STOREBOUGHT_CYBERDECK((deck)))
 
 // ITEM_PROGRAM convenience defines, aka GET_SOFTWARE
 #define GET_PROGRAM_TYPE(prog)                    (GET_OBJ_VAL((prog), 0))


### PR DESCRIPTION
A set of commands, `do_upload_headware` and `do_download_headware` meant to be used in meat space as `upload <file>` and `download <file number>`.

Both commands require the character to have:
- headware memory
- datajack
- a working cyberdeck carried or worn (the helper `find_cyberdeck` is created for this check)

`upload <file>` will take any `ITEM_DECK_ACCESSORY` file and insert it into your headware memory, if there is enough available space.  This is intended to be used with data files or photos, not skillsofts.

`download <file number>` reverses the process, it removes the file from your headware and places it in your inventory.


Example:
```
l
Eye Modification Cyberware (Peaceful)
   Eye modification is a booming business in 2064, anything from cosmetic
modification to retinal duplicators to image magnification. If eye
modifications are bought in a package, essence reductions apply, so it is
usually best to do it this way. However, not always can you find your desired
modification in a package and will have to buy it separately. All vision
modifiers given by cyberware is treated as natural vision, and as such, mages
with electronic magnification cannot cast any spells that require line of
sight without projecting or perceiving. 
Obvious exits:
South - [60517] Cyberware Central
Up    - [60629] Eye Modification Alphaware
Doc Bell stands here, poking at a human eyeball in a jar. 
...he has a few things for sale. Use the LIST command to see them.

<10P 10M> 
photo
You take a photo.

<10P 10M> 
memory
Headware Memory Contents (73/75):
  1) a photo of Eye Modification Cyberware    (1 MP) 
  2) a photo of Cyberware Central             (1 MP) 

<10P 10M> 
view 1
You need headware memory and an image link to do this.

<10P 10M> 
download 1
You transfer a photo of Eye Modification Cyberware through a Fairlight Executive into your hands.

<10P 10M> 
memory
Headware Memory Contents (74/75):
  1) a photo of Cyberware Central             (1 MP) 

<10P 10M> 
i
You are carrying:
a photo of Eye Modification Cyberware
a Fairlight Executive
a spyware disk
a large plastiboard box
an Athletics 5 ActiveSoft
a radio
a Neophyte Guild housing subsidy card
a map of Seattle

You're not using any equipment.

You have no ammo in your pockets.

<10P 10M> 
exa photo
Eye Modification Cyberware
   Eye modification is a booming business in 2064, anything from cosmetic
modification to retinal duplicators to image magnification. If eye
modifications are bought in a package, essence reductions apply, so it is
usually best to do it this way. However, not always can you find your desired
modification in a package and will have to buy it separately. All vision
modifiers given by cyberware is treated as natural vision, and as such, mages
with electronic magnification cannot cast any spells that require line of
sight without projecting or perceiving. 
Doc Bell stands here, poking at a human eyeball in a jar. 

You have no training in Police Procedures, but you guess that a photo of Eye Modification Cyberware
is completely legal.
A photo of Eye Modification Cyberware is in excellent condition.

<10P 10M> 
upload photo
You transfer a photo of Eye Modification Cyberware into your headware memory, through a Fairlight
Executive.

<10P 10M> 
memory
Headware Memory Contents (73/75):
  1) a photo of Eye Modification Cyberware    (1 MP) 
  2) a photo of Cyberware Central             (1 MP) 
```