### PR TITLE
Fix adept distance strike & penetrating strike interactions

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -31,7 +31,7 @@ BOOST_FLAGS = -lboost_filesystem
 
 # You probably want to comment this out: This is the makefile specification for the GitHub runner.
 LIBS = -lcrypt -L/usr/local/lib $(COMMON_FLAGS) $(BOOST_FLAGS) -lnsl -lcurl
-MYFLAGS = -DNOCRYPT -Dlinux -I /usr/local/include/ -Wall -Wextra -Wno-unused-parameter
+MYFLAGS = -DNOCRYPT -Dlinux -I /usr/local/include/ -Wall -Wextra -Wno-unused-parameter -std=c++11
 
 # OSX? Uncomment these:
 #LIBS = -L/usr/local/lib $(COMMON_FLAGS) $(BOOST_FLAGS) -lsodium -lcurl
@@ -39,12 +39,12 @@ MYFLAGS = -DNOCRYPT -Dlinux -I /usr/local/include/ -Wall -Wextra -Wno-unused-par
 
 # Linux / others? Uncomment these:
 #LIBS = -lcrypt -L/usr/local/lib $(COMMON_FLAGS) -lnsl -lsodium -lcurl
-#MYFLAGS = -DDEBUG_CRYPTO -DDEBUG -DSELFADVANCE -DIDLEDELETE_DRYRUN -Dlinux -I /usr/local/include/ -Wall -Wextra -Wno-unused-parameter -DSUPPRESS_MOB_SKILL_ERRORS
+#MYFLAGS = -DDEBUG_CRYPTO -DDEBUG -DSELFADVANCE -DIDLEDELETE_DRYRUN -Dlinux -I /usr/local/include/ -Wall -Wextra -Wno-unused-parameter -DSUPPRESS_MOB_SKILL_ERRORS -std=c++11
 # If you want GitHub integration, add -DGITHUB_INTEGRATION to the above and fill out your basic auth credentials in github_config.cpp.
 
 # Cygwin:
 #LIBS = -L/usr/local/lib $(COMMON_FLAGS) -lsodium -lcrypt
-#MYFLAGS = -DDEBUG -DSELFADVANCE -DIDLEDELETE_DRYRUN -DWIN32 -I /usr/local/include/ -Wall -Wextra -Wno-unused-parameter -DSUPPRESS_MOB_SKILL_ERRORS
+#MYFLAGS = -DDEBUG -DSELFADVANCE -DIDLEDELETE_DRYRUN -DWIN32 -I /usr/local/include/ -Wall -Wextra -Wno-unused-parameter -DSUPPRESS_MOB_SKILL_ERRORS -std=c++11
 
 CPPFLAGS = $(MYFLAGS) $(PROFILE)
 

--- a/src/act.obj.cpp
+++ b/src/act.obj.cpp
@@ -4133,6 +4133,9 @@ ACMD(do_activate)
       send_to_char("Penetrating strike is not compatible with distance strike.\r\n", ch);
       return;
     }
+    // Improved reflexes isn't checked/blocked here. Its incompatibility (as written in
+    // SR3, pg 169) can be interpreted as "does not stack" and so highest applies.
+    // This is also how its handled in handler.cpp: affect_total(struct char_data * ch)
 
     if (i < ADEPT_NUMPOWER) {
       if (desired_level == 0)

--- a/src/act.obj.cpp
+++ b/src/act.obj.cpp
@@ -4123,6 +4123,17 @@ ACMD(do_activate)
             return;
           }
 
+    // Prevent activation of incompatible powers.
+    // Penetrating strike can't be conbined with distance strike (SotA 2064, pg 67).
+    if ((i == ADEPT_DISTANCE_STRIKE) && GET_POWER(ch, ADEPT_PENETRATINGSTRIKE)) {
+      send_to_char("Distance strike is not compatible with penetrating strike.\r\n", ch);
+      return;
+    }
+    if ((i == ADEPT_PENETRATINGSTRIKE) && GET_POWER(ch, ADEPT_DISTANCE_STRIKE)) {
+      send_to_char("Penetrating strike is not compatible with distance strike.\r\n", ch);
+      return;
+    }
+
     if (i < ADEPT_NUMPOWER) {
       if (desired_level == 0)
         desired_level = GET_POWER_TOTAL(ch, i);

--- a/src/newfight.cpp
+++ b/src/newfight.cpp
@@ -1315,6 +1315,10 @@ bool handle_flame_aura(struct combat_data *att, struct combat_data *def) {
   if (att->ranged_combat_mode || att->weapon)
     return FALSE;
 
+  // no-op: adept distance strike
+  if (GET_POWER(att->ch, ADEPT_DISTANCE_STRIKE))
+    return FALSE;
+
   int force = -1;
 
   // Flameaura-flagged NPCs just use the larger of half their magic or their own full level as the force.

--- a/src/newfight.cpp
+++ b/src/newfight.cpp
@@ -780,7 +780,7 @@ bool hit_with_multiweapon_toggle(struct char_data *attacker, struct char_data *v
     engage_close_combat_if_appropriate(att, def, net_reach);
     engage_close_combat_if_appropriate(def, att, -net_reach);
 
-    if (!GET_POWER(att->ch, ADEPT_PENETRATINGSTRIKE) && GET_POWER(att->ch, ADEPT_DISTANCE_STRIKE)) {
+    if (GET_POWER(att->ch, ADEPT_DISTANCE_STRIKE)) {
       // MitS 149: Ignore reach modifiers.
       net_reach = 0;
     }
@@ -920,7 +920,7 @@ bool hit_with_multiweapon_toggle(struct char_data *attacker, struct char_data *v
 
     // If your enemy got more successes than you, guess what? You're the one who gets their face caved in.
     if (net_successes < 0) {
-      if (!GET_POWER(att->ch, ADEPT_PENETRATINGSTRIKE) && GET_POWER(att->ch, ADEPT_DISTANCE_STRIKE)) {
+      if (GET_POWER(att->ch, ADEPT_DISTANCE_STRIKE)) {
         // MitS 149: You cannot be counterstriked while using distance strike.
         return FALSE;
       }


### PR DESCRIPTION
Previously, having both penetrating strike and distance strike active at the same time meant that neither would work. Also, an adept using distance strike would still get scorched by flame aura, despite being up to (magic) meters away from their target. This PR does the following:

1. If both powers are active, default to distance strike (that is, only disable penetrating strike)
2. Distance strike skips flame aura (similar to as if the adept was using a weapon).
3. For that matter, let's block power activation if an incompatible power is already active.
4. Added a comment on why we don't prevent activation of adept improved reflexes when other tech/magic reaction/init is active (we can interpret it as "does not stack" and so the character gets whichever bonus is higher, which is how it's handled in `handler.cpp: affect_total`.