### PR TITLE
Platelet factories & crash tests

### DIFF
--- a/src/act.drive.cpp
+++ b/src/act.drive.cpp
@@ -29,7 +29,7 @@ ACMD_CONST(do_return);
 int get_vehicle_modifier(struct veh_data *veh, bool include_weather=TRUE);
 void stop_vehicle(struct veh_data *veh);
 void stop_rigging(struct char_data *ch);
-void stop_driving(struct char_data *ch);
+void stop_driving(struct char_data *ch, bool is_involuntary);
 int calculate_vehicle_entry_load(struct veh_data *veh);
 
 extern int max_npc_vehicle_lootwreck_time;

--- a/src/act.drive.cpp
+++ b/src/act.drive.cpp
@@ -2574,26 +2574,25 @@ void stop_driving(struct char_data *ch, bool is_involuntary) {
   if (!ch || !ch->in_veh)
     return;
 
+  if (is_involuntary) {
+    send_to_char("The controls slip from your unresponsive fingers.\r\n", ch);
+    snprintf(buf1, sizeof(buf1), "%s slumps, the controls slipping from %s fingers.\r\n", capitalize(GET_NAME(ch)), HSHR(ch));
+    send_to_veh(buf1, VEH, ch, FALSE);
+    
+    if (ch->in_veh->cspeed > SPEED_IDLE) {
+      // Crash test with no driver -- they've gone unconscious or something.
+      crash_test(ch, TRUE);
+    }
+  } else {
+    send_to_char("You relinquish the driver's seat.\r\n", ch);
+    snprintf(buf1, sizeof(buf1), "%s relinquishes the driver's seat.\r\n", capitalize(GET_NAME(ch)));
+    send_to_veh(buf1, VEH, ch, FALSE);
+  }
+
   if (AFF_FLAGGED(ch, AFF_RIG) || PLR_FLAGGED(ch, PLR_REMOTE)) {
     stop_rigging(ch);
   } else if (AFF_FLAGGED(ch, AFF_PILOT)) {
     stop_vehicle(ch->in_veh);
     AFF_FLAGS(ch).RemoveBit(AFF_PILOT);
-
-    if (is_involuntary) {
-      send_to_char("The controls slip from your unresponsive fingers.\r\n", ch);
-      snprintf(buf1, sizeof(buf1), "%s slumps, the controls slipping from %s fingers.\r\n", capitalize(GET_NAME(ch)), HSHR(ch));
-      send_to_veh(buf1, VEH, ch, FALSE);
-      
-      if (ch->in_veh->cspeed > SPEED_IDLE) {
-        // Crash test with no driver -- they've gone unconscious or something.
-        crash_test(ch, TRUE);
-      }
-    } else {
-      send_to_char("You relinquish the driver's seat.\r\n", ch);
-      snprintf(buf1, sizeof(buf1), "%s relinquishes the driver's seat.\r\n", capitalize(GET_NAME(ch)));
-      send_to_veh(buf1, VEH, ch, FALSE);
-    }
   }
-
 }

--- a/src/act.drive.cpp
+++ b/src/act.drive.cpp
@@ -104,7 +104,7 @@ void stop_chase(struct veh_data *veh)
   veh->following = NULL;
 }
 
