### PR TITLE
Fix for hedit 'x' crash, v.2

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -5542,25 +5542,14 @@ void free_host(struct host_data * host)
     host->trigger = NULL;
   }
 
-  { // Clean up associated entrances.
-    for (struct exit_data *exit = host->exit; exit; exit = exit->next) {
-      // Find the exit's matching entrance in the destination host.
-      rnum_t dest_rnum = real_host(exit->host);
-      if (dest_rnum >= 0) {
-        struct entrance_data *entrance = NULL, *temp;
-        for (entrance = matrix[dest_rnum].entrance; entrance; entrance = entrance->next) {
-          if (entrance->host == host)
-            break;
-        }
-        // Remove that entrance.
-        if (entrance) {
-          REMOVE_FROM_LIST(entrance, matrix[dest_rnum].entrance, next);
-          DELETE_AND_NULL(entrance);
-        } else {
-          log("SYSERR: Found no associated entrance in free_host()! ('x' option during hedit?)");
-        }
-      }
+  { // Clean up entrances in this host that lead to other hosts.
+    // Entrances in other hosts that lead to this host are rebuilt by collate_host_entrances().
+    struct entrance_data *entrance = NULL, *next = NULL;
+    for (entrance = host->entrance; entrance; entrance = next) {
+      next = entrance->next;
+      delete entrance;
     }
+    host->entrance = NULL;
   }
 
   { // Clean up the exits.

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -5543,10 +5543,9 @@ void free_host(struct host_data * host)
   }
 
   { // Clean up associated entrances.
-    rnum_t dest_rnum;
     for (struct exit_data *exit = host->exit; exit; exit = exit->next) {
       // Find the exit's matching entrance in the destination host.
-      dest_rnum = real_host(exit->host);
+      rnum_t dest_rnum = real_host(exit->host);
       if (dest_rnum >= 0) {
         struct entrance_data *entrance = NULL, *temp;
         for (entrance = matrix[dest_rnum].entrance; entrance; entrance = entrance->next) {

--- a/src/hedit.cpp
+++ b/src/hedit.cpp
@@ -301,7 +301,10 @@ void hedit_parse(struct descriptor_data *d, const char *arg)
         send_to_char("Writing host to disk.\r\n", d->character);
         write_host_to_disk(d->character->player_specials->saved.zonenum);
         send_to_char("Saved.\r\n", CH);
-        Mem->DeleteHost(d->edit_host);
+
+        // Use of clear_host here instead of DeleteHost lets us keep the same linked lists
+        clear_host(d->edit_host);
+        delete d->edit_host;
         d->edit_host = NULL;
         PLR_FLAGS(d->character).RemoveBit(PLR_EDITING);
         STATE(d) = CON_PLAYING;

--- a/src/hedit.cpp
+++ b/src/hedit.cpp
@@ -213,12 +213,6 @@ void hedit_parse(struct descriptor_data *d, const char *arg)
     case 'N':
       STATE(d) = CON_PLAYING;
       if (d->edit_host) {
-        // Drop our exits, they have no pair to remove so no further cleanup is needed.
-        for (struct entrance_data *entrance = d->edit_host->entrance, *next; entrance; entrance = next) {
-          next = entrance->next;
-          delete entrance;
-        }
-        d->edit_host->entrance = NULL;
         Mem->DeleteHost(d->edit_host);
       }
       d->edit_host = NULL;
@@ -307,8 +301,7 @@ void hedit_parse(struct descriptor_data *d, const char *arg)
         send_to_char("Writing host to disk.\r\n", d->character);
         write_host_to_disk(d->character->player_specials->saved.zonenum);
         send_to_char("Saved.\r\n", CH);
-        clear_host(d->edit_host);
-        delete d->edit_host;
+        Mem->DeleteHost(d->edit_host);
         d->edit_host = NULL;
         PLR_FLAGS(d->character).RemoveBit(PLR_EDITING);
         STATE(d) = CON_PLAYING;
@@ -320,12 +313,6 @@ void hedit_parse(struct descriptor_data *d, const char *arg)
       send_to_char("Host not saved, aborting.\r\n", d->character);
       STATE(d) = CON_PLAYING;
       if (d->edit_host) {
-        // Drop our exits, they have no pair to remove so no further cleanup is needed.
-        for (struct entrance_data *entrance = d->edit_host->entrance, *next; entrance; entrance = next) {
-          next = entrance->next;
-          delete entrance;
-        }
-        d->edit_host->entrance = NULL;
         Mem->DeleteHost(d->edit_host);
       }
       d->edit_host = NULL;

--- a/src/hedit.cpp
+++ b/src/hedit.cpp
@@ -212,9 +212,17 @@ void hedit_parse(struct descriptor_data *d, const char *arg)
     case 'n':
     case 'N':
       STATE(d) = CON_PLAYING;
-      if (d->edit_host)
+      if (d->edit_host) {
+        // Drop our exits, they have no pair to remove so no further cleanup is needed.
+        for (struct entrance_data *entrance = d->edit_host->entrance, *next; entrance; entrance = next) {
+          next = entrance->next;
+          delete entrance;
+        }
+        d->edit_host->entrance = NULL;
         Mem->DeleteHost(d->edit_host);
+      }
       d->edit_host = NULL;
+      d->edit_number = 0;
       PLR_FLAGS(d->character).RemoveBit(PLR_EDITING);
       break;
     default:
@@ -311,7 +319,6 @@ void hedit_parse(struct descriptor_data *d, const char *arg)
     case 'N':
       send_to_char("Host not saved, aborting.\r\n", d->character);
       STATE(d) = CON_PLAYING;
-      PLR_FLAGS(d->character).RemoveBit(PLR_EDITING);
       if (d->edit_host) {
         // Drop our exits, they have no pair to remove so no further cleanup is needed.
         for (struct entrance_data *entrance = d->edit_host->entrance, *next; entrance; entrance = next) {
@@ -323,6 +330,7 @@ void hedit_parse(struct descriptor_data *d, const char *arg)
       }
       d->edit_host = NULL;
       d->edit_number = 0;
+      PLR_FLAGS(d->character).RemoveBit(PLR_EDITING);
       break;
     default:
       send_to_char("Invalid choice!\r\n", d->character);

--- a/src/olc.cpp
+++ b/src/olc.cpp
@@ -2183,27 +2183,6 @@ ACMD(do_hedit)
       }
     }
 
-    // Duplicate the entrances.
-    if (matrix[host_num].entrance) {
-      host->entrance = new entrance_data;
-      struct entrance_data *temp = host->entrance;
-      for (struct entrance_data *ent_ptr = matrix[host_num].entrance; ent_ptr; ent_ptr = ent_ptr->next) {
-        // overwrite temp's values with the ones from ent_ptr
-        *temp = *ent_ptr;
-
-        // if there's supposed to be an entrance after this in the chain, create a new one
-        if (ent_ptr->next) {
-          temp->next = new entrance_data;
-          temp = temp->next;
-        }
-        // otherwise, make sure it's marked as null
-        else {
-          temp->next = NULL;
-          break;
-        }
-      }
-    }
-
     // Duplicate the exits.
     if (matrix[host_num].exit) {
       host->exit = new exit_data;

--- a/src/olc.cpp
+++ b/src/olc.cpp
@@ -2208,6 +2208,9 @@ ACMD(do_hedit)
       }
     }
 
+    // Don't duplicate entrances, since we rebuild them after changes are saved
+    host->entrance = NULL;
+
     d->edit_host = host;
 #ifdef CONFIRM_EXISTING
 

--- a/src/olc.cpp
+++ b/src/olc.cpp
@@ -2183,21 +2183,27 @@ ACMD(do_hedit)
 
     // Duplicate the exits.
     if (matrix[host_num].exit) {
-      struct exit_data *This, *temp, *temp2;
+      struct exit_data *temp;
 
       temp = new exit_data;
       host->exit = temp;
-      for (This = matrix[host_num].exit; This; This = This->next) {
-        *temp = *This;
-        if (This->addresses)
-          temp->addresses = str_dup(This->addresses);
-        if (This->roomstring)
-          temp->roomstring = str_dup(This->roomstring);
-        if (This->next) {
-          temp2 = new exit_data;
-          temp->next = temp2;
-          temp = temp2;
-        } else
+      for (struct exit_data *exit_ptr = matrix[host_num].exit; exit_ptr; exit_ptr = exit_ptr->next) {
+        // overwrite temp's values with the ones from exit_ptr
+        *temp = *exit_ptr;
+
+        // str_dup any strings
+        if (exit_ptr->addresses)
+          temp->addresses = str_dup(exit_ptr->addresses);
+        if (exit_ptr->roomstring)
+          temp->roomstring = str_dup(exit_ptr->roomstring);
+
+        // if there's supposed to be an exit after this in the chain, create a new one
+        if (exit_ptr->next) {
+          temp->next = new exit_data;
+          temp = temp->next;
+        } 
+        // otherwise, make sure it's marked as null
+        else
           temp->next = NULL;
       }
     }


### PR DESCRIPTION
1. When host changes are saved, we call `collate_host_entrances` to rebuild entrance lists. Thus, when deleting host A, we don't need to search other hosts for entrances pointing to host A. This solves the issue of trying to find an entrance in another host that may not (yet) exist.

2. It makes sense to clear host A's own list of entrances as part of `free_host` instead of in `hedit`.

3. When making a copy of an existing host for editing in `olc`, we don't want the copy to point to the existing host's list of entrances. This solves the issue where we can end up with a pointer directing us to freed memory. We also don't need to make a copy of the list because `collate_host_entrances` will rebuild the list if/when we save, so we can just set it to null.