### PR TITLE
Toxin extractors apply to drug onset damage as well as comedown

### DIFF
--- a/src/drugs.cpp
+++ b/src/drugs.cpp
@@ -271,8 +271,13 @@ bool process_drug_point_update_tick(struct char_data *ch) {
           damage_level++;
         }
 
+        int toxin_extractor_rating = 0;
+        for (struct obj_data *obj = ch->bioware; obj; obj = obj->next_content)
+          if (GET_BIOWARE_TYPE(obj) == BIO_TOXINEXTRACTOR)
+            toxin_extractor_rating = MAX(toxin_extractor_rating, GET_BIOWARE_RATING(obj));
+
         // The power of the damage is specified by the drug, and influenced by the doses taken.
-        int power = drug_types[drug_id].power;
+        int power = drug_types[drug_id].power - toxin_extractor_rating;
         if (GET_DRUG_DOSE(ch, drug_id) > 2) {
           power += GET_DRUG_DOSE(ch, drug_id) - 2;
         }


### PR DESCRIPTION
Previously, toxin extractors reduced the power of drug comedown damage. Man & Machine, pg 71, doesn't appear to have an exception for drug onset damage, so this PR applies toxin extractors to onset damage tests.