### PR TITLE
Fix mental/physical recovery pos fail

### DIFF
--- a/src/limits.cpp
+++ b/src/limits.cpp
@@ -65,7 +65,7 @@ void mental_gain(struct char_data * ch)
   }
 
   // Can't regenerate? Skip.
-  if (IS_NPC(ch) && GET_DEFAULT_POS(ch) <= POS_STUNNED) {
+  if (GET_DEFAULT_POS(ch) <= POS_MORTALLYW) {
     return;
   }
 
@@ -170,7 +170,7 @@ void physical_gain(struct char_data * ch)
   }
 
   // Can't regenerate? Skip.
-  if (IS_NPC(ch) && GET_DEFAULT_POS(ch) == POS_MORTALLYW) {
+  if (GET_DEFAULT_POS(ch) <= POS_MORTALLYW) {
     return;
   }
 


### PR DESCRIPTION
Mortally wounded characters cannot recover without medical attention, but unconscious characters can (SR3 pg 126). This PR removes the IS_NPC check since this should apply to all characters. Also and changes the `mental_gain` check from `POS_STUNNED` to `POS_MORTALLYW`, and the `physical_gain` check to also cover the possibility of `POS_DEAD`.

This answers the report: https://discord.com/channels/564618629467996170/788953927269613608/1337602787973795841