### PR TITLE
Various otaku/matrix things

### DIFF
--- a/src/act.informative.cpp
+++ b/src/act.informative.cpp
@@ -5144,8 +5144,15 @@ ACMD(do_score)
         strlcat(mage_string, "Physical Adept", sizeof(mage_string));
         break;
       default:
-        if (IS_OTAKU(ch)) strlcat(mage_string, "Otaku", sizeof(mage_string));
-        else strlcat(mage_string, "Mundane", sizeof(mage_string));
+        if (IS_OTAKU(ch)) {
+          if (GET_OTAKU_PATH(ch) == OTAKU_PATH_NORMIE) {
+            strlcat(mage_string, "Otaku path missing, contact staff", sizeof(mage_string));
+          } else {
+            strlcat(mage_string, (GET_OTAKU_PATH(ch) == OTAKU_PATH_CYBERADEPT) ? "Cyberadept Otaku" : "Technoshaman Otaku", sizeof(mage_string));
+          }
+        } else {
+          strlcat(mage_string, "Mundane", sizeof(mage_string));
+        }
         break;
     }
 

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -1437,17 +1437,17 @@ int make_prompt(struct descriptor_data * d)
             case 'D':
               snprintf(str, sizeof(str), "%d", GET_BODY_POOL(d->character));
               break;
-            case 'e':
+            case 'e':       // persona active memory
               if (ch->persona)
                 snprintf(str, sizeof(str), "%d", ch->persona->decker->active);
               else
-                snprintf(str, sizeof(str), "0");
+                snprintf(str, sizeof(str), "NA");
               break;
             case 'E':
               if (ch->persona && ch->persona->decker->deck)
-                snprintf(str, sizeof(str), "%d", GET_OBJ_VAL(ch->persona->decker->deck, 2));
+                snprintf(str, sizeof(str), "%d", GET_CYBERDECK_ACTIVE_MEMORY(ch->persona->decker->deck));
               else
-                snprintf(str, sizeof(str), "0");
+                snprintf(str, sizeof(str), "NA");
               break;
             case 'f':
               snprintf(str, sizeof(str), "%d", GET_CASTING(d->character));
@@ -1559,17 +1559,23 @@ int make_prompt(struct descriptor_data * d)
                 strlcpy(str, get_ch_domain_str(ch, TRUE), sizeof(str));
               }
               break;
-            case 'r':
+            case 'r':       // persona storage memory
               if (ch->persona && ch->persona->decker->deck)
-                snprintf(str, sizeof(str), "%d", GET_OBJ_VAL(ch->persona->decker->deck, 3) - GET_OBJ_VAL(ch->persona->decker->deck, 5));
+                if (ch->persona->type == ICON_LIVING_PERSONA && ch->persona->decker->proxy_deck)
+                  snprintf(str, sizeof(str), "%d", GET_CYBERDECK_FREE_STORAGE(ch->persona->decker->proxy_deck));
+                else
+                  snprintf(str, sizeof(str), "%d", GET_CYBERDECK_FREE_STORAGE(ch->persona->decker->deck));
               else
-                snprintf(str, sizeof(str), "0");
+                snprintf(str, sizeof(str), "NA");
               break;
             case 'R':
               if (ch->persona && ch->persona->decker && ch->persona->decker->deck)
-                snprintf(str, sizeof(str), "%d", GET_OBJ_VAL(ch->persona->decker->deck, 3));
+                if (ch->persona->type == ICON_LIVING_PERSONA && ch->persona->decker->proxy_deck)
+                  snprintf(str, sizeof(str), "%d", GET_CYBERDECK_TOTAL_STORAGE(ch->persona->decker->proxy_deck));
+                else
+                  snprintf(str, sizeof(str), "%d", GET_CYBERDECK_TOTAL_STORAGE(ch->persona->decker->deck));
               else
