### PR TITLE
Light spell effects applied in get_vision_penalty

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -263,7 +263,7 @@ int light_level(struct room_data *room)
   if (ROOM_FLAGGED(room, ROOM_STREETLIGHTS) && (time_info.hours <= 6 || time_info.hours >= 19)) {
     artificial_light_level = LIGHT_PARTLIGHT;
   } else {
-    int num_light_sources = room->light[ROOM_LIGHT_HEADLIGHTS_AND_FLASHLIGHTS] + room->light[ROOM_HIGHEST_SPELL_FORCE];
+    int num_light_sources = room->light[ROOM_LIGHT_HEADLIGHTS_AND_FLASHLIGHTS];
 
     // Light sources. More sources, more light.
     if (num_light_sources >= 2) {


### PR DESCRIPTION
The light spell's effects are included in vision_overhaul.cpp: `get_vision_penalty`. This PR removes its older implementation from utils.cpp: `light_level`.

Credit syspoint to: https://discord.com/channels/564618629467996170/788953927269613608/1210388828657942619