### PR TITLE
Minor fixes

### DIFF
--- a/src/act.movement.cpp
+++ b/src/act.movement.cpp
@@ -1908,7 +1908,7 @@ ACMD(do_drag)
 
     if (dir == -1 && veh) {
       // Does this veh fit in there?
-      if (veh->usedload + calculate_vehicle_entry_load(veh) > veh->load) {
+      if (veh->usedload + calculate_vehicle_entry_load(drag_veh) > veh->load) {
         send_to_char(ch, "%s won't fit in %s!", CAP(GET_VEH_NAME_NOFORMAT(drag_veh)), GET_VEH_NAME(veh));
         return;
       }

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -2386,18 +2386,21 @@ void docwagon_retrieve(struct char_data *ch) {
       int dw_random_cost = number(8, 12) * 500 / MAX(1, GET_DOCWAGON_CONTRACT_GRADE(docwagon));
       int creds = MAX(dw_random_cost, (int)(GET_NUYEN(ch) / 10));
 
-      send_to_char(ch, "DocWagon demands %d nuyen for your rescue.\r\n", creds);
+      send_to_char(ch, "DocWagon demands %d nuyen for your rescue.\r\n", dw_random_cost);
 
       if ((GET_NUYEN(ch) + GET_BANK(ch)) < creds) {
         send_to_char("Not finding sufficient payment, your DocWagon contract was retracted.\r\n", ch);
         extract_obj(docwagon);
       }
-      else if (GET_BANK(ch) < creds) {
-        lose_nuyen(ch, creds - GET_BANK(ch), NUYEN_OUTFLOW_DOCWAGON);
-        lose_bank(ch, GET_BANK(ch), NUYEN_OUTFLOW_DOCWAGON);
+      else if (GET_NUYEN(ch) < creds) {
+        lose_bank(ch, creds - GET_NUYEN(ch), NUYEN_OUTFLOW_DOCWAGON);
+        lose_nuyen(ch, GET_NUYEN(ch), NUYEN_OUTFLOW_DOCWAGON);
       }
       else {
-        lose_bank(ch, creds, NUYEN_OUTFLOW_DOCWAGON);
+        lose_nuyen(ch, creds, NUYEN_OUTFLOW_DOCWAGON);
+        if (creds > dw_random_cost) {
+          send_to_char(ch, "It seems that an additional %d nuyen has vanished from your cash-stuffed pockets.\r\n", creds - dw_random_cost);
+        }
       }
     } else {
       mudlog_vfprintf(ch, LOG_SYSLOG, "SYSERR: Could not find modulator after DW rescue of %s.", GET_CHAR_NAME(ch));

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -597,6 +597,14 @@ void affect_total(struct char_data * ch)
   GET_MAGIC_POOL(ch) = 0;
   GET_CONTROL(ch) = 0;
 
+  // These should also be set before other effects (like drugs) are applied
+  GET_MAX_MENTAL(ch) = 1000;
+  GET_MAX_PHYSICAL(ch) = 1000;
+  GET_TARGET_MOD(ch) = 0;
+  GET_CONCENTRATION_TARGET_MOD(ch) = 0;
+  GET_MAX_MENTAL(ch) -= GET_MENTAL_LOSS(ch) * 100;
+  GET_MAX_PHYSICAL(ch) -= GET_PHYSICAL_LOSS(ch) * 100;
+
   // Set reach, depending on race. Stripped out the 'you only get it at X height' thing since it's not canon and a newbie trap.
   if ((GET_RACE(ch) == RACE_TROLL || GET_RACE(ch) == RACE_CYCLOPS || GET_RACE(ch) == RACE_FOMORI || GET_RACE(ch) == RACE_GIANT ||
        GET_RACE(ch) == RACE_MINOTAUR || GET_RACE(ch) == RACE_GHOUL_TROLL || GET_RACE(ch) == RACE_DRAKE_TROLL) /* && GET_HEIGHT(ch) > 260 */)
@@ -912,12 +920,6 @@ void affect_total(struct char_data * ch)
     }
   }
 #endif
-  GET_MAX_MENTAL(ch) = 1000;
-  GET_MAX_PHYSICAL(ch) = 1000;
-  GET_TARGET_MOD(ch) = 0;
-  GET_CONCENTRATION_TARGET_MOD(ch) = 0;
-  GET_MAX_MENTAL(ch) -= GET_MENTAL_LOSS(ch) * 100;
-  GET_MAX_PHYSICAL(ch) -= GET_PHYSICAL_LOSS(ch) * 100;
 
   // Here so that other modifiers can't make the char immune to disabling via nerve strike
   if (GET_TEMP_QUI_LOSS(ch))

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -624,7 +624,7 @@ struct command_info cmd_info[] =
     { "domain"     , POS_LYING   , do_domain   , 0, 0, BLOCKS_IDLE_REWARD },
     { "download"   , POS_RESTING , do_download_headware, 0, 0, BLOCKS_IDLE_REWARD },
     { "donate"     , POS_RESTING , do_drop     , 0, SCMD_DONATE, BLOCKS_IDLE_REWARD },
-    { "drag"       , POS_STANDING, do_drag     , 0, 0, BLOCKS_IDLE_REWARD },
+    { "drag"       , POS_SITTING , do_drag     , 0, 0, BLOCKS_IDLE_REWARD },
     { "drink"      , POS_RESTING , do_drink    , 0, SCMD_DRINK, BLOCKS_IDLE_REWARD },
     { "drive"      , POS_SITTING , do_drive    , 0, 0, BLOCKS_IDLE_REWARD },
     { "drop"       , POS_LYING   , do_drop     , 0, SCMD_DROP, BLOCKS_IDLE_REWARD },

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -626,7 +626,7 @@ struct command_info cmd_info[] =
     { "domain"     , POS_LYING   , do_domain   , 0, 0, BLOCKS_IDLE_REWARD },
     { "download"   , POS_RESTING , do_download_headware, 0, 0, BLOCKS_IDLE_REWARD },
     { "donate"     , POS_RESTING , do_drop     , 0, SCMD_DONATE, BLOCKS_IDLE_REWARD },
-    { "drag"       , POS_SITTING , do_drag     , 0, 0, BLOCKS_IDLE_REWARD },
+    { "drag"       , POS_STANDING, do_drag     , 0, 0, BLOCKS_IDLE_REWARD },
     { "drink"      , POS_RESTING , do_drink    , 0, SCMD_DRINK, BLOCKS_IDLE_REWARD },
     { "drive"      , POS_SITTING , do_drive    , 0, 0, BLOCKS_IDLE_REWARD },
     { "drop"       , POS_LYING   , do_drop     , 0, SCMD_DROP, BLOCKS_IDLE_REWARD },


### PR DESCRIPTION
1. Better messaging will let players know that excess cash-in-hand is the reason for increased docwagon retrieval costs. For consistency (and for better in-universe reasoning), cost of retrieval is paid from cash-in-hand first, and then from the bank only if cash-in-hand is insufficient.

2. Max physical/mental boxes and target mods should be reset _before_ various effects (like drugs) are applied. This solves the missing TN penalties when undergoing drug withdrawal: https://discord.com/channels/564618629467996170/788953927269613608/1228962851381575791

3. (reverted)

4. When dragging veh A into veh B, check the weight of veh A instead of veh B.