-void crash_test(struct char_data *ch, bool force_zero_successes)
+void crash_test(struct char_data *ch, bool no_driver)
 {
   int target = 0, skill = 0;
   int power, attack_resist = 0, damage_total = SERIOUS;
@@ -119,9 +119,9 @@ void crash_test(struct char_data *ch, bool force_zero_successes)
   snprintf(buf, sizeof(buf), "%s begins to lose control!\r\n", capitalize(GET_VEH_NAME_NOFORMAT(veh)));
   send_to_room(buf, get_veh_in_room(veh), veh);
 
-  skill = veh_skill(ch, veh, &target) + veh->autonav;
+  skill = (no_driver ? 0 : veh_skill(ch, veh, &target)) + veh->autonav;
 
-  if (!force_zero_successes && success_test(skill, target, ch, "crash_test vehicle skill test") > 0)
+  if (success_test(skill, target, ch, "crash_test vehicle skill test") > 0)
   {
     snprintf(crash_buf, sizeof(crash_buf), "^y%s shimmies sickeningly under you, but you manage to keep control.^n\r\n", capitalize(GET_VEH_NAME_NOFORMAT(veh)));
     send_to_veh(crash_buf, veh, NULL, TRUE);
@@ -2586,7 +2586,7 @@ void stop_driving(struct char_data *ch, bool is_involuntary) {
       send_to_veh(buf1, VEH, ch, FALSE);
       
       if (ch->in_veh->cspeed > SPEED_IDLE) {
-        // Crash test with zero successes-- they've gone unconscious or something.
+        // Crash test with no driver -- they've gone unconscious or something.
         crash_test(ch, TRUE);
       }
     } else {

--- a/src/act.drive.cpp
+++ b/src/act.drive.cpp
@@ -123,10 +123,12 @@ void crash_test(struct char_data *ch, bool no_driver)
 
   if (success_test(skill, target, ch, "crash_test vehicle skill test") > 0)
   {
-    snprintf(crash_buf, sizeof(crash_buf), "^y%s shimmies sickeningly under you, but you manage to keep control.^n\r\n", capitalize(GET_VEH_NAME_NOFORMAT(veh)));
+    snprintf(crash_buf, sizeof(crash_buf), "^y%s shimmies sickeningly under you, but remains under control.^n\r\n", capitalize(GET_VEH_NAME_NOFORMAT(veh)));
     send_to_veh(crash_buf, veh, NULL, TRUE);
-    if (!number(0, 10))
-      send_to_char("^YYou don't have the skills to be driving like this!^n\r\n", ch);
+
+    // we didn't crash, so we *do* have the skills to be driving like this? - Khai
+    // if (!number(0, 10))
+    //   send_to_char("^YYou don't have the skills to be driving like this!^n\r\n", ch);
     return;
   }
   
@@ -156,11 +158,17 @@ void crash_test(struct char_data *ch, bool no_driver)
       char_to_room(tch, get_veh_in_room(veh));
       damage_total = convert_damage(stage(0 - success_test(GET_BOD(tch), power, tch, "crash_test damage resist"), MODERATE));
       send_to_char(tch, "You are thrown from the %s!\r\n", veh->type == VEH_BIKE ? "bike" : "boat");
-      if (damage(tch, tch, damage_total, TYPE_CRASH, PHYSICAL)) {
-        continue;
-      }
-      AFF_FLAGS(tch).RemoveBits(AFF_PILOT, AFF_RIG, ENDBIT);
+      damage(tch, tch, damage_total, TYPE_CRASH, PHYSICAL);
     }
+    AFF_FLAGS(ch).RemoveBits(AFF_PILOT, AFF_RIG, ENDBIT);
+    veh->cspeed = SPEED_OFF;
+    return;
+  }
+
+  // Can't drive wrecked vehicles
+  if (veh->damage >= VEH_DAM_THRESHOLD_DESTROYED) {
+    send_to_veh("You slam against your straps as you jerk to a sudden stop.\r\n", veh, 0, TRUE);
+    AFF_FLAGS(ch).RemoveBits(AFF_PILOT, AFF_RIG, ENDBIT);
     veh->cspeed = SPEED_OFF;
   }
 }

--- a/src/act.movement.cpp
+++ b/src/act.movement.cpp
@@ -830,7 +830,7 @@ void move_vehicle(struct char_data *ch, int dir)
   struct room_data *was_in = NULL;
   struct veh_data *veh;
   struct veh_follow *v, *nextv;
