### PR TITLE
Minor fixes

### DIFF
--- a/src/act.drive.cpp
+++ b/src/act.drive.cpp
@@ -1100,9 +1100,9 @@ ACMD(do_repair)
     return;
   }
 
-  skill = get_skill(ch, get_br_skill_for_veh(veh), target);
   target += (veh->damage - 2) / 2;
   target += modify_target(ch);
+  skill = get_skill(ch, get_br_skill_for_veh(veh), target);
 
   if (!access_level(ch, LVL_ADMIN)) {
     kit = has_kit(ch, TYPE_VEHICLE);

--- a/src/spec_procs.cpp
+++ b/src/spec_procs.cpp
@@ -2983,8 +2983,8 @@ SPECIAL(fixer)
       cost += ((float) GET_OBJ_COST(obj)) * 0.9;
     } else {
       // Otherwise, it's a lower percentage of the cost, moderated by the percentage of damage taken.
-      float damage_percentage = ((float) GET_OBJ_CONDITION(obj)) / (GET_OBJ_BARRIER(obj) == 0 ? GET_OBJ_CONDITION(obj) : GET_OBJ_BARRIER(obj));
-      cost += (int) (((float) GET_OBJ_COST(obj)) * damage_percentage * 0.6);
+      float condition_percentage = ((float) GET_OBJ_CONDITION(obj)) / (GET_OBJ_BARRIER(obj) == 0 ? GET_OBJ_CONDITION(obj) : GET_OBJ_BARRIER(obj));
+      cost += (int) (((float) GET_OBJ_COST(obj)) * (1.0 - condition_percentage) * 0.6);
     }
 
     // There's a minimum repair cost now.


### PR DESCRIPTION
Repair costs at Jim's FixIt were scaling by current condition percentage (i.e., the more damaged the item, the cheaper the repair cost). PR changes this to scale by the actual damage percentage.

For vehicle repairs, `get_skill` was being called before determining the TN from vehicle damage and other modifiers, meaning that a character could always default regardless of the TN. PR swaps the order of operations so that repairing wrecks require actually having the appropriate skill.