### PR TITLE
[Cyberware] Medial Cortex Bridge

### DIFF
--- a/lib/world/obj/5.obj
+++ b/lib/world/obj/5.obj
@@ -2690,4 +2690,66 @@ Material:	metal
 	Location:	Strength
 	Modifier:	2
 BREAK
+#593
+Keywords:	medial cortex bridge mct
+Name:	a medial cortex bridge I
+RoomDesc:$
+A strange brain-looking thang is here.~
+LookDesc:$
+Medial cortex bridge, rating 1.
+~
+Type:	Bioware
+WearFlags:	0
+ExtraFlags:	0
+AffFlags:	0
+Material:	organic
+[POINTS]
+	Weight:	0.00
+	Barrier:	1
+	Cost:	50000
+	AvailTN:	6
+	AvailDay:	14.00
+	LegalNum:	0
+	LegalCode:	0
+	LegalPermit:	0
+[VALUES]
+	Val0:	19
+	Val1:	1
+	Val2:	6
+	Val4:	40
+[AFFECT 0]
+	Location:	Willpower
+	Modifier:	1
+BREAK
+#594
+Keywords:	medial cortex bridge mct
+Name:	a medial cortex bridge II
+RoomDesc:$
+A brainish-looking creature stares you in the face.~
+LookDesc:$
+Medial cortex bridge, rating 2.
+~
+Type:	Bioware
+WearFlags:	0
+ExtraFlags:	0
+AffFlags:	0
+Material:	organic
+[POINTS]
+	Weight:	0.00
+	Barrier:	1
+	Cost:	110000
+	AvailTN:	6
+	AvailDay:	14.00
+	LegalNum:	0
+	LegalCode:	0
+	LegalPermit:	0
+[VALUES]
+	Val0:	19
+	Val1:	2
+	Val2:	6
+	Val4:	80
+[AFFECT 0]
+	Location:	Willpower
+	Modifier:	2
+BREAK
 END

--- a/src/awake.hpp
+++ b/src/awake.hpp
@@ -1696,7 +1696,8 @@ enum {
 #define BIO_PHENOTYPIC_STR       31
 // End of auto-cultured items.
 #define BIO_BIOSCULPTING         32
-#define NUM_BIOWARE              33
+#define BIO_MEDIALCORTEX         33
+#define NUM_BIOWARE              34
 
 #define BIOWARE_STANDARD 0
 #define BIOWARE_CULTURED 1
@@ -2800,7 +2801,6 @@ enum {
 #define OBJ_BIO_ENHANCED_ARTICULATION      85803
 #define OBJ_BIO_TRAUMA_DAMPER              85940
 #define OBJ_BIO_SYNAPTIC_ACCELERATOR_II    85939
-#define OBJ_BIO_CEREBRAL_BOOSTER_II        85927
 #define OBJ_BIO_CATS_EYES                  85802
 #define OBJ_BIO_METABOLIC_ARRESTER         85804
 #define OBJ_BIO_PAIN_EDITOR                85937
@@ -2813,7 +2813,6 @@ enum {
 #define OBJ_BIO_ENHANCED_ARTICULATION      415
 #define OBJ_BIO_TRAUMA_DAMPER              60611
 #define OBJ_BIO_SYNAPTIC_ACCELERATOR_II    414
-#define OBJ_BIO_CEREBRAL_BOOSTER_II        411
 #define OBJ_BIO_CATS_EYES                  1461
 #define OBJ_BIO_METABOLIC_ARRESTER         60605
 #define OBJ_BIO_PAIN_EDITOR                412

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -7649,6 +7649,14 @@ void price_bio(struct obj_data *obj)
       GET_OBJ_AVAILTN(obj) = 6;
       GET_OBJ_AVAILDAY(obj) = 14;
       break;
+    case BIO_MEDIALCORTEX:
+      if (GET_BIOWARE_RATING(obj) == 1)
+        GET_OBJ_COST(obj) = 50000;
+      else GET_OBJ_COST(obj) = 110000;
+      GET_BIOWARE_ESSENCE_COST(obj) = GET_BIOWARE_RATING(obj) * 40;
+      GET_OBJ_AVAILTN(obj) = 6;
+      GET_OBJ_AVAILDAY(obj) = 14;
+      break;
     case BIO_DAMAGECOMPENSATOR:
       if (GET_BIOWARE_RATING(obj) < 3) {
         GET_OBJ_COST(obj) = GET_BIOWARE_RATING(obj) * 25000;
@@ -7743,7 +7751,11 @@ void price_bio(struct obj_data *obj)
   }
 
   // Check for cultured. Don't modify the prices of things that are cultured by default (brainware, etc)
-  if ((GET_BIOWARE_TYPE(obj) < BIO_CEREBRALBOOSTER || GET_BIOWARE_TYPE(obj) >= BIO_BIOSCULPTING) && GET_SETTABLE_BIOWARE_IS_CULTURED(obj)) {
+  if (
+      (GET_BIOWARE_TYPE(obj) < BIO_CEREBRALBOOSTER || GET_BIOWARE_TYPE(obj) >= BIO_BIOSCULPTING) 
+      && GET_SETTABLE_BIOWARE_IS_CULTURED(obj)
+      && GET_BIOWARE_TYPE(obj) != BIO_MEDIALCORTEX
+    ) {
     GET_OBJ_COST(obj) *= 4;
     GET_BIOWARE_ESSENCE_COST(obj) = (int) round(GET_BIOWARE_ESSENCE_COST(obj) * .75);
     GET_OBJ_AVAILTN(obj) += 2;

--- a/src/otaku.cpp
+++ b/src/otaku.cpp
@@ -30,6 +30,10 @@ int get_otaku_wil(struct char_data *ch) {
   if (pain_editor && GET_BIOWARE_IS_ACTIVATED(pain_editor))
     wil_stat++;
 
+  struct obj_data *mct_bridge = find_bioware(ch, BIO_MEDIALCORTEX);
+  if (mct_bridge)
+    wil_stat += GET_BIOWARE_RATING(mct_bridge);
+
   /* Handling Drugs */
   int detox_force = affected_by_spell(ch, SPELL_DETOX);
   if (GET_DRUG_STAGE(ch, DRUG_KAMIKAZE) == DRUG_STAGE_ONSET && !IS_DRUG_DETOX(DRUG_KAMIKAZE, detox_force))


### PR DESCRIPTION
Just a simple PR adding the Homebrew Medial Cortex Bridge from Shadowrun: Denver to here.

```
This network of cultured neurons bridges the medial prefrontal cortex and the hypothalamus to give these parts of the brain more control over the amygdala. Additionally, modified adrenal medullae alter the hormones produced during panic situations. The character is less prone to panic attacks, stress, or other mental manipulations. Also referred to as the MCT Bridge.
```

It's like a Cerebral Booster, but for WIL.

Didn't discuss before writing it; reject PR if not a good fit for the game.