### PR TITLE
Magical shenanigans

### DIFF
--- a/src/invis_resistance_tests.cpp
+++ b/src/invis_resistance_tests.cpp
@@ -5,6 +5,8 @@
 #include "db.hpp"
 #include "config.hpp"
 
+extern bool focus_is_usable_by_ch(struct obj_data *focus, struct char_data *ch);
+
 void send_npc_newly_alarmed_message(struct char_data *npc, struct char_data *vict);
 
 // Helper function for remove_ch_from_pc_invis_resistance_records().
@@ -210,6 +212,21 @@ bool can_see_through_invis(struct char_data *ch, struct char_data *vict) {
     if (GET_POWER(ch, ADEPT_MAGIC_RESISTANCE)) {
       dice += GET_POWER(ch, ADEPT_MAGIC_RESISTANCE);
       buf_mod(resistance_test_rbuf, sizeof(resistance_test_rbuf), "MagicResist", GET_POWER(ch, ADEPT_MAGIC_RESISTANCE));
+    }
+  }
+
+  if (GET_FOCI(ch) > 0) {
+    for (int wearslot = 0; wearslot < NUM_WEARS; wearslot++) {
+      struct obj_data *eq = GET_EQ(ch, wearslot);
+      if (eq
+          && GET_OBJ_TYPE(eq) == ITEM_FOCUS
+          && GET_FOCUS_TYPE(eq) == FOCI_SPELL_DEFENSE)
+      {
+        if (focus_is_usable_by_ch(eq, ch) && GET_FOCUS_ACTIVATED(eq)) {
+          dice += GET_FOCUS_FORCE(eq);
+          buf_mod(resistance_test_rbuf, sizeof(resistance_test_rbuf), "FocusDefense", GET_FOCUS_FORCE(eq));
+        }
+      }
     }
   }
 

--- a/src/invis_resistance_tests.cpp
+++ b/src/invis_resistance_tests.cpp
@@ -216,6 +216,7 @@ bool can_see_through_invis(struct char_data *ch, struct char_data *vict) {
   }
 
   if (GET_FOCI(ch) > 0) {
+    int max_spell_def = 0;
     for (int wearslot = 0; wearslot < NUM_WEARS; wearslot++) {
       struct obj_data *eq = GET_EQ(ch, wearslot);
       if (eq
@@ -223,12 +224,12 @@ bool can_see_through_invis(struct char_data *ch, struct char_data *vict) {
           && GET_FOCUS_TYPE(eq) == FOCI_SPELL_DEFENSE)
       {
         if (focus_is_usable_by_ch(eq, ch) && GET_FOCUS_ACTIVATED(eq)) {
-          dice += GET_FOCUS_FORCE(eq);
-          buf_mod(resistance_test_rbuf, sizeof(resistance_test_rbuf), "FocusDefense", GET_FOCUS_FORCE(eq));
-          break;
+          max_spell_def = MAX(max_spell_def, GET_FOCUS_FORCE(eq));
         }
       }
     }
+    dice += max_spell_def;
+    buf_mod(resistance_test_rbuf, sizeof(resistance_test_rbuf), "FocusDefense", max_spell_def);
   }
 
   int magic_pool_dice = GET_SDEFENSE(ch) + GET_REFLECT(ch);

--- a/src/invis_resistance_tests.cpp
+++ b/src/invis_resistance_tests.cpp
@@ -225,6 +225,7 @@ bool can_see_through_invis(struct char_data *ch, struct char_data *vict) {
         if (focus_is_usable_by_ch(eq, ch) && GET_FOCUS_ACTIVATED(eq)) {
           dice += GET_FOCUS_FORCE(eq);
           buf_mod(resistance_test_rbuf, sizeof(resistance_test_rbuf), "FocusDefense", GET_FOCUS_FORCE(eq));
+          break;
         }
       }
     }

--- a/src/newmagic.cpp
+++ b/src/newmagic.cpp
@@ -249,7 +249,7 @@ void totem_bonus(struct char_data *ch, int action, int type, int &target, int &s
   } else if (GET_TOTEM(ch) == TOTEM_SCORPION && (time_info.hours > 6 && time_info.hours < 19)) {
     target += 2;
   } else if (GET_TOTEM(ch) == TOTEM_SPIDER && OUTSIDE(ch)) {
-    target += 2;
+    target += 1;  // MitS 157: +2 in the open, away from immediate shelter (which we can't check for)
   }
 
   if (action == SPELLCASTING)

--- a/src/newmagic.cpp
+++ b/src/newmagic.cpp
@@ -1428,6 +1428,7 @@ int resist_spell(struct char_data *ch, int spell, int force, int sub)
                    GET_OBJ_NAME(eq),
                    GET_OBJ_VNUM(eq),
                    GET_FOCUS_FORCE(eq));
+          break;
         } else {
           snprintf(ENDOF(rbuf), sizeof(rbuf) - strlen(rbuf), " - Skipping spell defense focus %s (%ld): %s, %s\r\n",
                    GET_OBJ_NAME(eq),

--- a/src/newmagic.cpp
+++ b/src/newmagic.cpp
@@ -5660,11 +5660,15 @@ ACMD(do_order)
     }
     if (spirit->services < 1 && order != SERV_LEAVE) {
       send_to_char(ch, "The %s no longer listens to you.\r\n", GET_TRADITION(ch) == TRAD_HERMETIC ? "elemental" : "spirit");
+      send_to_char(ch, "^[F222](OOC: You should RELEASE your %s since they don't owe you any more services.)^n\r\n", GET_TRADITION(ch) == TRAD_HERMETIC ? "elemental" : "spirit");
       return;
     }
     ((*services[order].func) (ch, mob, spirit, buf2));
-    if (order != SERV_LEAVE)
-      elemental_fulfilled_services(ch, mob, spirit);
+
+    // This also extracts nature spirits and thus immediately ends open ended powers such as conceal, confusion, etc.
+    // Easier to just require the conjurer to manually release an elemental/spirit that has 0 services remaining.
+    // if (order != SERV_LEAVE)
+    //   elemental_fulfilled_services(ch, mob, spirit);
   }
 }
 

