### PR TITLE
Minor fixes

### DIFF
--- a/src/act.movement.cpp
+++ b/src/act.movement.cpp
@@ -2236,7 +2236,7 @@ ACMD(do_leave)
   }
 
   // Movement restriction: Must be standing and not fighting.
-  FAILURE_CASE(GET_POS(ch) < POS_STANDING, "Maybe you should get on your feet first?");
+  FAILURE_CASE(GET_POS(ch) < POS_FIGHTING, "Maybe you should get on your feet first?");
   FAILURE_CASE(FIGHTING(ch) || FIGHTING_VEH(ch), "You'll have to FLEE if you want to escape from combat!");
 
   // Leaving an elevator shaft is handled in the button panel's spec proc code. See transport.cpp.

--- a/src/limits.cpp
+++ b/src/limits.cpp
@@ -65,7 +65,7 @@ void mental_gain(struct char_data * ch)
   }
 
   // Can't regenerate? Skip.
-  if (IS_NPC(ch) && GET_DEFAULT_POS(ch) <= POS_STUNNED) {
+  if (IS_NPC(ch) && GET_DEFAULT_POS(ch) == POS_STUNNED) {
     return;
   }
 


### PR DESCRIPTION
- allow npcs with default POS_MORTALLYW to recover mental after being healed (discussed at https://discord.com/channels/564618629467996170/1337602787973795841 )
- send the correct fail message when attempting to leave combat when a character is on their feet (answers https://discord.com/channels/564618629467996170/673710279485423648/1338425295300198438 )