-  extern void crash_test(struct char_data *, bool);
+  extern void crash_test(struct char_data *, bool no_driver);
   char empty_argument = '\0';
 
   RIG_VEH(ch, veh);

--- a/src/act.other.cpp
+++ b/src/act.other.cpp
@@ -761,10 +761,10 @@ ACMD(do_use)
     if (do_drug_take(ch, obj))
       return;
   } else if (GET_OBJ_SPEC(obj) && GET_OBJ_SPEC(obj) == anticoagulant) {
-    for (struct obj_data *cyber = ch->bioware; cyber; cyber = cyber->next_content) {
-      if (GET_OBJ_VAL(cyber, 0) == BIO_PLATELETFACTORY) {
-        GET_OBJ_VAL(cyber, 5) = 36;
-        GET_OBJ_VAL(cyber, 6) = 0;
+    for (struct obj_data *bio = ch->bioware; bio; bio = bio->next_content) {
+      if (GET_BIOWARE_TYPE(bio) == BIO_PLATELETFACTORY) {
+        GET_BIOWARE_PLATELETFACTORY_DATA(bio) = 36;
+        GET_BIOWARE_PLATELETFACTORY_DIFFICULTY(bio) = 0;
         break;
       }
     }

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -96,7 +96,7 @@ extern struct zone_data *zone_table;
 extern void perform_tell(struct char_data *, struct char_data *, char *);
 extern int can_wield_both(struct char_data *, struct obj_data *, struct obj_data *);
 extern void find_and_draw_weapon(struct char_data *);
-extern void crash_test(struct char_data *ch, bool force_zero_successes);
+extern void crash_test(struct char_data *ch, bool no_driver);
 extern int get_vehicle_modifier(struct veh_data *veh, bool include_weather=TRUE);
 extern bool mob_magic(struct char_data *ch);
 extern void cast_spell(struct char_data *ch, int spell, int sub, int force, char *arg);

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -887,7 +887,7 @@ void death_cry(struct char_data * ch, idnum_t cause_of_death_idnum)
 
 void raw_kill(struct char_data * ch, idnum_t cause_of_death_idnum)
 {
-  struct obj_data *bio, *obj, *o;
+  struct obj_data *obj, *o;
   struct room_data *dest_room;
 
   if (CH_IN_COMBAT(ch))
@@ -926,20 +926,25 @@ void raw_kill(struct char_data * ch, idnum_t cause_of_death_idnum)
       make_corpse(ch);
 
     if (!IS_NPC(ch)) {
-      for (bio = ch->bioware; bio; bio = bio->next_content) {
+      // Disable bioware etc that resets on death.
+      for (struct obj_data *bio = ch->bioware; bio; bio = bio->next_content) {
         switch (GET_BIOWARE_TYPE(bio)) {
           case BIO_ADRENALPUMP:
-            if (GET_OBJ_VAL(bio, 5) > 0) {
+            if (GET_BIOWARE_PUMP_ADRENALINE(bio) > 0) {
               for (int affect_idx = 0; affect_idx < MAX_OBJ_AFFECT; affect_idx++)
                 affect_modify(ch,
                               bio->affected[affect_idx].location,
                               bio->affected[affect_idx].modifier,
                               bio->obj_flags.bitvector, FALSE);
-              GET_OBJ_VAL(bio, 5) = 0;
+              GET_BIOWARE_PUMP_ADRENALINE(bio) = 0;
             }
             break;
           case BIO_PAINEDITOR:
             GET_BIOWARE_IS_ACTIVATED(bio) = 0;
+            break;
+          case BIO_PLATELETFACTORY:
+            GET_BIOWARE_PLATELETFACTORY_DATA(bio) = 36;
+            GET_BIOWARE_PLATELETFACTORY_DIFFICULTY(bio) = 0;
             break;
         }
       }
@@ -2392,17 +2397,21 @@ void docwagon_retrieve(struct char_data *ch) {
   for (struct obj_data *bio = ch->bioware; bio; bio = bio->next_content) {
     switch (GET_BIOWARE_TYPE(bio)) {
       case BIO_ADRENALPUMP:
-        if (GET_OBJ_VAL(bio, 5) > 0) {
-          for (int i = 0; i < MAX_OBJ_AFFECT; i++)
+        if (GET_BIOWARE_PUMP_ADRENALINE(bio) > 0) {
+          for (int affect_idx = 0; affect_idx < MAX_OBJ_AFFECT; affect_idx++)
             affect_modify(ch,
-                          bio->affected[i].location,
-                          bio->affected[i].modifier,
+                          bio->affected[affect_idx].location,
+                          bio->affected[affect_idx].modifier,
                           bio->obj_flags.bitvector, FALSE);
-          GET_OBJ_VAL(bio, 5) = 0;
+          GET_BIOWARE_PUMP_ADRENALINE(bio) = 0;
         }
         break;
       case BIO_PAINEDITOR:
         GET_BIOWARE_IS_ACTIVATED(bio) = 0;
+        break;
+      case BIO_PLATELETFACTORY:
+        GET_BIOWARE_PLATELETFACTORY_DATA(bio) = 36;
+        GET_BIOWARE_PLATELETFACTORY_DIFFICULTY(bio) = 0;
         break;
     }
   }

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -966,6 +966,8 @@ void raw_kill(struct char_data * ch, idnum_t cause_of_death_idnum)
         dest_room = get_jurisdiction_docwagon_room(GET_JURISDICTION(in_room));
       }
 
+      stop_driving(ch, TRUE);
+
       if (ch->persona) {
         if (access_level(ch, LVL_PRESIDENT))
           send_to_char(ch, "^YExtracted icon from host.\r\n");
@@ -2358,6 +2360,8 @@ void docwagon_retrieve(struct char_data *ch) {
   if (GET_SUSTAINED(ch)) {
     end_all_sustained_spells(ch);
   }
+
+  stop_driving(ch, TRUE);
 
   // Remove them from the Matrix.
   if (ch->persona) {

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -2353,6 +2353,18 @@ void docwagon_retrieve(struct char_data *ch) {
   if (CH_IN_COMBAT(ch))
     stop_fighting(ch);
 
+  // Stop their vehicle
+  if ((ch->in_veh && AFF_FLAGGED(ch, AFF_PILOT)) || PLR_FLAGGED(ch, PLR_REMOTE)) {
+    struct veh_data *veh;
+    RIG_VEH(ch, veh);
+
+    send_to_veh("Now driverless, the vehicle slows to a stop.\r\n", veh, ch, FALSE);
+    AFF_FLAGS(ch).RemoveBits(AFF_PILOT, AFF_RIG, ENDBIT);
+    stop_chase(veh);
+    if (!veh->dest)
+      veh->cspeed = SPEED_OFF;
+  }
+
   // Stop all their sustained spells as if they died.
   if (GET_SUSTAINED(ch)) {
     end_all_sustained_spells(ch);


### PR DESCRIPTION
1. Synthacardium adds its rating in dice to resist cardiac and circulatory things (M&M pg 70), such as the platelet factories' risk of cardiac arrest when not taking anticoagulants for too long (M&M pg 69). This addresses https://discord.com/channels/564618629467996170/788953927269613608/1311143404419285105

2. DocWagon now gives aspirin to patients with platelet factories. This addresses https://discord.com/channels/564618629467996170/788953927269613608/1317680664346103829

3. Losing consciousness now stops a driver's vehicle (with a crash test using autonav dice) if it was moving. This occurs when damage causes POS_MORTALLYW, POS_STUNNED, or POS_DEAD, and is also checked in `raw_kill` and `docwagon_retrieve`. This addresses https://discord.com/channels/564618629467996170/788953927269613608/1317679405568364545

4. Crash tests now properly clears flags / stops the vehicle if the driver was ejected or the vehicle was destroyed.