### PR TITLE
Attempting to make autokill toggle more consistent (fingers crossed)

### DIFF
--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -3562,7 +3562,7 @@ bool raw_damage(struct char_data *ch, struct char_data *victim, int dam, int att
       break;
   }
 
-  if (GET_MENTAL(victim) < 100 || GET_PHYSICAL(victim) < 0)
+  if (GET_MENTAL(victim) < 100 || GET_PHYSICAL(victim) < 1)
     if (FIGHTING(ch) == victim)
       if (GET_POS(victim) == POS_DEAD || !IS_NPC(victim) || PRF_FLAGGED(ch, PRF_NOAUTOKILL)) {
         stop_fighting(ch);

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -3562,7 +3562,7 @@ bool raw_damage(struct char_data *ch, struct char_data *victim, int dam, int att
       break;
   }
 
-  if (GET_MENTAL(victim) < 100 || GET_PHYSICAL(victim) < 1)
+  if (GET_MENTAL(victim) < 100 || GET_PHYSICAL(victim) < 100)
     if (FIGHTING(ch) == victim)
       if (GET_POS(victim) == POS_DEAD || !IS_NPC(victim) || PRF_FLAGGED(ch, PRF_NOAUTOKILL)) {
         stop_fighting(ch);


### PR DESCRIPTION
All I've done so far is change the value that `GET_PHYSICAL(victim)` checks against from 0 to 1 to hopefully address a single deadly wound (that morts a mob) not properly triggering `stop_fighting(ch)`.

I do kind of want to explore the necessity of `(GET_MENTAL(victim) < 100` but I haven't quite figured out what the implications of changing/removing that would be.
