### PR TITLE
Surprised targets don't penalize attacks against them

### DIFF
--- a/src/newfight.cpp
+++ b/src/newfight.cpp
@@ -363,7 +363,9 @@ bool hit_with_multiweapon_toggle(struct char_data *attacker, struct char_data *v
     }
 
     // Setup: If your attacker is closing the distance (running), take a penalty per Core p112.
-    if (!def->is_paralyzed_or_insensate) {
+    // We can't avoid setting AFF_APPROACH in set_fighting for surprised targets since it also
+    // indicates not-in-melee-range, so make an exception since they're probably not moving yet.
+    if (!def->is_paralyzed_or_insensate && !def->is_surprised) {
       if (AFF_FLAGGED(def->ch, AFF_APPROACH))
         att->ranged->modifiers[COMBAT_MOD_DEFENDER_MOVING] += 2;
       else if (!def->ranged_combat_mode && def->ch->in_room == att->ch->in_room && !IS_JACKED_IN(def->ch))


### PR DESCRIPTION
So, `set_fighting` sets the `AFF_APPROACH` flag when a combatant is wielding a melee weapon, which in turn means that somebody shooting at them gets the +2 TN `COMBAT_MOD_DEFENDER_MOVING` penalty. However, this penalty applies even if the combatant is surprised and thus may not realistically have a reason to already be moving.

We can't avoid setting `AFF_APPROACH` in `set_fighting` since it's also used to indicate that the combatant is not in melee range. So, this PR blocks the `COMBAT_MOD_DEFENDER_MOVING` penalty if the defender is surprised.

Balance-wise, this change would let assault cannons, when combined with surprise, be a viable option against the hive queen. Currently, the cannon-wielder attacks with TN = 4 (base) -3 (smartlink-2) +2 (ultrasound vs invis) +2 (moving) +2 (room darkness vs best non-ghoul vision) = 7, regardless of surprise, and the queen rolls soak against TN 2. If a mundane rolls their max possible 12 skill + 12 cp + 1 enhanced articulation +1 reflex recorder = 26 dice, then they would have a 10% chance for any damage at all (and thus a chance to end one of her buff spells) if she has no more than 18 soak dice. But the queen rolls significantly more dice than that - how much more depending on her combat sense spell.