### PR TITLE
Fixed Hitchikers

### DIFF
--- a/src/act.comm.cpp
+++ b/src/act.comm.cpp
@@ -109,7 +109,7 @@ ACMD(do_say)
           ) {
           continue;
         }
-        if (!IS_IGNORING(targ, is_blocking_ic_interaction_from, ch)) // Gag check for ignored characters
+        if (!IS_IGNORING(targ, is_blocking_ic_interaction_from, ch)) {// Gag check for ignored characters
           // We found our hitcher
           snprintf(buf, sizeof(buf), "Your hitcher says, \"%s^n\"\r\n", capitalize(arg_known_size));
           send_to_char(buf, targ);

--- a/src/act.comm.cpp
+++ b/src/act.comm.cpp
@@ -100,17 +100,25 @@ ACMD(do_say)
         }
       }
     } else {
-      for (struct char_data *targ = get_ch_in_room(ch)->people; targ; targ = targ->next_in_room)
-        if (targ != ch && PLR_FLAGGED(targ, PLR_MATRIX) && !IS_IGNORING(targ, is_blocking_ic_interaction_from, ch)) {
-          // Send and store.
-          snprintf(buf, sizeof(buf), "Your hitcher says, \"%s^n\"\r\n", capitalize(arg_known_size));
-          send_to_char(buf, targ);
-          store_message_to_history(targ->desc, COMM_CHANNEL_SAYS, buf);
+      for (struct char_data *targ = get_ch_in_room(ch)->people; targ; targ = targ->next_in_room) {
+        if (targ == ch
+            || !PLR_FLAGGED(targ, PLR_MATRIX)
+            || !targ->persona
+            || !targ->persona->decker
+            || targ->persona->decker->hitcher != ch
+          ) {
+          continue;
         }
-      // Send and store.
-      snprintf(buf, sizeof(buf), "You send, down the line, \"%s^n\"\r\n", capitalize(arg_known_size));
-      send_to_char(buf, ch);
-      store_message_to_history(ch->desc, COMM_CHANNEL_SAYS, buf);
+        // We found our hitcher
+        snprintf(buf, sizeof(buf), "Your hitcher says, \"%s^n\"\r\n", capitalize(arg_known_size));
+        send_to_char(buf, targ);
+        store_message_to_history(targ->desc, COMM_CHANNEL_SAYS, buf);
+        
+        // Send and store.
+        snprintf(buf, sizeof(buf), "You send, down the line, \"%s^n\"\r\n", capitalize(arg_known_size));
+        send_to_char(buf, ch);
+        store_message_to_history(ch->desc, COMM_CHANNEL_SAYS, buf);
+      }
     }
     return;
   }

--- a/src/act.comm.cpp
+++ b/src/act.comm.cpp
@@ -109,11 +109,13 @@ ACMD(do_say)
           ) {
           continue;
         }
-        // We found our hitcher
-        snprintf(buf, sizeof(buf), "Your hitcher says, \"%s^n\"\r\n", capitalize(arg_known_size));
-        send_to_char(buf, targ);
-        store_message_to_history(targ->desc, COMM_CHANNEL_SAYS, buf);
-        
+        if (!IS_IGNORING(targ, is_blocking_ic_interaction_from, ch)) // Gag check for ignored characters
+          // We found our hitcher
+          snprintf(buf, sizeof(buf), "Your hitcher says, \"%s^n\"\r\n", capitalize(arg_known_size));
+          send_to_char(buf, targ);
+          store_message_to_history(targ->desc, COMM_CHANNEL_SAYS, buf);
+        }
+
         // Send and store.
         snprintf(buf, sizeof(buf), "You send, down the line, \"%s^n\"\r\n", capitalize(arg_known_size));
         send_to_char(buf, ch);

--- a/src/act.movement.cpp
+++ b/src/act.movement.cpp
@@ -1042,6 +1042,7 @@ int perform_move(struct char_data *ch, int dir, int extra, struct char_data *vic
   }
 
   FALSE_CASE(GET_POS(ch) < POS_FIGHTING || (AFF_FLAGGED(ch, AFF_PRONE) && !IS_NPC(ch)), "Maybe you should get on your feet first?");