-                snprintf(str, sizeof(str), "0");
+                snprintf(str, sizeof(str), "NA");
               break;
             case 's':       // current ammo
               if (GET_EQ(d->character, WEAR_HOLD) &&

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -555,12 +555,12 @@ bool do_damage_persona(struct matrix_icon *targ, int dmg)
 {
   if (targ->type == ICON_LIVING_PERSONA) {
     // It's an otaku! They get to suffer MENTAL DAMAGE!
-    // targ->condition seems to be 1-10 scale, while ch mental wounds seems to be 1-100. Multiply by ten.
-
     // damage() returns TRUE if the target has been deleted from memory, so when this function returns true, we must bail out of everything immediately.
     if (damage(targ->decker->ch, targ->decker->ch, dmg, TYPE_BLACKIC, MENTAL))
       return TRUE;
 
+    // targ->condition is 0-10 scale, while ch mental wounds is 0-100.
+    targ->condition = GET_MENTAL(targ->decker->ch) / 10;
     return FALSE;
   }
   targ->condition -= dmg;

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -2918,8 +2918,8 @@ ACMD(do_decrypt)
     // If there's nothing to decrypt, there's nothing to succeed at.
     if (!matrix[PERSONA->in_host].stats[mode][MTX_STAT_ENCRYPTED]) {
       send_to_icon(PERSONA, "The local %s subsystem doesn't seem to be encrypted.\r\n", mtx_subsystem_names[mode]);
-      if (mode == ACIFS_ACCESS && PRF_FLAGGED(ch, PRF_SEE_TIPS))
-        send_to_icon(PERSONA, "[OOC: To decrypt a remote host's SAN, try \"decrypt <host>\".]\r\n");
+      if (PRF_FLAGGED(ch, PRF_SEE_TIPS) && (mode == ACIFS_ACCESS))
+        send_to_icon(PERSONA, "[OOC: To decrypt a remote host's SAN, try ^WDECRYPT <HOST>^n.]\r\n");
       return;
     }
 

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -2917,7 +2917,9 @@ ACMD(do_decrypt)
 
     // If there's nothing to decrypt, there's nothing to succeed at.
     if (!matrix[PERSONA->in_host].stats[mode][MTX_STAT_ENCRYPTED]) {
-      send_to_icon(PERSONA, "The %s subsystem doesn't seem to be encrypted.\r\n", mtx_subsystem_names[mode]);
+      send_to_icon(PERSONA, "The local %s subsystem doesn't seem to be encrypted.\r\n", mtx_subsystem_names[mode]);
+      if (mode == ACIFS_ACCESS && PRF_FLAGGED(ch, PRF_SEE_TIPS))
+        send_to_icon(PERSONA, "[OOC: To decrypt a remote host's SAN, try \"decrypt <host>\".]\r\n");
       return;
     }
 

--- a/src/otaku.cpp
+++ b/src/otaku.cpp
@@ -240,7 +240,6 @@ void _update_living_persona(struct char_data *ch, struct obj_data *cyberdeck, in
   ch->persona->decker->mpcp = mpcp;
   ch->persona->decker->hardening = GET_CYBERDECK_HARDENING(cyberdeck);
   ch->persona->decker->response = GET_CYBERDECK_RESPONSE_INCREASE(cyberdeck);
-  ch->persona->decker->io = GET_CYBERDECK_IO_RATING(cyberdeck);
 
   for (struct obj_data *part = cyberdeck->contains; part; part = part->next_content) {
     if (GET_OBJ_TYPE(part) != ITEM_PART) continue;

--- a/src/otaku.cpp
+++ b/src/otaku.cpp
@@ -271,6 +271,7 @@ void update_otaku_deck(struct char_data *ch, struct obj_data *cyberdeck) {
   GET_CYBERDECK_HARDENING(cyberdeck) = MIN(get_otaku_wil(ch), GET_CYBERDECK_HARDENING(cyberdeck));
   GET_CYBERDECK_ACTIVE_MEMORY(cyberdeck) = 0; // Otaku do not have active memory.
   GET_CYBERDECK_TOTAL_STORAGE(cyberdeck) = 0;
+  // Otaku don't have response increase, so use this for matrix reaction instead
   GET_CYBERDECK_RESPONSE_INCREASE(cyberdeck) = get_otaku_rea(ch) + GET_ECHO(ch, ECHO_IMPROVED_REA);
   GET_CYBERDECK_RESPONSE_INCREASE(cyberdeck) = MIN(mpcp * 1.5, GET_CYBERDECK_RESPONSE_INCREASE(cyberdeck));
   GET_CYBERDECK_IO_RATING(cyberdeck) = (get_otaku_int(ch) * 100) + (GET_ECHO(ch, ECHO_IMPROVED_IO) * 100);

--- a/src/pro_create.cpp
+++ b/src/pro_create.cpp
@@ -244,8 +244,8 @@ struct obj_data *can_program(struct char_data *ch)
     if (!comp) {
       send_to_char(ch, "There is no computer here for you to use.\r\n");
       // A computer isn't used to design a complex form, but we use a different command for that
-      if (IS_OTAKU(ch))
-        send_to_char(ch, "Did you mean \"forms learn <form>\"?\r\n");
+      if (IS_OTAKU(ch) && PRF_FLAGGED(ch, PRF_SEE_TIPS))
+        send_to_char(ch, "[OOC: For complex forms, try \"forms learn <form>\".]\r\n");
       return NULL;
     }
     return comp;
@@ -362,8 +362,8 @@ ACMD(do_design)
   if (!prog) {
     send_to_char(ch, "The program design isn't on %s.\r\n", decapitalize_a_an(GET_OBJ_NAME(comp)));
     // A computer isn't used to design a complex form, but we use a different command
-    if (IS_OTAKU(ch))
-      send_to_char(ch, "Did you mean \"forms learn <form>\"?\r\n");
+    if (IS_OTAKU(ch) && PRF_FLAGGED(ch, PRF_SEE_TIPS))
+      send_to_char(ch, "[OOC: For complex forms, try \"forms learn <form>\".]\r\n");
     return;
   }
   if (GET_DESIGN_COMPLETED(prog) || GET_DESIGN_PROGRAMMING_TICKS_LEFT(prog)) {

--- a/src/pro_create.cpp
+++ b/src/pro_create.cpp
@@ -243,6 +243,9 @@ struct obj_data *can_program(struct char_data *ch)
       comp = NULL;
     if (!comp) {
       send_to_char(ch, "There is no computer here for you to use.\r\n");
+      // A computer isn't used to design a complex form, but we use a different command for that
+      if (IS_OTAKU(ch))
+        send_to_char(ch, "Did you mean \"forms learn <form>\"?\r\n");
       return NULL;
     }
     return comp;
@@ -358,6 +361,9 @@ ACMD(do_design)
 
   if (!prog) {
     send_to_char(ch, "The program design isn't on %s.\r\n", decapitalize_a_an(GET_OBJ_NAME(comp)));
+    // A computer isn't used to design a complex form, but we use a different command
+    if (IS_OTAKU(ch))
+      send_to_char(ch, "Did you mean \"forms learn <form>\"?\r\n");
     return;
   }
   if (GET_DESIGN_COMPLETED(prog) || GET_DESIGN_PROGRAMMING_TICKS_LEFT(prog)) {

--- a/src/pro_create.cpp
+++ b/src/pro_create.cpp
@@ -233,7 +233,7 @@ struct obj_data *can_program(struct char_data *ch)
   else {
     for (struct char_data *vict = ch->in_veh ? ch->in_veh->people : ch->in_room->people; vict; vict = vict->next_in_room)
       if (AFF_FLAGS(vict).AreAnySet(AFF_PROGRAM, AFF_DESIGN, ENDBIT)) {
-        send_to_char(ch, "Someone is already using the computer.\r\n");
+        send_to_char("Someone is already using the computer.\r\n", ch);
         return NULL;
       }
     FOR_ITEMS_AROUND_CH(ch, comp)
@@ -244,8 +244,8 @@ struct obj_data *can_program(struct char_data *ch)
     if (!comp) {
       send_to_char(ch, "There is no computer here for you to use.\r\n");
       // A computer isn't used to design a complex form, but we use a different command for that
-      if (IS_OTAKU(ch) && PRF_FLAGGED(ch, PRF_SEE_TIPS))
-        send_to_char(ch, "[OOC: For complex forms, try \"forms learn <form>\".]\r\n");
+      if (PRF_FLAGGED(ch, PRF_SEE_TIPS) && IS_OTAKU(ch))
+        send_to_char("[OOC: To learn a complex form, try ^WFORMS LEARN <FORM>^n.]\r\n", ch);
       return NULL;
     }
     return comp;
@@ -361,9 +361,9 @@ ACMD(do_design)
 
   if (!prog) {
     send_to_char(ch, "The program design isn't on %s.\r\n", decapitalize_a_an(GET_OBJ_NAME(comp)));
-    // A computer isn't used to design a complex form, but we use a different command
-    if (IS_OTAKU(ch) && PRF_FLAGGED(ch, PRF_SEE_TIPS))
-      send_to_char(ch, "[OOC: For complex forms, try \"forms learn <form>\".]\r\n");
+    // A computer isn't used to design a complex form, but we use a different command for that
+    if (PRF_FLAGGED(ch, PRF_SEE_TIPS) && IS_OTAKU(ch))
+      send_to_char("[OOC: To learn a complex form, try ^WFORMS LEARN <FORM>^n.]\r\n", ch);
     return;
   }
   if (GET_DESIGN_COMPLETED(prog) || GET_DESIGN_PROGRAMMING_TICKS_LEFT(prog)) {


### PR DESCRIPTION
1) When connected with a living persona, use proxy deck values when showing storage memory in prompts.
https://discord.com/channels/564618629467996170/788953927269613608/1354737619493191741
https://discord.com/channels/564618629467996170/788953927269613608/1355008663164682290

2) Prevent living persona updates from overriding room I/O limits. Note that the way this was fixed means that I/O won't get updated if the otaku loses int, but I think typical room limits are low enough that it won't matter.
https://discord.com/channels/564618629467996170/788953927269613608/1355285007186530478

3) Add hints for decrypting SANs and learning complex forms.
https://discord.com/channels/564618629467996170/1219763142628999198/1354663103731859553
https://discord.com/channels/564618629467996170/788953927269613608/1354591108218491041

4) Fix matrix initiative: `GET_CYBERDECK_RESPONSE_INCREASE` is the otaku's matrix reaction, not response increase
https://discord.com/channels/564618629467996170/788953927269613608/1355299468643270808

5) Add otaku path to score.
https://discord.com/channels/564618629467996170/788953927269613608/1354095217044750357