### PR TITLE
Don't compare vision penalties against those ch doesn't have

### DIFF
--- a/src/vision_overhaul.cpp
+++ b/src/vision_overhaul.cpp
@@ -351,11 +351,11 @@ int get_vision_penalty(struct char_data *ch, struct room_data *temp_room, char *
     }
   }
 
-  if (has_thermographic && tn_with_thermo <= tn_with_ll && tn_with_thermo <= tn_with_none) {
+  if (has_thermographic && (has_lowlight && (tn_with_thermo <= tn_with_ll)) && tn_with_thermo <= tn_with_none) {
     penalty_vector = &thermo_penalties;
     penalty_chosen = tn_with_thermo;
   }
-  else if (has_lowlight && tn_with_ll <= tn_with_thermo && tn_with_ll <= tn_with_none) {
+  else if (has_lowlight && (has_thermographic && (tn_with_ll <= tn_with_thermo)) && tn_with_ll <= tn_with_none) {
     penalty_vector = &lowlight_penalties;
     penalty_chosen = tn_with_ll;
   }

--- a/src/vision_overhaul.cpp
+++ b/src/vision_overhaul.cpp
@@ -351,11 +351,11 @@ int get_vision_penalty(struct char_data *ch, struct room_data *temp_room, char *
     }
   }
 
-  if (has_thermographic && (has_lowlight && (tn_with_thermo <= tn_with_ll)) && tn_with_thermo <= tn_with_none) {
+  if (has_thermographic && (!has_lowlight || (tn_with_thermo <= tn_with_ll)) && tn_with_thermo <= tn_with_none) {
     penalty_vector = &thermo_penalties;
     penalty_chosen = tn_with_thermo;
   }
-  else if (has_lowlight && (has_thermographic && (tn_with_ll <= tn_with_thermo)) && tn_with_ll <= tn_with_none) {
+  else if (has_lowlight && (!has_thermographic || (tn_with_ll <= tn_with_thermo)) && tn_with_ll <= tn_with_none) {
     penalty_vector = &lowlight_penalties;
     penalty_chosen = tn_with_ll;
   }


### PR DESCRIPTION
Vision penalties are calculated in two steps:
1. Penalties for normal, LL, and thermo are summed up. This occurs regardless of whether you actually have the vision type. If you don't have the natural version of LL or thermo, then their respective calculations default to artificial versions.
2. If you have a vision type and its penalty is better than the other vision types, then you get that penalty.

But, (2) wasn't avoiding penalty comparisons against vision types the character doesn't have. If the penalty for an artificial vision type is lower, when you don't have that vision type, then you can end with a higher normal vision penalty. This PR provides a solution.

This addresses: https://discord.com/channels/564618629467996170/788953927269613608/1280229594561253504