### PR TITLE
Metavariant social penalty bits (add newbie tip, no penalties w/ vending machines)

### DIFF
--- a/src/newshop.cpp
+++ b/src/newshop.cpp
@@ -1841,7 +1841,7 @@ void shop_list(char *arg, struct char_data *ch, struct char_data *keeper, vnum_t
   if (has_availtns) {
     send_to_char(ch, "This shop uses %s for difficult purchases.\r\n", skills[shop_table[shop_nr].etiquette].name);
     if (SHOULD_SEE_TIPS(ch) && get_metavariant_penalty(ch, keeper))
-      send_to_char(ch, "NOTE: %s ^w%s^n will suffer penalties to etiquette/negotiation tests here.\r\n",
+      send_to_char(ch, "NOTE: %s ^W%s^n will suffer penalties to etiquette/negotiation tests here.\r\n",
                    AN(pc_race_types_decap[(int)GET_RACE(ch)]), pc_race_types_decap[(int)GET_RACE(ch)]);
   }
 }

--- a/src/newshop.cpp
+++ b/src/newshop.cpp
@@ -1291,7 +1291,7 @@ void shop_buy(char *arg, size_t arg_len, struct char_data *ch, struct char_data 
                                        GET_OBJ_AVAILTN(obj),
                                        GET_AVAIL_OFFSET(ch),
                                        GET_POWER(ch, ADEPT_KINESICS),
-                                       GET_RACE(ch) != GET_RACE(keeper) ? get_metavariant_penalty(ch) : 0,
+                                       ((GET_RACE(ch) != GET_RACE(keeper)) && !MOB_FLAGGED(keeper, MOB_INANIMATE)) ? get_metavariant_penalty(ch) : 0,
                                        abs(GET_BEST_LIFESTYLE(ch)),
                                        phero ? GET_BIOWARE_RATING(phero) * (GET_BIOWARE_IS_CULTURED(phero) ? 2 : 1) : 0,
                                        0);

--- a/src/newshop.cpp
+++ b/src/newshop.cpp
@@ -1838,8 +1838,11 @@ void shop_list(char *arg, struct char_data *ch, struct char_data *keeper, vnum_t
   if (SHOULD_SEE_TIPS(ch))
     send_to_char("\r\nUse ^WPROBE^n for more details.\r\n", ch);
 
-  if (has_availtns)
+  if (has_availtns) {
     send_to_char(ch, "This shop uses %s for difficult purchases.\r\n", skills[shop_table[shop_nr].etiquette].name);
+    if (SHOULD_SEE_TIPS(ch) && get_metavariant_penalty)
+      send_to_char("\r\n^wMetavariants^n may suffer etiquette/negotiation penalties.\r\n", ch);
+  }
 }
 
 void shop_value(char *arg, struct char_data *ch, struct char_data *keeper, vnum_t shop_nr)

--- a/src/newshop.cpp
+++ b/src/newshop.cpp
@@ -1291,7 +1291,7 @@ void shop_buy(char *arg, size_t arg_len, struct char_data *ch, struct char_data 
                                        GET_OBJ_AVAILTN(obj),
                                        GET_AVAIL_OFFSET(ch),
                                        GET_POWER(ch, ADEPT_KINESICS),
-                                       ((GET_RACE(ch) != GET_RACE(keeper)) && !MOB_FLAGGED(keeper, MOB_INANIMATE)) ? get_metavariant_penalty(ch) : 0,
+                                       get_metavariant_penalty(ch, keeper),
                                        abs(GET_BEST_LIFESTYLE(ch)),
                                        phero ? GET_BIOWARE_RATING(phero) * (GET_BIOWARE_IS_CULTURED(phero) ? 2 : 1) : 0,
                                        0);
@@ -1840,8 +1840,9 @@ void shop_list(char *arg, struct char_data *ch, struct char_data *keeper, vnum_t
 
   if (has_availtns) {
     send_to_char(ch, "This shop uses %s for difficult purchases.\r\n", skills[shop_table[shop_nr].etiquette].name);
-    if (SHOULD_SEE_TIPS(ch) && get_metavariant_penalty)
-      send_to_char("\r\n^wMetavariants^n may suffer etiquette/negotiation penalties.\r\n", ch);
+    if (SHOULD_SEE_TIPS(ch) && get_metavariant_penalty(ch, keeper))
+      send_to_char(ch, "NOTE: %s ^w%s^n will suffer penalties to etiquette/negotiation tests here.\r\n",
+                   AN(pc_race_types_decap[(int)GET_RACE(ch)]), pc_race_types_decap[(int)GET_RACE(ch)]);
   }
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1536,8 +1536,10 @@ void _get_negotiation_data(
 #endif
 
   // Apply metavariant penalty whether or not it's a negotiation test.
+  // Vending machines don't care what you look like.
   if (include_metavariant_penalty
       && GET_RACE(ch) != GET_RACE(tch)
+      && !MOB_FLAGGED(tch, MOB_INANIMATE)
       && (metavariant_penalty = get_metavariant_penalty(ch)))
   {
     snprintf(ENDOF(tn_rbuf), sizeof(tn_rbuf) - strlen(tn_rbuf), "%sMetavariant %d", wrote_something ? ", " : "", metavariant_penalty);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1448,7 +1448,7 @@ int get_speed(struct veh_data *veh)
 }
 
 #define METAVARIANT_PENALTY 4
-int get_metavariant_penalty(struct char_data *ch) {
+int get_metavariant_penalty(struct char_data *ch, struct char_data *tch) {
   // Base races take no penalties.
   if (GET_RACE(ch) >= RACE_HUMAN && GET_RACE(ch) <= RACE_TROLL)
     return 0;
@@ -1459,6 +1459,14 @@ int get_metavariant_penalty(struct char_data *ch) {
 
   // Ghouls take no penalties (they look like messed-up base races, and only can shop at ghoul-friendly establishments to begin with)
   if (IS_GHOUL(ch))
+    return 0;
+
+  // No penalties when interacting with same race.
+  if (GET_RACE(ch) == GET_RACE(tch))
+    return 0;
+
+  // No penalties when interacting with vending machines.
+  if (MOB_FLAGGED(tch, MOB_INANIMATE))
     return 0;
 
   // Everyone else takes a +4, including metaform dragons (houserule: they're alien enough in nature that they flub social things)
@@ -1536,11 +1544,8 @@ void _get_negotiation_data(
 #endif
 
   // Apply metavariant penalty whether or not it's a negotiation test.
-  // Vending machines don't care what you look like.
   if (include_metavariant_penalty
-      && GET_RACE(ch) != GET_RACE(tch)
-      && !MOB_FLAGGED(tch, MOB_INANIMATE)
-      && (metavariant_penalty = get_metavariant_penalty(ch)))
+      && (metavariant_penalty = get_metavariant_penalty(ch, tch)))
   {
     snprintf(ENDOF(tn_rbuf), sizeof(tn_rbuf) - strlen(tn_rbuf), "%sMetavariant %d", wrote_something ? ", " : "", metavariant_penalty);
     wrote_something = TRUE;

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -164,7 +164,7 @@ const char *get_ch_domain_str(struct char_data *ch, bool include_possibilities);
 void    zero_cost_of_obj_and_contents(struct obj_data *obj);
 struct char_data *ch_is_grouped_with_idnum(struct char_data *ch, idnum_t idnum);
 void    log_traceback(const char *context, ...);
-int     get_metavariant_penalty(struct char_data *ch);
+int     get_metavariant_penalty(struct char_data *ch, struct char_data *tch);
 int     get_total_active_focus_rating(struct char_data *i, int &total);
 void    add_ch_to_character_list(struct char_data *ch, const char *source);
 void    remove_ch_from_character_list(struct char_data *ch, const char *source);


### PR DESCRIPTION
Added checks so that metavariant penalties aren't applied when a character is interacting with some kind of inanimate, since vending machines shouldn't care what you look like. Other inanimates (robots, etc) _probably_ also shouldn't care.