### PR TITLE
Various matrix things

### DIFF
--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -2132,6 +2132,15 @@ const char *ic_option_long[] =
     "Trap  "
   };
 
+int ic_dmg_by_color[] =
+  {
+    LIGHT,    // Blue
+    MODERATE, // Green
+    SERIOUS,  // Orange
+    SERIOUS,  // Red
+    SERIOUS,  // Black, also +2 power
+  };
+
 // Weight and cost are PER ROUND now.
 struct ammo_data ammo_type[] =
   {

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -79,6 +79,7 @@ extern const char *alerts[3];
 extern const char *ic_type[];
 extern const char *ic_option[];
 extern const char *ic_option_long[];
+extern int ic_dmg_by_color[];
 extern struct ammo_data ammo_type[];
 extern struct part_data parts[];
 extern struct program_data programs[];

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -881,8 +881,7 @@ void matrix_fight(struct matrix_icon *icon, struct matrix_icon *targ)
         send_to_icon(targ, "It tears into your living persona!\r\n");
         do_damage_persona(targ, damage_total);
         return;
-      }
-      if (success >= 2) {
+      } else if (success >= 2) {
         send_to_icon(targ, "It tears into the program!\r\n");
         while (success >= 2) {
           success -= 2;

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -875,10 +875,6 @@ void matrix_fight(struct matrix_icon *icon, struct matrix_icon *targ)
         if (damage_total <= 0) {
           return send_to_icon(targ, "It fails to damage your living persona.\r\n");
         }
-        damage_total = convert_damage(stage((2 - success_test(GET_BOD(targ->decker->ch) + GET_BODY_POOL(targ->decker->ch), MIN(matrix[icon->in_host].color + 1, DEADLY))), damage_total));
-        if (damage_total <= 0) {
-          return send_to_icon(targ, "You power through it and nullify the damage.\r\n");
-        }
         send_to_icon(targ, "It tears into your living persona!\r\n");
         do_damage_persona(targ, damage_total);
         return;

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -444,6 +444,16 @@ int system_test(rnum_t host, struct char_data *ch, int type, int software, int m
         break;
     }
     target -= channel_rating;
+  } else {
+    // ... or by the appropriate decker utility program
+    for (struct obj_data *soft = DECKER->software; soft; soft = soft->next_content) {
+      if (GET_PROGRAM_TYPE(soft) == software) {
+        target -= GET_PROGRAM_RATING(soft);
+        buf_mod(rollbuf, sizeof(rollbuf), "soft", -GET_PROGRAM_RATING(soft));
+        prog = soft;  // for tarbaby/tarpit
+        break;
+      }
+    }
   }
   snprintf(rollbuf, sizeof(rollbuf), "System test against %s with software %s: Starting TN %d", acifs_strings[type], programs[software].name, target);
 
@@ -465,15 +475,6 @@ int system_test(rnum_t host, struct char_data *ch, int type, int software, int m
   strlcat(rollbuf, ". Modifiers: ", sizeof(rollbuf));
   target += modify_target_rbuf_raw(ch, rollbuf, sizeof(rollbuf), 8, FALSE) + DECKER->res_test + (DECKER->ras ? 0 : 4);
 
-  for (struct obj_data *soft = DECKER->software; soft; soft = soft->next_content) {
-    if (prog) break;
-    if (GET_PROGRAM_TYPE(soft) == SOFT_SLEAZE) break;
-    if (GET_PROGRAM_TYPE(soft) == software) {
-      target -= GET_PROGRAM_RATING(soft);
-      buf_mod(rollbuf, sizeof(rollbuf), "soft", -GET_PROGRAM_RATING(soft));
-      prog = soft;
-    }
-  }
   detect = get_detection_factor(ch);
 
   int tally = MAX(0, success_test(HOST.security, detect));

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -346,7 +346,7 @@ bool dumpshock(struct matrix_icon *icon)
       }
     }
 
-    int resist = -success_test(GET_WIL(icon->decker->ch), matrix[icon->in_host].security - (GET_ECHO(icon->decker->ch, ECHO_NEUROFILTER) * 2));
+    int resist = -success_test(GET_WIL(icon->decker->ch), matrix[icon->in_host].security);
     int dam = convert_damage(stage(resist, MIN(matrix[icon->in_host].color + 1, DEADLY)));
 
     struct obj_data *jack = get_datajack(icon->decker->ch, FALSE);
