### PR TITLE
Add cha mods to otaku masking, cha+wil mods to otaku mpcp

### DIFF
--- a/src/otaku.cpp
+++ b/src/otaku.cpp
@@ -35,6 +35,19 @@ int complex_form_programs[COMPLEX_FORM_TYPES] = {
   SOFT_SHIELD
 };
 
+int get_otaku_cha(struct char_data *ch) {
+  int cha_stat = GET_REAL_CHA(ch);
+
+  /* Handling Drugs */
+  int detox_force = affected_by_spell(ch, SPELL_DETOX);
+  if (GET_DRUG_STAGE(ch, DRUG_NOVACOKE) == DRUG_STAGE_ONSET && !IS_DRUG_DETOX(DRUG_NOVACOKE, detox_force))
+    cha_stat += 1;
+  if (GET_DRUG_STAGE(ch, DRUG_NOVACOKE) == DRUG_STAGE_COMEDOWN && !IS_DRUG_DETOX(DRUG_NOVACOKE, detox_force))
+    cha_stat = 1;
+
+  return cha_stat;
+}
+
 int get_otaku_wil(struct char_data *ch) {
   int wil_stat = GET_REAL_WIL(ch);
 
@@ -279,7 +292,7 @@ void update_otaku_deck(struct char_data *ch, struct obj_data *cyberdeck) {
         GET_PART_RATING(part) = get_otaku_int(ch);
         break;
       case PART_MASKING:
-        GET_PART_RATING(part) = (get_otaku_wil(ch) + GET_REAL_CHA(ch) + 1) / 2;
+        GET_PART_RATING(part) = (get_otaku_wil(ch) + get_otaku_cha(ch) + 1) / 2;
         break;
     }
   }

--- a/src/otaku.cpp
+++ b/src/otaku.cpp
@@ -41,7 +41,7 @@ int get_otaku_cha(struct char_data *ch) {
   /* Handling Drugs */
   int detox_force = affected_by_spell(ch, SPELL_DETOX);
   if (GET_DRUG_STAGE(ch, DRUG_NOVACOKE) == DRUG_STAGE_ONSET && !IS_DRUG_DETOX(DRUG_NOVACOKE, detox_force))
-    cha_stat += 1;
+    cha_stat++;
   if (GET_DRUG_STAGE(ch, DRUG_NOVACOKE) == DRUG_STAGE_COMEDOWN && !IS_DRUG_DETOX(DRUG_NOVACOKE, detox_force))
     cha_stat = 1;
 
@@ -63,7 +63,7 @@ int get_otaku_wil(struct char_data *ch) {
   if (GET_DRUG_STAGE(ch, DRUG_NITRO) == DRUG_STAGE_ONSET && !IS_DRUG_DETOX(DRUG_NITRO, detox_force))
     wil_stat += 2;
   if (GET_DRUG_STAGE(ch, DRUG_ZEN) == DRUG_STAGE_ONSET && !IS_DRUG_DETOX(DRUG_ZEN, detox_force))
-    wil_stat += 2;
+    wil_stat++;
   
   if (GET_DRUG_STAGE(ch, DRUG_KAMIKAZE) == DRUG_STAGE_COMEDOWN && !IS_DRUG_DETOX(DRUG_KAMIKAZE, detox_force))
     wil_stat--;

--- a/src/otaku.hpp
+++ b/src/otaku.hpp
@@ -7,6 +7,7 @@ struct otaku_echo {
   bool nerps;
 };
 
+int     get_otaku_cha(struct char_data *ch);
 int     get_otaku_wil(struct char_data *ch);
 int     get_otaku_int(struct char_data *ch);
 int     get_otaku_qui(struct char_data *ch);
@@ -24,7 +25,7 @@ extern int complex_form_programs[COMPLEX_FORM_TYPES];
 
 #define GET_OTAKU_MPCP(ch)           \
   (({ \
-    int mpcp = (get_otaku_int(ch) + GET_REAL_WIL(ch) + GET_REAL_CHA(ch) + 2) / 3; \
+    int mpcp = (get_otaku_int(ch) + get_otaku_wil(ch) + get_otaku_cha(ch) + 2) / 3; \
     if (GET_ECHO(ch, ECHO_IMPROVED_MPCP)) { \
       mpcp = MIN(get_otaku_int(ch) * 2, mpcp + GET_ECHO(ch, ECHO_IMPROVED_MPCP)); \
     } \


### PR DESCRIPTION
This PR updates otaku masking calculation to include charisma modifiers (wil mods were already included), and also otaku MPCP calculation to include cha and wil mods (int mods were already included).