### PR TITLE
Hermes tweaks

### DIFF
--- a/src/spec_procs.cpp
+++ b/src/spec_procs.cpp
@@ -6367,8 +6367,8 @@ SPECIAL(mageskill_hermes)
             dq = TRUE;
         if (dq) {
           // Reject people who couldn't pass the quest.
-          if (GET_MAG(ch) <= 0 || GET_TRADITION(ch) == TRAD_MUNDANE || (GET_SKILL(ch, SKILL_SORCERY) < 8 && GET_SKILL(ch, SKILL_AURA_READING) < 8)) {
-            snprintf(arg, sizeof(arg), "%s It's nice, isn't it? It's something that only elite awakened ones can obtain.", GET_CHAR_NAME(ch));
+          if (GET_MAG(ch) <= 0 || GET_TRADITION(ch) == TRAD_MUNDANE || (GET_SKILL(ch, SKILL_SORCERY) < 8 && GET_SKILL(ch, SKILL_CONJURING) < 8 && GET_SKILL(ch, SKILL_AURA_READING) < 8)) {
+            snprintf(arg, sizeof(arg), "%s It's nice, isn't it? It's something that only highly skilled awakened practitioners can obtain.", GET_CHAR_NAME(ch));
             do_say(mage, arg, 0, SCMD_SAYTO);
             return TRUE;
           }


### PR DESCRIPTION
Specify that Hermes is looking for _highly skilled_ awakened. This solves the edge case where a lower skilled awakened may be directed here but isn't able to figure out why they can't pick up the quest.

Also, allow conjuring skill as an alternative to sorcery/aura reading (e.g., for summoning focused or aspected characters).

This addresses:
https://discord.com/channels/564618629467996170/788953927269613608/1251271414405664808
https://discord.com/channels/564618629467996170/788953927269613608/1251271642458492928