### PR TITLE
Removing automatic computer spend for otaku

### DIFF
--- a/src/chargen.cpp
+++ b/src/chargen.cpp
@@ -1120,10 +1120,6 @@ static void start_game(descriptor_data *d, const char *origin)
 
   // Otaku get some starting gear and skills, so assign that here
   if (d->ccr.is_otaku) {
-    // Assign starting computers to be helpful
-    GET_SKILL_POINTS(d->character) -= 6;
-    set_character_skill(d->character, SKILL_COMPUTER, 6, FALSE);
-
     // Equip cyberware (deduct essence and modify stats as appropriate)
     obj_data *temp_obj;
     for (int cyb = 0; cyb < OTAKU_CYBERWARE_NUM; cyb++) {


### PR DESCRIPTION
Bug: When making an otaku the skill points would be deducted by the character would not have computers 6.

I tried to fix this in various ways but cannot get the computers skill to persist. Somehow or somewhere the skills are getting reset in chargen. Rather than pursue this forever, I just removed the helper.

The validation still exists so that you cannot create a character with less than 6 skillpoints (see points creation) so you cannot softlock yourself.