--- a/src/newmagic.cpp
+++ b/src/newmagic.cpp
@@ -1416,6 +1416,7 @@ int resist_spell(struct char_data *ch, int spell, int force, int sub)
   }
 
   if (GET_FOCI(ch) > 0) {
+    int max_spell_def = 0;    
     for (int wearslot = 0; wearslot < NUM_WEARS; wearslot++) {
       struct obj_data *eq = GET_EQ(ch, wearslot);
       if (eq
@@ -1423,12 +1424,11 @@ int resist_spell(struct char_data *ch, int spell, int force, int sub)
           && GET_FOCUS_TYPE(eq) == FOCI_SPELL_DEFENSE)
       {
         if (focus_is_usable_by_ch(eq, ch) && GET_FOCUS_ACTIVATED(eq)) {
-          skill += GET_FOCUS_FORCE(eq);
-          snprintf(ENDOF(rbuf), sizeof(rbuf) - strlen(rbuf), " - Using spell defense focus %s (%ld) for +%d skill.\r\n",
+          max_spell_def = MAX(max_spell_def, GET_FOCUS_FORCE(eq));
+          snprintf(ENDOF(rbuf), sizeof(rbuf) - strlen(rbuf), " - Found spell defense focus %s (%ld) with rating +%d.\r\n",
                    GET_OBJ_NAME(eq),
                    GET_OBJ_VNUM(eq),
                    GET_FOCUS_FORCE(eq));
-          break;
         } else {
           snprintf(ENDOF(rbuf), sizeof(rbuf) - strlen(rbuf), " - Skipping spell defense focus %s (%ld): %s, %s\r\n",
                    GET_OBJ_NAME(eq),
@@ -1439,6 +1439,9 @@ int resist_spell(struct char_data *ch, int spell, int force, int sub)
         }
       }
     }
+    skill += max_spell_def;
+    snprintf(ENDOF(rbuf), sizeof(rbuf) - strlen(rbuf), " - Using best spell defense focus for +%d skill.\r\n",
+             max_spell_def);
   }
 
   skill += GET_SDEFENSE(ch);

--- a/src/newmagic.cpp
+++ b/src/newmagic.cpp
@@ -249,7 +249,7 @@ void totem_bonus(struct char_data *ch, int action, int type, int &target, int &s
   } else if (GET_TOTEM(ch) == TOTEM_SCORPION && (time_info.hours > 6 && time_info.hours < 19)) {
     target += 2;
   } else if (GET_TOTEM(ch) == TOTEM_SPIDER && OUTSIDE(ch)) {
-    target++;
+    target += 2;
   }
 
   if (action == SPELLCASTING)

--- a/src/newmagic.cpp
+++ b/src/newmagic.cpp
@@ -1954,7 +1954,8 @@ void raw_cast_health_spell(struct char_data *ch, struct char_data *vict, int spe
       // fall through
     case SPELL_HEAL:
       {
-        if (AFF_FLAGGED(vict, AFF_HEALED)) {
+        // House rule: don't limit heals if the victim is still mortally wounded.
+        if (AFF_FLAGGED(vict, AFF_HEALED) && GET_PHYSICAL(vict) >= 100) {
           send_to_char(ch, "%s has been healed too recently for this spell.\r\n", GET_NAME(vict));
           return;
         }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -6659,7 +6659,7 @@ bool obj_is_apartment_only_drop_item(struct obj_data *obj, struct room_data *des
       return TRUE;
     case ITEM_MAGIC_TOOL:
       // You can only drop conjuring libraries, and only then at power sites.
-      return GET_MAGIC_TOOL_TYPE(obj) != TYPE_LIBRARY_CONJURE || (dest_room && dest_room->background[CURRENT_BACKGROUND_TYPE] == AURA_POWERSITE);
+      return GET_MAGIC_TOOL_TYPE(obj) != TYPE_LIBRARY_CONJURE || (dest_room && dest_room->background[CURRENT_BACKGROUND_TYPE] != AURA_POWERSITE);
     case ITEM_DECK_ACCESSORY:
       // You can't drop parts/chips, nor can you drop computers unless they're laptops.
       return (GET_DECK_ACCESSORY_TYPE(obj) == TYPE_PARTS) || (GET_DECK_ACCESSORY_TYPE(obj) == TYPE_COMPUTER && !GET_DECK_ACCESSORY_COMPUTER_IS_LAPTOP(obj));


### PR DESCRIPTION
1. Spider totem penalty for outdoor magics should be +2, per MitS pg 157.
2. Add dice from spell defense foci to invisibility resistance tests. If spell pool allocated to spell defense / reflect apply, then an activated spell defense foci should also apply.
3. Fix the logic to enable dropping conjuring libraries at power sites. Casting buffs at a power site doesn't result in an unusual increase in successes, so conjuring there should be fine.
4. Remove auto-extraction of elementals/spirits when using their last service. Instead of adding exceptions for all the sustained nature spirit powers, easier to just require manual dismissal once services have been expended.

This addresses the following:
https://discord.com/channels/564618629467996170/788953927269613608/1241234594850930830
https://discord.com/channels/564618629467996170/1224099384527032431
https://discord.com/channels/564618629467996170/1241603104659603520