### PR TITLE
Otaku fixes 3

### DIFF
--- a/src/cf_create.cpp
+++ b/src/cf_create.cpp
@@ -9,6 +9,7 @@
 #include "screen.hpp"
 #include "constants.hpp"
 #include "olc.hpp"
+#include "otaku.hpp"
 #include "newmagic.hpp"
 
 #define CH d->character
@@ -168,6 +169,9 @@ void cfedit_parse(struct descriptor_data *d, const char *arg)
   case CFEDIT_RATING:
     if (option_n > GET_SKILL(CH, SKILL_COMPUTER)) {
       send_to_char(CH, "You can't create a program of a higher rating than your computer skill.\r\n"
+                   "Enter Rating: ");
+    } else if (option_n > GET_OTAKU_MPCP(CH)) {
+      send_to_char(CH, "You can't create a program of a higher rating than your living persona's MPCP rating.\r\n"
                    "Enter Rating: ");
     } else {
       GET_DESIGN_RATING(d->edit_obj) = option_n;

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -466,7 +466,9 @@ int system_test(rnum_t host, struct char_data *ch, int type, int software, int m
   target += modify_target_rbuf_raw(ch, rollbuf, sizeof(rollbuf), 8, FALSE) + DECKER->res_test + (DECKER->ras ? 0 : 4);
 
   for (struct obj_data *soft = DECKER->software; soft; soft = soft->next_content) {
-    if (!prog && GET_PROGRAM_TYPE(soft) == software) {
+    if (prog) break;
+    if (GET_PROGRAM_TYPE(soft) == SOFT_SLEAZE) break;
+    if (GET_PROGRAM_TYPE(soft) == software) {
       target -= GET_PROGRAM_RATING(soft);
       buf_mod(rollbuf, sizeof(rollbuf), "soft", -GET_PROGRAM_RATING(soft));
       prog = soft;

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -16,11 +16,14 @@
 #include "ignore_system.hpp"
 #include "moderation.hpp"
 #include "pets.hpp"
+#include "otaku.hpp"
 
 #define PERSONA ch->persona
 #define PERSONA_CONDITION ch->persona->condition
 #define DECKER PERSONA->decker
 struct ic_info dummy_ic;
+
+extern struct otaku_echo echoes[];
 
 #define ICON_IS_IC(icon) (!(icon)->decker)
 
@@ -1320,6 +1323,26 @@ ACMD(do_matrix_score)
 
   if (DECKER->io < GET_CYBERDECK_IO_RATING(DECKER->deck)) {
     snprintf(ENDOF(buf), sizeof(buf) - strlen(buf), "^yYour I/O rating is restricted to %d by your jackpoint.^n\r\n", DECKER->io * 10);
+  }
+
+  if (ch->persona->type == ICON_LIVING_PERSONA) {
+    snprintf(ENDOF(buf), sizeof(buf) - strlen(buf), "     Echoes: ");
+    int echoes_found = 0;
+    for (int ci=ECHO_UNDEFINED + 1; ci <= ECHO_MAX;ci++) {
+      if (!GET_ECHO(ch, ci)) continue;
+      echoes_found++;
+      if (echoes[ci].incremental)
+        snprintf(ENDOF(buf), sizeof(buf) - strlen(buf), "%s%s (%d)",
+          echoes_found > 0 ? ", " : "",
+          echoes[ci].name,
+          GET_ECHO(ch, ci));
+      else
+        snprintf(ENDOF(buf), sizeof(buf) - strlen(buf), "%s%s",
+          echoes_found > 0 ? ", " : "",
+          echoes[ci].name);
+    }
+    if (echoes_found > 0) snprintf(ENDOF(buf), sizeof(buf) - strlen(buf), "\r\n");
+    else snprintf(ENDOF(buf), sizeof(buf) - strlen(buf), " None\r\n");
   }
 
   strlcat(buf, "\r\n(Switches available: ^WSCORE HEALTH^n, ^WSTATS^n, ^WDECK^n, ^WMEMORY^n.)\r\n", sizeof(buf));

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -18,7 +18,7 @@
 #include "pets.hpp"
 
 #define PERSONA ch->persona
-#define PERSONA_CONDITION ch->persona->type == ICON_LIVING_PERSONA ? (100 * GET_MENTAL(ch)) / MAX(1, GET_MAX_MENTAL(ch)) : ch->persona->condition
+#define PERSONA_CONDITION ch->persona->condition
 #define DECKER PERSONA->decker
 struct ic_info dummy_ic;
 
@@ -1287,8 +1287,17 @@ ACMD(do_matrix_score)
     strlcat(buf, get_plaintext_matrix_score_deck(ch), sizeof(buf));
     strlcat(buf, get_plaintext_matrix_score_memory(ch), sizeof(buf));
   } else {
+    if (ch->persona->type == ICON_LIVING_PERSONA) {
+      snprintf(ENDOF(buf), sizeof(buf) - strlen(buf),
+              "     Mental:^B%3d(%2d)^n       Physical:^R%3d(%2d)^n\r\n",
+              (int)(GET_MENTAL(ch) / 100), (int)(GET_MAX_MENTAL(ch) / 100), 
+              (int)(GET_PHYSICAL(ch) / 100), (int)(GET_MAX_PHYSICAL(ch) / 100));
+    } else {
+      snprintf(ENDOF(buf), sizeof(buf) - strlen(buf),
+              "  Condition:^B%3d^n           Physical:^R%3d(%2d)^n\r\n",
+              PERSONA_CONDITION, (int)(GET_PHYSICAL(ch) / 100), (int)(GET_MAX_PHYSICAL(ch) / 100));
+    }
     snprintf(ENDOF(buf), sizeof(buf) - strlen(buf), 
-            "  Condition:^B%3d^n           Physical:^R%3d(%2d)^n\r\n"
             "  Detection:^r%3d^n       Hacking Pool:^g%3d/%3d (%2d)^n\r\n"
             "    Storage:^g%4d^n/%4d (^c%d^n MP free)\r\n"
             "            ^cPersona Programs:^n\r\n"
@@ -1297,7 +1306,6 @@ ACMD(do_matrix_score)
             "               ^cDeck Status:^n\r\n"
             "  Hardening:^g%3d^n       MPCP:^g%3d^n\r\n"
             "   IO Speed:^g%4d^n      Response Increase:^g%3d^n\r\n",
-            PERSONA_CONDITION, (int)(GET_PHYSICAL(ch) / 100), (int)(GET_MAX_PHYSICAL(ch) / 100),
             detect, MAX(0, GET_REM_HACKING(ch)), GET_HACKING(ch), GET_MAX_HACKING(ch),
             GET_CYBERDECK_USED_STORAGE(DECKER->deck), GET_CYBERDECK_TOTAL_STORAGE(DECKER->deck), GET_CYBERDECK_FREE_STORAGE(DECKER->deck),
             DECKER->bod, DECKER->evasion, DECKER->masking, DECKER->sensor,

--- a/src/otaku.cpp
+++ b/src/otaku.cpp
@@ -76,10 +76,7 @@ struct obj_data *make_otaku_deck(struct char_data *ch) {
   struct obj_data *new_deck = read_object(OBJ_CUSTOM_CYBERDECK_SHELL, VIRTUAL, OBJ_LOAD_REASON_OTAKU_RESONANCE);
 
   // Add parts.
-  int mpcp = (get_otaku_int(ch) + GET_REAL_WIL(ch) + GET_REAL_CHA(ch) + 2) / 3; // adding 2 always ensures a round up
-  if (GET_ECHO(ch, ECHO_IMPROVED_MPCP)) {
-    mpcp = MIN(get_otaku_int(ch) * 2, mpcp + GET_ECHO(ch, ECHO_IMPROVED_MPCP));
-  }
+  int mpcp = GET_OTAKU_MPCP(ch);
 
   obj_to_obj(make_new_finished_part(PART_MPCP, mpcp, mpcp), new_deck);
   obj_to_obj(make_new_finished_part(PART_BOD, mpcp, GET_REAL_WIL(ch)), new_deck);
@@ -104,6 +101,7 @@ struct obj_data *make_otaku_deck(struct char_data *ch) {
   for (struct obj_data *form = asist->contains; form; form = form->next_content) {
     if (GET_OBJ_TYPE(form) != ITEM_COMPLEX_FORM) continue;
     if (GET_DESIGN_PROGRAMMING_TICKS_LEFT(form) > 0) continue; // The complex form is in unfinished.
+    if (GET_PROGRAM_RATING(form) > mpcp) continue; // Can't load complex forms greater than mpcp rating.
     struct obj_data *active = read_object(OBJ_BLANK_PROGRAM, VIRTUAL, OBJ_LOAD_REASON_OTAKU_RESONANCE);
     GET_PROGRAM_TYPE(active) = GET_PROGRAM_TYPE(form);
     GET_PROGRAM_SIZE(active) = 0; // Complex forms don't take up memory.
@@ -150,6 +148,12 @@ bool submersion_cost(struct char_data *ch, bool spend)
     return FALSE;
   }
 
+  // Enforce grade restrictions. We can't do this init_cost since it's used elsewhere.
+  if ((GET_GRADE(ch) + 1) > SUBMERSION_CAP) {
+    send_to_char("Congratulations, you've reached the submersion cap! You're not able to advance further.\r\n", ch);
+    return FALSE;
+  }
+
   long tke = 0;
   if (karmacost > GET_KARMA(ch) || (GET_KARMA(ch) - karmacost) > GET_KARMA(ch)) {
     send_to_char(ch, "You do not have enough karma to increase submersion. It will cost you %.2f karma.\r\n", ((float) karmacost / 100));
@@ -188,10 +192,13 @@ bool submersion_cost(struct char_data *ch, bool spend)
 void disp_submersion_menu(struct descriptor_data *d)
 {
   CLS(CH);
-  send_to_char("1) Increase submersion grade\r\n"
-               "2) Learn a new echo\r\n"
-               "3) Return to game\r\n"
-               "Enter initiation option: ", CH);
+  send_to_char(CH, "Deep in the resonance you focus on becoming closer to the matrix:\r\n"
+               " 1) Increase submersion grade (%s)\r\n"
+               " 2) Learn a new echo (%d echoes available)\r\n"
+               " 3) Return to reality\r\n"
+               "Enter submersion option: ",
+               submersion_cost(CH, FALSE) ? "^gavailable^n" : "^runavailable^n",
+               get_free_echoes(CH));
   d->edit_mode = SUBMERSION_MAIN;
 }
 
@@ -199,18 +206,6 @@ ACMD(do_submerse)
 {
   FAILURE_CASE(!IS_OTAKU(ch), "Sorry, submersions are for otaku characters only.");
 
-  skip_spaces(&argument);
-
-  // Enforce grade restrictions. We can't do this init_cost since it's used elsewhere.
-  if ((GET_GRADE(ch) + 1) > SUBMERSION_CAP) {
-    send_to_char("Congratulations, you've reached the submersion cap! You're not able to advance further.\r\n", ch);
-    return;
-  }
-
-  // Check to see that they can afford it. This sends its own message.
-  if (!submersion_cost(ch, FALSE)) {
-    return;
-  }
   STATE(ch->desc) = CON_SUBMERSION;
   PLR_FLAGS(ch).SetBit(PLR_SUBMERSION);
   disp_submersion_menu(ch->desc);
@@ -283,14 +278,14 @@ void submersion_parse(struct descriptor_data *d, char *arg)
     case SUBMERSION_CONFIRM:
       if (*arg == 'y') {
         if (!submersion_cost(CH, TRUE)) { // Actually spends the points for submersion
-          STATE(d) = CON_PLAYING;
-          PLR_FLAGS(CH).RemoveBit(PLR_SUBMERSION);
+          send_to_char("Returning to main menu.", CH);
+          d->edit_mode = SUBMERSION_MAIN;
           return;
         }
         GET_GRADE(CH)++;
         send_to_char(CH, "You feel yourself grow closer to the resonance, opening new echoes for you to learn.\r\n");
-        STATE(d) = CON_PLAYING;
-        PLR_FLAGS(CH).RemoveBit(PLR_SUBMERSION);
+        send_to_char("Returning to main menu.", CH);
+        d->edit_mode = SUBMERSION_MAIN;
       } else {
         disp_submersion_menu(d);
       }
@@ -309,8 +304,8 @@ void submersion_parse(struct descriptor_data *d, char *arg)
       else {
         SET_ECHO(CH, number, GET_ECHO(CH, number) + 1);
         send_to_char(CH, "New ways to manipulate the resonance open up before you as you learn %s.\r\n", echoes[number].name);
-        STATE(d) = CON_PLAYING;
-        PLR_FLAGS(CH).RemoveBit(PLR_SUBMERSION);
+        send_to_char("Returning to main menu.", CH);
+        d->edit_mode = SUBMERSION_MAIN;
       }
       break;   
   }

--- a/src/otaku.cpp
+++ b/src/otaku.cpp
@@ -189,6 +189,15 @@ bool submersion_cost(struct char_data *ch, bool spend)
   return TRUE;
 }
 
+int get_free_echoes(struct char_data *ch)
+{
+  int available_echoes = GET_GRADE(ch);
+  for (int i = 1; i < ECHO_MAX; i++) {
+    available_echoes -= GET_ECHO(ch, i);
+  }
+  return available_echoes;
+}
+
 void disp_submersion_menu(struct descriptor_data *d)
 {
   CLS(CH);
@@ -209,15 +218,6 @@ ACMD(do_submerse)
   STATE(ch->desc) = CON_SUBMERSION;
   PLR_FLAGS(ch).SetBit(PLR_SUBMERSION);
   disp_submersion_menu(ch->desc);
-}
-
-int get_free_echoes(struct char_data *ch)
-{
-  int available_echoes = GET_GRADE(ch);
-  for (int i = 1; i < ECHO_MAX; i++) {
-    available_echoes -= GET_ECHO(ch, i);
-  }
-  return available_echoes;
 }
 
 bool can_select_echo(struct char_data *ch, int i)

--- a/src/otaku.hpp
+++ b/src/otaku.hpp
@@ -6,8 +6,21 @@ struct otaku_echo {
   bool incremental;
 };
 
+int     get_otaku_int(struct char_data *ch);
+int     get_otaku_qui(struct char_data *ch);
+int     get_otaku_rea(struct char_data *ch);
+
 #define SUBMERSION_MAIN	             0
 #define SUBMERSION_ECHO	             1
 #define SUBMERSION_CONFIRM           2
+
+#define GET_OTAKU_MPCP(ch)           \
+  (({ \
+    int mpcp = (get_otaku_int(ch) + GET_REAL_WIL(ch) + GET_REAL_CHA(ch) + 2) / 3; \
+    if (GET_ECHO(ch, ECHO_IMPROVED_MPCP)) { \
+      mpcp = MIN(get_otaku_int(ch) * 2, mpcp + GET_ECHO(ch, ECHO_IMPROVED_MPCP)); \
+    } \
+    mpcp; \
+  }))
 
 #endif


### PR DESCRIPTION
A bunch of quality of life and small fixes to otaku.

Fixing detection factor calculations.
Add echoes to matrix score card
Limiting complex form creation and loading by MPCP
Renaming Condition to Mental for otaku

And more