### PR TITLE
On NPC death, leave up to one round in their firearm

### DIFF
--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -686,7 +686,7 @@ void make_corpse(struct char_data * ch)
       else {
         // Zero out magazines from this and everything it contains.
         // Leave a round in NPC firearms so characters get some indication of what ammo was being used against them
-        zero_out_magazine_counts(o, IS_NPC(ch));
+        zero_out_magazine_counts(o, IS_NPC(ch) ? 1 : 0);
 
         // Put the item in the corpse.
         obj_to_obj(o, corpse);

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -76,7 +76,7 @@ bool damage(struct char_data *ch, struct char_data *victim, int dam, int attackt
 bool damage_without_message(struct char_data *ch, struct char_data *victim, int dam, int attacktype, bool is_physical);
 bool raw_damage(struct char_data *ch, struct char_data *victim, int dam, int attacktype, bool is_physical, bool send_message);
 void docwagon_retrieve(struct char_data *ch);
-void zero_out_magazine_counts(struct obj_data *obj);
+void zero_out_magazine_counts(struct obj_data *obj, int max_ammo_remaining = 0);
 
 SPECIAL(weapon_dominator);
 SPECIAL(pocket_sec);
@@ -685,7 +685,8 @@ void make_corpse(struct char_data * ch)
         extract_obj(o);
       else {
         // Zero out magazines from this and everything it contains.
-        zero_out_magazine_counts(o);
+        // Leave a round in NPC firearms so characters get some indication of what ammo was being used against them
+        zero_out_magazine_counts(o, IS_NPC(ch));
 
         // Put the item in the corpse.
         obj_to_obj(o, corpse);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -8117,16 +8117,16 @@ bool ch_is_in_viewers_visual_range(struct char_data *ch, struct char_data *viewe
   return FALSE;
 }
 
-void zero_out_magazine_counts(struct obj_data *obj) {
+void zero_out_magazine_counts(struct obj_data *obj, int max_ammo_remaining = 0) {
   if (!obj) {
     mudlog_vfprintf(NULL, LOG_SYSLOG, "SYSERR: Got NULL object to zero_out_magazine_counts().");
     return;
   }
 
-  if (GET_OBJ_TYPE(obj) == ITEM_GUN_MAGAZINE)
-    GET_MAGAZINE_AMMO_COUNT(obj) = 0;
+  if ((GET_OBJ_TYPE(obj) == ITEM_GUN_MAGAZINE) && (GET_MAGAZINE_AMMO_COUNT(obj) > max_ammo_remaining))
+    GET_MAGAZINE_AMMO_COUNT(obj) = max_ammo_remaining;
 
   for (struct obj_data *contained = obj->contains; contained; contained = contained->next_content) {
-    zero_out_magazine_counts(contained);
+    zero_out_magazine_counts(contained, max_ammo_remaining);
   }
 }


### PR DESCRIPTION
When ammo dropped in NPC firearms, players could learn what type of ammo was being fired at them with an in-character mechanism, helping them understand why some enemies are more dangerous than others. Allowing up to one round to remain in dropped NPC firearms restores this mechanism.

Technically, this restores some ability to farm ammo, but at no more than one round per firearm, it would be... inefficient. 