### PR TITLE
Fix persona program storage space usage

### DIFF
--- a/src/newdb.cpp
+++ b/src/newdb.cpp
@@ -2433,7 +2433,8 @@ void auto_repair_obj(struct obj_data *obj, idnum_t owner) {
                 break;
             }
           }
-          if (GET_OBJ_TYPE(installed) == ITEM_PROGRAM) {
+          // Personas don't take up storage in store-bought decks (personas are not programs in custom decks)
+          if ((GET_OBJ_TYPE(installed) == ITEM_PROGRAM) && !((GET_OBJ_TYPE(obj) == ITEM_CYBERDECK) && (GET_PROGRAM_TYPE(installed) <= SOFT_SENSOR))) {
             GET_CYBERDECK_USED_STORAGE(obj) += GET_PROGRAM_SIZE(installed);
           }
         }


### PR DESCRIPTION
In `auto_repair_obj`, persona programs in store-bought decks were being added to `GET_CYBERDECK_USED_STORAGE`. Only utility programs and files that can be uploaded/downloaded should use storage memory (SR3 pg 207). This PR fixes this for store-bought decks (in custom decks, persona programs are handled as hardware, not software).

This check already exists for loading/unloading persona programs from store-bought decks.