### PR TITLE
Fixed uploads not processing from otaku proxy decks

### DIFF
--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -3041,7 +3041,7 @@ void process_upload(struct matrix_icon *persona)
           // Make it seen by them.
           GET_DECK_ACCESSORY_FILE_FOUND_BY(soft) = GET_IDNUM(persona->decker->ch);
           // Remove it from their deck's used storage.
-          GET_CYBERDECK_USED_STORAGE(persona->decker->deck) -= GET_DECK_ACCESSORY_FILE_SIZE(soft);
+          GET_CYBERDECK_USED_STORAGE(deck) -= GET_DECK_ACCESSORY_FILE_SIZE(soft);
           GET_DECK_ACCESSORY_FILE_IS_UPLOADING_TO_HOST(soft) = 0;
           GET_DECK_ACCESSORY_FILE_REMAINING(soft) = 0;
 

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -2983,7 +2983,11 @@ void process_upload(struct matrix_icon *persona)
 {
   // Note: We only upload one file at a time. Find the first valid one and process it, then stop.
   if (persona && persona->decker && persona->decker->deck) {
-    for (struct obj_data *soft = persona->decker->deck->contains, *next_obj; soft; soft = next_obj) {
+    obj_data *deck = persona->decker->deck;
+    if (persona->decker->proxy_deck)
+      deck = persona->decker->proxy_deck;
+
+    for (struct obj_data *soft = deck->contains, *next_obj; soft; soft = next_obj) {
       next_obj = soft->next_content;
 
       // Sanity check: Only upload deck accessories.


### PR DESCRIPTION
When uploading from a proxy deck the upload does not progress. This patch fixes that issue by redirecting the upload to the proxy deck since persona->decker->deck on otaku will never (in the current code) have storage memory.

If living persona ever get memory this will need to be modified.