### PR TITLE
Fixes for close-to-melee

### DIFF
--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -6205,7 +6205,7 @@ void perform_violence(void)
         // Set the target from the defender's attribute.
         target += defender_attribute;
         // Lock the target to a range. Nobody enjoys rolling TN 14 to close with high-level invis mages.
-        target = MIN(MINIMUM_TN_FOR_CLOSING_CHECK, MAX(target, MAXIMUM_TN_FOR_CLOSING_CHECK));
+        target = MAX(MINIMUM_TN_FOR_CLOSING_CHECK, MIN(target, MAXIMUM_TN_FOR_CLOSING_CHECK));
 
         // Strike.
         if (quickness > 0 && success_test(quickness, target) > 1) {

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -6208,7 +6208,7 @@ void perform_violence(void)
         target = MAX(MINIMUM_TN_FOR_CLOSING_CHECK, MIN(target, MAXIMUM_TN_FOR_CLOSING_CHECK));
 
         // Strike.
-        if (quickness > 0 && success_test(quickness, target) > 1) {
+        if (quickness > 0 && success_test(quickness, target) > 0) {
           send_to_char(ch, "You close the distance and strike!\r\n");
           act("$n closes the distance and strikes.", TRUE, ch, 0, 0, TO_ROOM);
           AFF_FLAGS(ch).RemoveBit(AFF_APPROACH);


### PR DESCRIPTION
The close-to-melee TN capping code was flipped, so that the test TN was always being set to MINIMUM_TN_FOR_CLOSING_CHECK = 4. This PR fixes this so that TNs can properly rise to MAXIMUM_TN_FOR_CLOSING_CHECK = 10 against difficult targets.

With the fix, the requirement for 2 net successes to close to melee may be too punishing for melee builds. Assuming reasonably optimized characters reach 11-14 quickness, they would then have only 23%-33% odds vs TN 10, compared to the 99%+ that they currently have (due to TN 4). Reducing the requirement to only 1 net success alongside the above fix would put them at 62%-70%.