### PR TITLE
If you can't see ch, you don't see their movement

### DIFF
--- a/src/act.movement.cpp
+++ b/src/act.movement.cpp
@@ -205,6 +205,11 @@ bool should_tch_see_chs_movement_message(struct char_data *tch, struct char_data
     return FALSE;
   }
 
+  // Check for invisibility.
+  if (!can_see_through_invis(tch, ch)) {
+    return FALSE;
+  }
+
   // Check for stealth and other person-to-person modifiers.
   if (we_care_about_sneaking && IS_AFFECTED(ch, AFF_SNEAK)) {
     int dummy_tn = 2;

--- a/src/act.movement.cpp
+++ b/src/act.movement.cpp
@@ -196,9 +196,15 @@ bool should_tch_see_chs_movement_message(struct char_data *tch, struct char_data
   if (tch == ch || PRF_FLAGGED(tch, PRF_MOVEGAG) || !AWAKE(tch) || IS_IGNORING(tch, is_blocking_ic_interaction_from, ch))
     return FALSE;
 
-  // Tuned out doing other things.
-  if (PLR_FLAGGED(tch, PLR_REMOTE) || PLR_FLAGGED(tch, PLR_MATRIX))
+  // If both tch and ch are NPCs, we don't care.
+  if (IS_NPC(tch) && IS_NPC(ch)) {
     return FALSE;
+  }
+
+  // Tuned out doing other things.
+  if (PLR_FLAGGED(tch, PLR_REMOTE) || PLR_FLAGGED(tch, PLR_MATRIX)) {
+    return FALSE;
+  }
 
   // Failed to see from vehicle.
   if (tch->in_veh && (tch->in_veh->cspeed > SPEED_IDLE && success_test(GET_INT(tch), 4) <= 0)) {

--- a/src/act.movement.cpp
+++ b/src/act.movement.cpp
@@ -212,7 +212,7 @@ bool should_tch_see_chs_movement_message(struct char_data *tch, struct char_data
     char rbuf[1000];
     struct room_data *in_room = get_ch_in_room(ch);
 
-    // If you're sneaking, take an open test to determine the TN for the perception test to notice you.
+    // If you're sneaking, make an open test to determine the TN for the perception test to notice you.
     if (IS_AFFECTED(ch, AFF_SNEAK)) {
       // Get the skill dice to roll.
       snprintf(rbuf, sizeof(rbuf), "Sneak perception test: %s vs %s. get_skill: ", GET_CHAR_NAME(tch), GET_CHAR_NAME(ch));
@@ -240,7 +240,7 @@ bool should_tch_see_chs_movement_message(struct char_data *tch, struct char_data
     open_test_result = MAX(open_test_result, 0);
 
     // Vision modifiers, wound penalties, and other distractions.
-    int tn_modifiers = modify_target_rbuf_raw(tch, rbuf, sizeof(rbuf), get_vision_penalty(tch, in_room, rbuf, sizeof(rbuf)), FALSE)
+    int tn_modifiers = modify_target_rbuf_raw(tch, rbuf, sizeof(rbuf), get_vision_penalty(tch, in_room, rbuf, sizeof(rbuf)), FALSE);
 
     // House rule: Stealth/silence spells add a TN penalty to the spotter, up to 4.
     int stealth_spell_tn = get_spell_affected_successes(ch, SPELL_STEALTH);

--- a/src/act.movement.cpp
+++ b/src/act.movement.cpp
@@ -182,7 +182,7 @@ int can_move(struct char_data *ch, int dir, int extra)
   return 1;
 }
 
-bool should_tch_see_chs_movement_message(struct char_data *tch, struct char_data *ch, bool we_care_about_sneaking) {
+bool should_tch_see_chs_movement_message(struct char_data *tch, struct char_data *ch, bool should_roll_perception) {
   if (!tch) {
     mudlog("SYSERR: Received null tch to s_v_o_s_m_m!", tch, LOG_SYSLOG, TRUE);
     return FALSE;
@@ -219,7 +219,7 @@ bool should_tch_see_chs_movement_message(struct char_data *tch, struct char_data
   }
 
   // Check for stealth and other person-to-person modifiers.
-  if (we_care_about_sneaking) {
+  if (should_roll_perception) {
     int dummy_tn = 2;
     int open_test_result = 0;
     char rbuf[1000];

--- a/src/act.movement.cpp
+++ b/src/act.movement.cpp
@@ -205,57 +205,52 @@ bool should_tch_see_chs_movement_message(struct char_data *tch, struct char_data
     return FALSE;
   }
 
-  // Check for invisibility.
-  if (!can_see_through_invis(tch, ch)) {
-    return FALSE;
-  }
-
   // Check for stealth and other person-to-person modifiers.
-  if (we_care_about_sneaking && IS_AFFECTED(ch, AFF_SNEAK)) {
+  if (we_care_about_sneaking) {
     int dummy_tn = 2;
+    int open_test_result = 0;
     char rbuf[1000];
     struct room_data *in_room = get_ch_in_room(ch);
 
-    // Get the skill dice to roll.
-    snprintf(rbuf, sizeof(rbuf), "Sneak perception test: %s vs %s. get_skill: ", GET_CHAR_NAME(tch), GET_CHAR_NAME(ch));
-    int skill_dice = get_skill(ch, SKILL_STEALTH, dummy_tn);
+    // If you're sneaking, take an open test to determine the TN for the perception test to notice you.
+    if (IS_AFFECTED(ch, AFF_SNEAK)) {
+      // Get the skill dice to roll.
+      snprintf(rbuf, sizeof(rbuf), "Sneak perception test: %s vs %s. get_skill: ", GET_CHAR_NAME(tch), GET_CHAR_NAME(ch));
+      int skill_dice = get_skill(ch, SKILL_STEALTH, dummy_tn);
 
-    // Make an open test to determine the TN for the perception test to notice you.
-    strlcat(rbuf, ". get_vision_penalty: ", sizeof(rbuf));
-    int open_test_result = open_test(skill_dice);
+      // Make the roll.
+      open_test_result = open_test(skill_dice);
 
-    // If we've defaulted, this is reflected by an increased TN-- if the TN went up, cap successes.
-    int defaulting_amount = (dummy_tn - 2);
-    if (defaulting_amount > 0) {
-      if (defaulting_amount <= 2) {
-        // +2 means we defaulted to a linked skill. Mild penalty.
-        open_test_result = MIN(open_test_result - 2, 10);
-        strlcat(rbuf, "(defaulted: OT -2, cap 10!)", sizeof(rbuf));
-      } else {
-        // +4 means we defaulted to an attribute. Harsh penalty.
-        open_test_result = MIN(open_test_result - 4, 6);
-        strlcat(rbuf, "(defaulted: OT -4, cap 6!)", sizeof(rbuf));
+      // If we've defaulted, this is reflected by an increased TN-- if the TN went up, cap successes.
+      int defaulting_amount = (dummy_tn - 2);
+      if (defaulting_amount > 0) {
+        if (defaulting_amount <= 2) {
+          // +2 means we defaulted to a linked skill. Mild penalty.
+          open_test_result = MIN(open_test_result - 2, 10);
+          strlcat(rbuf, "(defaulted: OT -2, cap 10!)", sizeof(rbuf));
+        } else {
+          // +4 means we defaulted to an attribute. Harsh penalty.
+          open_test_result = MIN(open_test_result - 4, 6);
+          strlcat(rbuf, "(defaulted: OT -4, cap 6!)", sizeof(rbuf));
+        }
       }
     }
 
-    int vision_penalty = get_vision_penalty(tch, in_room, rbuf, sizeof(rbuf));
-    snprintf(ENDOF(rbuf), sizeof(rbuf) - strlen(rbuf), ". TN is %d (OT) + %d (vis)", open_test_result, vision_penalty);
+    // Don't allow negative results.
+    open_test_result = MAX(open_test_result, 0);
 
-    int test_tn = open_test_result + vision_penalty;
+    // Vision modifiers, wound penalties, and other distractions.
+    int tn_modifiers = modify_target_rbuf_raw(tch, rbuf, sizeof(rbuf), get_vision_penalty(tch, in_room, rbuf, sizeof(rbuf)), FALSE)
 
     // House rule: Stealth/silence spells add a TN penalty to the spotter, up to 4.
-    {
-      int stealth_spell_tn = get_spell_affected_successes(ch, SPELL_STEALTH);
-      int silence_tn = in_room->silence[ROOM_NUM_SPELLS_OF_TYPE] > 0 ? in_room->silence[ROOM_HIGHEST_SPELL_FORCE] : 0;
-      int magic_tn_modifier = MIN(stealth_spell_tn + silence_tn, 4);
+    int stealth_spell_tn = get_spell_affected_successes(ch, SPELL_STEALTH);
+    int silence_tn = in_room->silence[ROOM_NUM_SPELLS_OF_TYPE] > 0 ? in_room->silence[ROOM_HIGHEST_SPELL_FORCE] : 0;
+    int silence_tn_modifier = MIN(stealth_spell_tn + silence_tn, 4);
 
-      if (magic_tn_modifier > 0) {
-        test_tn += magic_tn_modifier;
-        snprintf(ENDOF(rbuf), sizeof(rbuf) - strlen(rbuf), " + %d (magic)", magic_tn_modifier);
-      }
-    }
+    snprintf(ENDOF(rbuf), sizeof(rbuf) - strlen(rbuf), ". TN is %d (OT) + %d (vis/wounds/etc) + %d (silence)", open_test_result, tn_modifiers, silence_tn_modifier);
 
     // Roll the perception test.
+    int test_tn = open_test_result + tn_modifiers + silence_tn_modifier;
     int perception_result = success_test(GET_INT(tch) + GET_POWER(tch, ADEPT_IMPROVED_PERCEPT), test_tn);
     snprintf(ENDOF(rbuf), sizeof(rbuf) - strlen(rbuf), "Result: %d hits.", perception_result);
     if (GET_INVIS_LEV(tch) <= GET_LEVEL(ch))
@@ -263,19 +258,24 @@ bool should_tch_see_chs_movement_message(struct char_data *tch, struct char_data
 
     bool spotted_movement = perception_result > 0;
 
-    // We rolled at least one hit above our open test TN? NOW we check if we can see them.
-    if (spotted_movement && CAN_SEE(tch, ch)) {
+    // Failed to notice them.
+    if (!spotted_movement) {
+      return FALSE;
+    }
+
+    // They were sneaking but we noticed.
+    if (IS_AFFECTED(ch, AFF_SNEAK) && spotted_movement) {
       // Spotting someone sneaking around puts NPCs on edge.
       if (IS_NPC(tch) && GET_MOBALERT(tch) != MALERT_ALARM) {
         GET_MOBALERT(tch) = MALERT_ALERT;
         GET_MOBALERTTIME(tch) = MAX(GET_MOBALERTTIME(tch), 10);
       }
-      return TRUE;
+
+      // Messaging?
     }
-    return FALSE;
   }
 
-  // If we got here, we can see it.
+  // If we got here, we noticed them.
   return TRUE;
 }
 

--- a/src/act.movement.cpp
+++ b/src/act.movement.cpp
@@ -197,8 +197,14 @@ bool should_tch_see_chs_movement_message(struct char_data *tch, struct char_data
   if (tch == ch || PRF_FLAGGED(tch, PRF_MOVEGAG) || !AWAKE(tch) || IS_IGNORING(tch, is_blocking_ic_interaction_from, ch))
     return FALSE;
 
-  // If both tch and ch are NPCs, we don't care.
-  if (IS_NPC(tch) && IS_NPC(ch)) {
+  // Ch is astral and not manifest but tch can't see astral
+  if (IS_ASTRAL(ch) && !AFF_FLAGGED(ch, AFF_MANIFEST) && !SEES_ASTRAL(tch)) {
+    return FALSE;
+  }
+
+  // If both tch and ch are NPCs, then we don't care.
+  // Note: player projections are flagged as NPCs.
+  if (IS_NPC(tch) && IS_NPC(ch) && !IS_PROJECT(tch) && !IS_PROJECT(ch)) {
     return FALSE;
   }
 

--- a/src/act.movement.cpp
+++ b/src/act.movement.cpp
@@ -251,12 +251,15 @@ bool should_tch_see_chs_movement_message(struct char_data *tch, struct char_data
     // House rule: Stealth/silence spells add a TN penalty to the spotter, up to 4.
     int stealth_spell_tn = get_spell_affected_successes(ch, SPELL_STEALTH);
     int silence_tn = in_room->silence[ROOM_NUM_SPELLS_OF_TYPE] > 0 ? in_room->silence[ROOM_HIGHEST_SPELL_FORCE] : 0;
-    int silence_tn_modifier = MIN(stealth_spell_tn + silence_tn, 4);
+    int magic_tn_modifier = MIN(stealth_spell_tn + silence_tn, 4);
 
-    snprintf(ENDOF(rbuf), sizeof(rbuf) - strlen(rbuf), ". TN is %d (OT) + %d (vis/wounds/etc) + %d (silence)", open_test_result, tn_modifiers, silence_tn_modifier);
+    // Spirit Conceal power adds to the TN.
+    magic_tn_modifier += affected_by_power(ch, CONCEAL); 
+
+    snprintf(ENDOF(rbuf), sizeof(rbuf) - strlen(rbuf), ". TN is %d (OT) + %d (vis/wounds/etc) + %d (other magic)", open_test_result, tn_modifiers, magic_tn_modifier);
 
     // Roll the perception test.
-    int test_tn = open_test_result + tn_modifiers + silence_tn_modifier;
+    int test_tn = open_test_result + tn_modifiers + magic_tn_modifier;
     int perception_result = success_test(GET_INT(tch) + GET_POWER(tch, ADEPT_IMPROVED_PERCEPT), test_tn);
     snprintf(ENDOF(rbuf), sizeof(rbuf) - strlen(rbuf), "Result: %d hits.", perception_result);
     if (GET_INVIS_LEV(tch) <= GET_LEVEL(ch))

--- a/src/act.movement.cpp
+++ b/src/act.movement.cpp
@@ -48,6 +48,7 @@ extern void send_mob_aggression_warnings(struct char_data *pc, struct char_data 
 extern bool vict_is_valid_aggro_target(struct char_data *ch, struct char_data *vict);
 extern struct char_data *find_a_character_that_blocks_fleeing_for_ch(struct char_data *ch);
 extern bool precipitation_is_snow(int jurisdiction);
+extern int calculate_vision_penalty(struct char_data *ch, struct char_data *victim);
 
 extern sh_int mortal_start_room;
 extern sh_int frozen_start_room;

--- a/src/invis_resistance_tests.cpp
+++ b/src/invis_resistance_tests.cpp
@@ -282,8 +282,8 @@ void send_npc_newly_alarmed_message(struct char_data *npc, struct char_data *vic
         act("$n^n swivels around with an alarmed chirp.", TRUE, npc, 0, vict, TO_VICT);
       } else {
         act("You scowl as you hear something out of place.^n", TRUE, npc, 0, vict, TO_CHAR);
-        act("$n^n scowls, their eyes sweeping the area with noticeable concern.", TRUE, npc, 0, vict, TO_NOTVICT);
-        act("$n^n scowls, their eyes sweeping the area with noticeable concern.", TRUE, npc, 0, vict, TO_VICT);
+        act("$n^n scowls, their eyes sweeping the area with suspicion.", TRUE, npc, 0, vict, TO_NOTVICT);
+        act("$n^n scowls, their eyes sweeping the area with suspicion.", TRUE, npc, 0, vict, TO_VICT);
       }
     }
   }

--- a/src/invis_resistance_tests.cpp
+++ b/src/invis_resistance_tests.cpp
@@ -88,13 +88,13 @@ bool process_spotted_invis(struct char_data *ch, struct char_data *vict) {
       GET_MOBALERT(ch) = MALERT_ALARM;
       send_npc_newly_alarmed_message(ch, vict);
       if (access_level(vict, LVL_PRESIDENT) && PRF_FLAGGED(vict, PRF_ROLLS)) {
-        send_to_char(vict, "^L[%s#%ld has become ^ralarmed^L due to seeing you while you're invis.]\r\n", GET_CHAR_NAME(ch), GET_MOB_UNIQUE_ID(ch));
+        send_to_char(vict, "You have been noticed while invisible! ^L[%s#%ld has become ^ralarmed^L!]\r\n", GET_CHAR_NAME(ch), GET_MOB_UNIQUE_ID(ch));
       }
       return TRUE;
     } else {
       GET_MOBALERT(ch) = MALERT_ALERT;
       if (access_level(vict, LVL_PRESIDENT) && PRF_FLAGGED(vict, PRF_ROLLS)) {
-        send_to_char(vict, "^L[%s#%ld has become ^yalert^L due to seeing you while you're invis.]\r\n", GET_CHAR_NAME(ch), GET_MOB_UNIQUE_ID(ch));
+        send_to_char(vict, "You have been noticed while invisible! ^L[%s#%ld has become ^yalert^L!]\r\n", GET_CHAR_NAME(ch), GET_MOB_UNIQUE_ID(ch));
       }
       return FALSE;
     }
@@ -264,14 +264,27 @@ void send_npc_newly_alarmed_message(struct char_data *npc, struct char_data *vic
   bool passed_check = success_test(GET_INT(vict) + GET_POWER(vict, ADEPT_IMPROVED_PERCEPT), GET_INT(npc)) > 0;
 
   if (passed_check && CAN_SEE(vict, npc) && vict->in_room == npc->in_room) {
-    if (MOB_FLAGGED(npc, MOB_INANIMATE)) {
-      act("You swivel towards $N with an alarmed chirp as your sensors pierce $S invisibility.^n", TRUE, npc, 0, vict, TO_CHAR);
-      act("$n^n swivels towards $N with an alarmed chirp.", TRUE, npc, 0, vict, TO_NOTVICT);
-      act("^y$n^y swivels towards you with an alarmed chirp as its sensors pierce your invisibility.^n", TRUE, npc, 0, vict, TO_VICT);
+    // Its possible to get here despite not actually being able to see the victim
+    if (can_see_through_invis(npc, vict)) {
+      if (MOB_FLAGGED(npc, MOB_INANIMATE)) {
+        act("You swivel towards $N with an alarmed chirp as your sensors pierce $S invisibility.^n", TRUE, npc, 0, vict, TO_CHAR);
+        act("$n^n swivels towards $N with an alarmed chirp.", TRUE, npc, 0, vict, TO_NOTVICT);
+        act("^y$n^y swivels towards you with an alarmed chirp as its sensors pierce your invisibility.^n", TRUE, npc, 0, vict, TO_VICT);
+      } else {
+        act("You scowl at $N as your eyes focus through $S invisibility.^n", TRUE, npc, 0, vict, TO_CHAR);
+        act("$n^n scowls at $N as $s eyes focus through $S invisibility.", TRUE, npc, 0, vict, TO_NOTVICT);
+        act("^y$n^y scowls at you as $s eyes focus through your invisibility.^n", TRUE, npc, 0, vict, TO_VICT);
+      }
     } else {
-      act("You scowl at $N as your eyes focus through $S invisibility.^n", TRUE, npc, 0, vict, TO_CHAR);
-      act("$n^n scowls at $N as $s eyes focus through $S invisibility.", TRUE, npc, 0, vict, TO_NOTVICT);
-      act("^y$n^y scowls at you as $s eyes focus through your invisibility.^n", TRUE, npc, 0, vict, TO_VICT);
+      if (MOB_FLAGGED(npc, MOB_INANIMATE)) {
+        act("You swivel around with an alarmed chirp as your sensors notice something out of place.^n", TRUE, npc, 0, vict, TO_CHAR);
+        act("$n^n swivels around with an alarmed chirp.", TRUE, npc, 0, vict, TO_NOTVICT);
+        act("$n^n swivels around with an alarmed chirp.", TRUE, npc, 0, vict, TO_VICT);
+      } else {
+        act("You scowl as you hear something out of place.^n", TRUE, npc, 0, vict, TO_CHAR);
+        act("$n^n scowls, their eyes sweeping the area with noticeable concern.", TRUE, npc, 0, vict, TO_NOTVICT);
+        act("$n^n scowls, their eyes sweeping the area with noticeable concern.", TRUE, npc, 0, vict, TO_VICT);
+      }
     }
   }
   // Otherwise, you have a chance to get a feeling about it.


### PR DESCRIPTION
Previously, `should_tch_see_chs_movement_message` didn't check for invisibility. This meant that guards could become alerted even though they couldn't see/attack the character. The character would also see messaging as if the guard did see through their invis. This PR adds a `can_see_through_invis` check to `should_tch_see_chs_movement_message`.

This addresses: [https://discord.com/channels/564618629467996170/788953927269613608/1211114620618805313](url)

Alternatively, if we want guards to be able to become alerted through contextual clues despite not being able to see the char ("hey, did somebody just come through that door/bump the trash can/kick a pebble"), we might want to fix the messaging, and also make it a roll instead of being automatic.