+  FALSE_CASE(PLR_FLAGGED(ch, PLR_MATRIX), "It will be difficult to do that while tethered to the matrix."); // This is for hitchers, primarily
 
   if (GET_POS(ch) >= POS_FIGHTING && FIGHTING(ch)) {
     WAIT_STATE(ch, PULSE_VIOLENCE * 2);

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -25,8 +25,6 @@ extern const char *CHARACTER_DELETED_NAME_FOR_SQL;
 
 #define STAFF_CONTACT_EMAIL "<insert_staff_email_here>"
 
-#define ENABLE_PK 1
-
 // What karma / nuyen multipliers do you want your game to have? This effects grind length, higher is faster.
 #define KARMA_GAIN_MULTIPLIER                                  2.0
 #define NUYEN_GAIN_MULTIPLIER                                  2.0

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -25,6 +25,8 @@ extern const char *CHARACTER_DELETED_NAME_FOR_SQL;
 
 #define STAFF_CONTACT_EMAIL "<insert_staff_email_here>"
 
+#define ENABLE_PK 1
+
 // What karma / nuyen multipliers do you want your game to have? This effects grind length, higher is faster.
 #define KARMA_GAIN_MULTIPLIER                                  2.0
 #define NUYEN_GAIN_MULTIPLIER                                  2.0

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -1293,6 +1293,52 @@ ACMD_DECLARE(do_talk);
 ACMD_DECLARE(do_trace);
 ACMD_DECLARE(do_fry_self);
 
+struct command_info mtx_htr_info[] =
+  {
+    { "RESERVED", 0, 0, 0, 0
+    , BLOCKS_IDLE_REWARD },
+    { "afk", 0, do_afk, 0, 0, ALLOWS_IDLE_REWARD },
+    { "disconnect", 0, do_logoff, 0, 1, BLOCKS_IDLE_REWARD },
+    { "logoff", 0, do_logoff, 0, 0, BLOCKS_IDLE_REWARD },
+    { "emote", 0, do_echo, 0, SCMD_EMOTE , BLOCKS_IDLE_REWARD },
+    { ":", 0, do_echo, 0, SCMD_EMOTE , BLOCKS_IDLE_REWARD },
+    { "exit", 0, do_logoff, 0, 0, BLOCKS_IDLE_REWARD },
+    { "help", 0, do_help, 0, 0, BLOCKS_IDLE_REWARD },
+    { "ht", 0, do_gen_comm , 0, SCMD_HIREDTALK, BLOCKS_IDLE_REWARD },
+    { "idea", 0, do_gen_write, 0, SCMD_IDEA, BLOCKS_IDLE_REWARD },
+    { "index", 0, do_index, 0, 0, BLOCKS_IDLE_REWARD },
+    { "jobs", 0, do_recap, 0, 0, BLOCKS_IDLE_REWARD },
+    { "look", 0, do_look, 0, 0, BLOCKS_IDLE_REWARD },
+    { "say", 0, do_say, 0, 0, BLOCKS_IDLE_REWARD },
+    { "'", 0, do_say, 0, 0, BLOCKS_IDLE_REWARD },
+    { "ooc", 0, do_gen_comm, 0, SCMD_OOC, BLOCKS_IDLE_REWARD },
+    { "quit", 0, do_logoff, 0, 0, BLOCKS_IDLE_REWARD },
+    { "praise", 0, do_gen_write, 0, SCMD_PRAISE, BLOCKS_IDLE_REWARD },
+    { "reply", 0, do_reply, 0, 0 , BLOCKS_IDLE_REWARD },
+    { "tell", 0, do_tell, 0, 0 , BLOCKS_IDLE_REWARD },
+    { "skills", 0, do_skills   , 0, 0, BLOCKS_IDLE_REWARD },
+    { "score", 0, do_score, 0, 0, BLOCKS_IDLE_REWARD },
+    { "typo", 0, do_gen_write, 0, SCMD_TYPO, BLOCKS_IDLE_REWARD },
+    { "who", 0, do_who, 0, 0, BLOCKS_IDLE_REWARD },
+    { "wtell", 0, do_wiztell, LVL_BUILDER, 0, BLOCKS_IDLE_REWARD },
+
+        // Channel history commands.
+    { "history"    , 0, do_message_history, 0, 0, ALLOWS_IDLE_REWARD },
+    { "hts"        , 0, do_switched_message_history, 0, COMM_CHANNEL_HIRED, ALLOWS_IDLE_REWARD },
+    { "questions"  , 0, do_switched_message_history, 0, COMM_CHANNEL_QUESTIONS, ALLOWS_IDLE_REWARD },
+    { "oocs"       , 0, do_switched_message_history, 0, COMM_CHANNEL_OOC, ALLOWS_IDLE_REWARD },
+    { "osays"      , 0, do_switched_message_history, 0, COMM_CHANNEL_OSAYS, ALLOWS_IDLE_REWARD },
+    { "pages"      , 0, do_switched_message_history, LVL_ARCHITECT, COMM_CHANNEL_PAGES, ALLOWS_IDLE_REWARD },
+    { "rts"        , 0, do_switched_message_history, 0, COMM_CHANNEL_RPE, ALLOWS_IDLE_REWARD },
+    { "says"       , 0, do_switched_message_history, 0, COMM_CHANNEL_SAYS, ALLOWS_IDLE_REWARD },
+    { "shouts"     , 0, do_switched_message_history, 0, COMM_CHANNEL_SHOUTS, ALLOWS_IDLE_REWARD },
+    { "tells"      , 0, do_switched_message_history, 0, COMM_CHANNEL_TELLS, ALLOWS_IDLE_REWARD },
+    { "wtells"     , 0, do_switched_message_history, LVL_BUILDER, COMM_CHANNEL_WTELLS, ALLOWS_IDLE_REWARD },
+    { "wts"        , 0, do_switched_message_history, LVL_BUILDER, COMM_CHANNEL_WTELLS, ALLOWS_IDLE_REWARD },
+
+    { "\n", 0, 0, 0, 0, FALSE  }
+  };
+
 struct command_info mtx_info[] =
   {
     { "RESERVED", 0, 0, 0, 0
@@ -1547,12 +1593,75 @@ void nonsensical_reply(struct char_data *ch, const char *arg, const char *mode)
   }
 }
 
+ACMD_DECLARE(quit_the_matrix_first);
+bool matrix_interpreter(struct char_data * ch, char *argument, char *line, command_info *scmd_list) {
+  int cmd, length;
+
+  for (length = strlen(arg), cmd = 0; *scmd_list[cmd].command != '\n'; cmd++)
+    if (!strncmp(scmd_list[cmd].command, arg, length))
+      if ((scmd_list[cmd].minimum_level < LVL_BUILDER) || access_level(ch, scmd_list[cmd].minimum_level))
+        break;
+
+  // If they have failed to enter a valid Matrix command, and we were unable to fix a typo in their command:
+  if (*scmd_list[cmd].command == '\n' && (cmd = fix_common_command_fuckups(arg, scmd_list)) == -1) {
+    // If the command exists outside of the Matrix, let them know that it's not an option here.
+    for (length = strlen(arg), cmd = 0; *cmd_info[cmd].command != '\n'; cmd++)
+      if (!strncmp(cmd_info[cmd].command, arg, length))
+        if ((cmd_info[cmd].minimum_level < LVL_BUILDER) || access_level(ch, cmd_info[cmd].minimum_level))
+          break;
+
+    // Nothing was found? Give them the "wat" and bail.
+    if (*cmd_info[cmd].command == '\n' && (cmd = fix_common_command_fuckups(arg, cmd_info)) == -1) {
+      // Attempt to send it as a custom channel message. If that doesn't work, nonsensical reply.
+      if (!send_command_as_custom_channel_message(ch, arg)) {
+        nonsensical_reply(ch, arg, "matrix");
+      }
+#ifdef ENABLE_THIS_IF_YOU_WANT_TO_HATE_YOUR_LIFE
+      verify_every_pointer_we_can_think_of();
+#endif
+      return TRUE;
+    }
+
+    if (ch->desc)
+      ch->desc->invalid_command_counter = 0;
+
+    // Their command was valid in external context. Inform them.
+    quit_the_matrix_first(ch, line, 0, 0);
+  }
+  else {
+    // Sanity check: Level restriction.
+    if ((scmd_list[cmd].minimum_level >= LVL_BUILDER) && !access_level(ch, scmd_list[cmd].minimum_level)) {
+      send_to_char(ch, "Sorry, that's a staff-only command.\r\n", ch);
+      mudlog_vfprintf(ch, LOG_SYSLOG, "SYSERR: %s was able to trigger staff-only matrix command %s!", GET_CHAR_NAME(ch), scmd_list[cmd].command);
+#ifdef ENABLE_THIS_IF_YOU_WANT_TO_HATE_YOUR_LIFE
+      verify_every_pointer_we_can_think_of();
+#endif
+      return TRUE;
+    }
+
+    if (ch->persona && ch->persona->decker->hitcher) {
+      send_to_char(ch->persona->decker->hitcher, "^y<OUTGOING> %s^n\r\n", argument);
+    }
+    verify_data(ch, line, cmd, scmd_list[cmd].subcmd, "pre-matrix");
+    if (!special(ch, cmd, line)) {
+      ((scmd_list[cmd].command_pointer) (ch, line, cmd, scmd_list[cmd].subcmd));
+      verify_data(ch, line, cmd, scmd_list[cmd].subcmd, "matrix");
+    } else {
+      verify_data(ch, line, cmd, scmd_list[cmd].subcmd, "matrix special");
+    }
+    return TRUE;
+  }
+  #ifdef ENABLE_THIS_IF_YOU_WANT_TO_HATE_YOUR_LIFE
+  verify_every_pointer_we_can_think_of();
+  #endif
+  return FALSE;
+}
+
 /*
  * This is the actual command interpreter called from game_loop() in comm.c
  * It makes sure you are the proper level and position to execute the command,
  * then calls the appropriate function.
  */
-ACMD_DECLARE(quit_the_matrix_first);
 ACMD_DECLARE(stop_rigging_first);
 void command_interpreter(struct char_data * ch, char *argument, const char *tcname)
 {
@@ -1626,64 +1735,14 @@ void command_interpreter(struct char_data * ch, char *argument, const char *tcna
   }
 
   /* otherwise, find the command */
-  if (PLR_FLAGGED(ch, PLR_MATRIX) && ch->persona)
-  {
-    for (length = strlen(arg), cmd = 0; *mtx_info[cmd].command != '\n'; cmd++)
-      if (!strncmp(mtx_info[cmd].command, arg, length))
-        if ((mtx_info[cmd].minimum_level < LVL_BUILDER) || access_level(ch, mtx_info[cmd].minimum_level))
-          break;
-
-    // If they have failed to enter a valid Matrix command, and we were unable to fix a typo in their command:
-    if (*mtx_info[cmd].command == '\n' && (cmd = fix_common_command_fuckups(arg, mtx_info)) == -1) {
-      // If the command exists outside of the Matrix, let them know that it's not an option here.
-      for (length = strlen(arg), cmd = 0; *cmd_info[cmd].command != '\n'; cmd++)
-        if (!strncmp(cmd_info[cmd].command, arg, length))
-          if ((cmd_info[cmd].minimum_level < LVL_BUILDER) || access_level(ch, cmd_info[cmd].minimum_level))
-            break;
-
-      // Nothing was found? Give them the "wat" and bail.
-      if (*cmd_info[cmd].command == '\n' && (cmd = fix_common_command_fuckups(arg, cmd_info)) == -1) {
-        // Attempt to send it as a custom channel message. If that doesn't work, nonsensical reply.
-        if (!send_command_as_custom_channel_message(ch, arg)) {
-          nonsensical_reply(ch, arg, "matrix");
-        }
-#ifdef ENABLE_THIS_IF_YOU_WANT_TO_HATE_YOUR_LIFE
-        verify_every_pointer_we_can_think_of();
-#endif
-        return;
-      }
-
-      if (ch->desc)
-        ch->desc->invalid_command_counter = 0;
-
-      // Their command was valid in external context. Inform them.
-      quit_the_matrix_first(ch, line, 0, 0);
+  if (PLR_FLAGGED(ch, PLR_MATRIX)) {
+    if (!ch->persona) {
+      // This block exists for the hitcher-exclusive matrix commandset.
+      if (matrix_interpreter(ch, argument, line, mtx_htr_info)) return;
+    } else {
+      // This is the proper command code for matrix/deckers
+      if (matrix_interpreter(ch, argument, line, mtx_info)) return;
     }
-    else {
-      // Sanity check: Level restriction.
-      if ((mtx_info[cmd].minimum_level >= LVL_BUILDER) && !access_level(ch, mtx_info[cmd].minimum_level)) {
-        send_to_char(ch, "Sorry, that's a staff-only command.\r\n", ch);
-        mudlog_vfprintf(ch, LOG_SYSLOG, "SYSERR: %s was able to trigger staff-only matrix command %s!", GET_CHAR_NAME(ch), mtx_info[cmd].command);
-#ifdef ENABLE_THIS_IF_YOU_WANT_TO_HATE_YOUR_LIFE
-        verify_every_pointer_we_can_think_of();
-#endif
-        return;
-      }
-
-      if (ch->persona->decker->hitcher) {
-        send_to_char(ch->persona->decker->hitcher, "^y<OUTGOING> %s^n\r\n", argument);
-      }
-      verify_data(ch, line, cmd, mtx_info[cmd].subcmd, "pre-matrix");
-      if (!special(ch, cmd, line)) {
-        ((*mtx_info[cmd].command_pointer) (ch, line, cmd, mtx_info[cmd].subcmd));
-        verify_data(ch, line, cmd, mtx_info[cmd].subcmd, "matrix");
-      } else {
-        verify_data(ch, line, cmd, mtx_info[cmd].subcmd, "matrix special");
-      }
-    }
-#ifdef ENABLE_THIS_IF_YOU_WANT_TO_HATE_YOUR_LIFE
-    verify_every_pointer_we_can_think_of();
-#endif
   } else if (PLR_FLAGGED(ch, PLR_REMOTE) || AFF_FLAGGED(ch, AFF_RIG))
   {
     for (length = strlen(arg), cmd = 0; *rig_info[cmd].command != '\n'; cmd++)

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -1625,13 +1625,8 @@ void command_interpreter(struct char_data * ch, char *argument, const char *tcna
     return;
   }
 
-  if (PLR_FLAGGED(ch, PLR_MATRIX) && !ch->persona) {
-    mudlog("SYSERR: PLR_MATRIX-flagged character did not have a persona! Removing matrix flag.", ch, LOG_SYSLOG, TRUE);
-    PLR_FLAGS(ch).RemoveBit(PLR_MATRIX);
-  }
-
   /* otherwise, find the command */
-  if (PLR_FLAGGED(ch, PLR_MATRIX))
+  if (PLR_FLAGGED(ch, PLR_MATRIX) && ch->persona)
   {
     for (length = strlen(arg), cmd = 0; *mtx_info[cmd].command != '\n'; cmd++)
       if (!strncmp(mtx_info[cmd].command, arg, length))

--- a/src/interpreter.hpp
+++ b/src/interpreter.hpp
@@ -69,6 +69,7 @@ struct command_info
 
 #ifndef __INTERPRETER_CC__
 extern struct command_info cmd_info[];
+extern struct command_info mtx_htr_info[];
 extern struct command_info mtx_info[];
 extern struct command_info rig_info[];
 #endif

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -1799,7 +1799,7 @@ ACMD(do_logoff)
   if (!PERSONA) {
     send_to_char(ch, "You yank the plug out and return to the real world.\r\n");
     PLR_FLAGS(ch).RemoveBit(PLR_MATRIX);
-    
+
     // Message our driver
     for (struct char_data *targ = get_ch_in_room(ch)->people; targ; targ = targ->next_in_room) {
         if (targ == ch
@@ -1885,7 +1885,6 @@ ACMD(do_connect)
     skip_spaces(&argument);
     
     temp = get_char_room_vis(ch, argument);
-    if (IS_IGNORING(temp, is_blocking_ic_interaction_from, ch)) temp = NULL;
     if (!temp) {
       send_to_char(ch, "You don't see anyone named '%s' here.\r\n", argument);
       return;
@@ -1897,7 +1896,8 @@ ACMD(do_connect)
         || !temp->persona
         || !temp->persona->decker
         || !temp->persona->decker->deck
-        || !HAS_HITCHER_JACK(temp->persona->decker->deck)) {
+        || !HAS_HITCHER_JACK(temp->persona->decker->deck)
+        || IS_IGNORING(temp, is_blocking_ic_interaction_from, ch)) {
       send_to_char(ch, "It doesn't look like you can hitch a ride with %s.", argument);
       return;
     } else if (temp->persona->decker->hitcher) {

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -23,6 +23,13 @@ struct ic_info dummy_ic;
 
 #define ICON_IS_IC(icon) (!(icon)->decker)
 
+#define HAS_HITCHER_JACK(deck) ([](struct obj_data *d) { \
+    for (struct obj_data *hitch = (d)->contains; hitch; hitch = hitch->next_content) \
+        if (GET_OBJ_TYPE(hitch) == ITEM_DECK_ACCESSORY && GET_OBJ_VAL(hitch, 0) == 1 && GET_OBJ_VAL(hitch, 1) == 3) \
+            return true; \
+    return false; \
+})(deck)
+
 extern void order_list(struct matrix_icon *start);
 extern void create_program(struct char_data *ch);
 extern void create_part(struct char_data *ch);
@@ -1218,6 +1225,10 @@ ACMD(do_matrix_score)
             DECKER->bod, DECKER->evasion, DECKER->masking, DECKER->sensor,
             DECKER->hardening, DECKER->mpcp, DECKER->deck ? GET_CYBERDECK_IO_RATING(DECKER->deck) : 0, DECKER->response);
   }
+  
+  if (HAS_HITCHER_JACK(DECKER->deck)) {
+    snprintf(ENDOF(buf), sizeof(buf) - strlen(buf), "    Hitcher: %s\r\n", DECKER->hitcher ? "^gconnected^n" : "^rdisconnected^n");
+  }
 
   if (DECKER->io < GET_CYBERDECK_IO_RATING(DECKER->deck)) {
     snprintf(ENDOF(buf), sizeof(buf) - strlen(buf), "^yYour I/O rating is restricted to %d by your jackpoint.^n\r\n", DECKER->io * 10);
@@ -1836,13 +1847,6 @@ ACMD(do_logoff)
     do_look(ch, emptybuf, 0, 0);
   }
 }
-
-#define HAS_HITCHER_JACK(deck) ([](struct obj_data *d) { \
-    for (struct obj_data *hitch = (d)->contains; hitch; hitch = hitch->next_content) \
-        if (GET_OBJ_TYPE(hitch) == ITEM_DECK_ACCESSORY && GET_OBJ_VAL(hitch, 0) == 1 && GET_OBJ_VAL(hitch, 1) == 3) \
-            return true; \
-    return false; \
-})(deck)
 
 ACMD(do_connect)
 {

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -1477,11 +1477,6 @@ void show_icon_to_persona(struct matrix_icon *ch, struct matrix_icon *icon) {
 
 ACMD(do_matrix_look)
 {
-  if (!PERSONA) {
-    send_to_char(ch, "You can't do that while hitching.\r\n");
-    return;
-  }
-
   // Did they supply a target? Look at that instead.
   if (argument && *argument) {
     one_argument(argument, arg);


### PR DESCRIPTION
Patched the hitcher code for matrix. List of changes:

- [x] Players can no longer move while connected to a hitcher
- [x] The syntax has been changed to 'connect <driver>' to connect as a hitcher to a driver (the person on the matrix)
- [x] say has been fixed for hitchers and now the messages are sent to the driver
- [x] hitchers now have a curated command list to secure what they can do, preventing erroneous states.  This can be expanded as desired.
- [x] score now shows if you have a hitcher connected or not

Example image of new UI:
![image](https://github.com/user-attachments/assets/b180fd57-a9e9-4f4d-bef1-d3f6d94dc23f)
 