### PR TITLE
A few initiative things

### DIFF
--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -5705,8 +5705,9 @@ void roll_individual_initiative(struct char_data *ch)
 {
   if (AWAKE(ch))
   {
+    // this also applies wound modifiers
     GET_INIT_ROLL(ch) = roll_default_initiative(ch);
-    GET_INIT_ROLL(ch) -= damage_modifier(ch, buf, sizeof(buf));
+
     if (AFF_FLAGGED(ch, AFF_ACTION)) {
       GET_INIT_ROLL(ch) -= 10;
       AFF_FLAGS(ch).RemoveBit(AFF_ACTION);

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -5730,6 +5730,12 @@ void roll_individual_initiative(struct char_data *ch)
       else
         GET_INIT_ROLL(ch) += 20;
     }
+
+    // If you rolled zero or negative initiative, let it be known
+    if (GET_INIT_ROLL(ch) <= 0) {
+      act("You struggle to act as your wounds limit your actions! [OOC: You rolled an initiative of zero or less]", FALSE, ch, 0, 0, TO_CHAR);
+    }
+
     // Here we set the Surprise flag to our target if conditions are met. Clearing of flag and alert status are handled
     // in hit_with_multi_weapon_toggle() as soon as a suprised NPC gets damaged in combat. Otherwise we can't
     // properly enter the surprise state due to mobs being continously alert. Because we were handling this in
@@ -5741,7 +5747,7 @@ void roll_individual_initiative(struct char_data *ch)
         && !MOB_FLAGGED(FIGHTING(ch), MOB_INANIMATE)
         && GET_MOBALERT(FIGHTING(ch)) == MALERT_CALM
         && success_test(GET_REA(ch), 4) > success_test(GET_REA(FIGHTING(ch)), 4)) {
-      GET_INIT_ROLL(FIGHTING(ch)) = 0;
+      GET_INIT_ROLL(FIGHTING(ch)) <= 0;
       act("You surprise $n!", TRUE, FIGHTING(ch), 0, ch, TO_VICT);
       AFF_FLAGS(FIGHTING(ch)).SetBit(AFF_SURPRISE);
     }

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -5747,7 +5747,7 @@ void roll_individual_initiative(struct char_data *ch)
         && !MOB_FLAGGED(FIGHTING(ch), MOB_INANIMATE)
         && GET_MOBALERT(FIGHTING(ch)) == MALERT_CALM
         && success_test(GET_REA(ch), 4) > success_test(GET_REA(FIGHTING(ch)), 4)) {
-      GET_INIT_ROLL(FIGHTING(ch)) <= 0;
+      GET_INIT_ROLL(FIGHTING(ch)) = 0;
       act("You surprise $n!", TRUE, FIGHTING(ch), 0, ch, TO_VICT);
       AFF_FLAGS(FIGHTING(ch)).SetBit(AFF_SURPRISE);
     }

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -5712,6 +5712,18 @@ void roll_individual_initiative(struct char_data *ch)
       GET_INIT_ROLL(ch) -= 10;
       AFF_FLAGS(ch).RemoveBit(AFF_ACTION);
     }
+
+    // By the book, MBW 3 adds an extra action to their first pass and 4 adds an additional action to their second.
+    // This implementation is mechanically weaker since chars will get the extras at the end of the turn.
+    for (obj_data *cyber = ch->cyberware; cyber; cyber = cyber->next_content) {
+      if (GET_CYBERWARE_TYPE(cyber) == CYB_MOVEBYWIRE) {
+        if (GET_CYBERWARE_RATING(cyber) == 3)
+          GET_INIT_ROLL(ch) += 10;
+        else if (GET_CYBERWARE_RATING(cyber) == 4)
+          GET_INIT_ROLL(ch) += 20;
+      }
+    }
+
     if (IS_SPIRIT(ch) || IS_ANY_ELEMENTAL(ch)) {
       if (IS_DUAL(ch))
         GET_INIT_ROLL(ch) += 10;

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -5718,9 +5718,9 @@ void roll_individual_initiative(struct char_data *ch)
     for (obj_data *cyber = ch->cyberware; cyber; cyber = cyber->next_content) {
       if (GET_CYBERWARE_TYPE(cyber) == CYB_MOVEBYWIRE) {
         if (GET_CYBERWARE_RATING(cyber) == 3)
-          GET_INIT_ROLL(ch) += 10;
+          GET_INIT_ROLL(ch) += 5;
         else if (GET_CYBERWARE_RATING(cyber) == 4)
-          GET_INIT_ROLL(ch) += 20;
+          GET_INIT_ROLL(ch) += 10;
       }
     }
 


### PR DESCRIPTION
1. Fix for wound modifiers applying twice to initiative
2. Add messaging for the case where a character rolls zero or negative initiative (only possible through a low roll + wound penalties).

These two address: https://discord.com/channels/564618629467996170/788953927269613608/1218251123249647756

3. With the now available delta grade move-by-wires cyberware, they are now feasible for character builds, but they were missing a key feature. MBW3 and MBW4, by the book, are supposed to gain extra actions in the first one or two passes through an initiative turn. We can simulate that by adding 10/20 to their initiative roll, though this is mechanically weaker because the extra actions will occur at the end of an initiative turn instead of near the beginning.