@@ -1068,7 +1068,7 @@ void matrix_fight(struct matrix_icon *icon, struct matrix_icon *targ)
       else
         resist = GET_WIL(targ->decker->ch);
 
-      int wil_test_result = success_test(GET_WIL(targ->decker->ch), power - (GET_ECHO(targ->decker->ch, ECHO_NEUROFILTER) * 2));
+      int wil_test_result = success_test(GET_WIL(targ->decker->ch), power);
       int bod_test_result = success_test(GET_BOD(targ->decker->ch), power);
       success -= targ->decker->iccm ? MAX(wil_test_result, bod_test_result) : success_test(resist, power);
       int meatdam = convert_damage(stage(success, dam));
@@ -1108,7 +1108,7 @@ void matrix_fight(struct matrix_icon *icon, struct matrix_icon *targ)
         power = 5;
         break;
       }
-      if (success_test(GET_WIL(targ->decker->ch), power - (GET_ECHO(targ->decker->ch, ECHO_NEUROFILTER) * 2)) < 1) {
+      if (success_test(GET_WIL(targ->decker->ch), power) < 1) {
         send_to_icon(targ, "Your interface overloads.\r\n");
         if (damage(targ->decker->ch, targ->decker->ch, 1, TYPE_TASER, MENTAL)) {
           return;

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -396,8 +396,10 @@ int get_detection_factor(struct char_data *ch)
 {
   int detect = 0;
   for (struct obj_data *soft = DECKER->software; soft; soft = soft->next_content)
-    if (GET_PROGRAM_TYPE(soft) == SOFT_SLEAZE)
+    if (GET_PROGRAM_TYPE(soft) == SOFT_SLEAZE) {
       detect = GET_PROGRAM_RATING(soft);
+      break;
+    }
   detect += DECKER->masking + 1; // +1 because we round up
   detect = detect / 2;
   detect -= DECKER->res_det;

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -347,7 +347,7 @@ bool dumpshock(struct matrix_icon *icon)
     }
 
     int resist = -success_test(GET_WIL(icon->decker->ch), matrix[icon->in_host].security - (GET_ECHO(icon->decker->ch, ECHO_NEUROFILTER) * 2));
-    int dam = convert_damage(stage(resist, matrix[icon->in_host].color));
+    int dam = convert_damage(stage(resist, MIN(matrix[icon->in_host].color + 1, DEADLY)));
 
     struct obj_data *jack = get_datajack(icon->decker->ch, FALSE);
 

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -443,7 +443,7 @@ int system_test(rnum_t host, struct char_data *ch, int type, int software, int m
         channel_rating += GET_SKILL(ch, SKILL_CHANNEL_SLAVE);
         break;
     }
-    target = MAX(2, target - channel_rating);
+    target -= channel_rating;
   }
   snprintf(rollbuf, sizeof(rollbuf), "System test against %s with software %s: Starting TN %d", acifs_strings[type], programs[software].name, target);
 


### PR DESCRIPTION
~~1. Previously, crippler/ripper damage to otaku was very unlikely to happen, except when a race condition occurs (see: 4 below). In the scenario of an early-game otaku with 7 in the relevant attribute, hacking pool set to 3, and 12 soak dice (body + cpool), that is in a Red host with rating 6 security (existing Red hosts at this rating are difficult but accessible by early game deckers), and is successfully hit by a rating 6 crippler/ripper, they would only have a 0.15% chance of taking any damage at all. This PR removes the second resistance test, making it a 6.5% chance. Conceptually, this would work more like powerbolt (where you only have a spell resistance test and no soak test).~~

~~It's unclear what the desired probability of damage is, but we can increase it to 21% in the given scenario by removing the /2 a few lines before the deleted portion.~~

2. Previously, otaku system tests were being capped at min 2 before other penalties were applied (like host alert and wound penalties). This is removed here so that otaku can actually reach the min TN 2 while taking penalties.

3. Some cleanup in system_test - no need to search for decker utility programs with living personae since they use channels instead, and no reason to search for sleaze when `get_detection_factor(ch)` already does that.

4. When hit by a crippler/ripper IC, living persona would have their attribute lowered, but then reset by the next `affect_total` -> `update_otaku_deck`. If the crippler/ripper IC hits while the attribute is lowered, number of successes rolled by the IC can rise sharply. Per https://discord.com/channels/564618629467996170/797657781507194880/1350710279071203338 , crippler/ripper IC should only deal damage, not reduce persona attributes.