### PR TITLE
More matrix fixes

### DIFF
--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -339,9 +339,11 @@ bool dumpshock(struct matrix_icon *icon)
 {
   if (!icon) return FALSE;
 
-  if (icon->decker && icon->decker->ch)
+  struct char_data *ch = icon->decker->ch;
+
+  if (icon->decker && ch)
   {
-    send_to_char(icon->decker->ch, "You are dumped from the matrix!\r\n");
+    send_to_char(ch, "You are dumped from the matrix!\r\n");
     snprintf(buf, sizeof(buf), "%s^n depixelates and vanishes from the host.\r\n", CAP(icon->name));
     send_to_host(icon->in_host, buf, icon, FALSE);
 
@@ -363,10 +365,10 @@ bool dumpshock(struct matrix_icon *icon)
       }
     }
 
-    int resist = -success_test(GET_WIL(icon->decker->ch), matrix[icon->in_host].security);
+    int resist = -success_test(GET_WIL(ch), matrix[icon->in_host].security);
     int dam = convert_damage(stage(resist, MIN(matrix[icon->in_host].color + 1, DEADLY)));
 
-    struct obj_data *jack = get_datajack(icon->decker->ch, FALSE);
+    struct obj_data *jack = get_datajack(ch, FALSE);
 
     if (GET_OBJ_TYPE(jack) == ITEM_CYBERWARE) {
       if (GET_CYBERWARE_TYPE(jack) == CYB_DATAJACK) {
@@ -384,22 +386,17 @@ bool dumpshock(struct matrix_icon *icon)
       // Trode net.
       snprintf(buf, sizeof(buf), "$n suddenly jerks forward and rips the 'trode net off of $s head!");
     }
-    act(buf, FALSE, icon->decker->ch, NULL, NULL, TO_ROOM);
+    act(buf, FALSE, ch, NULL, NULL, TO_ROOM);
     icon->decker->PERSONA = NULL;
-    PLR_FLAGS(icon->decker->ch).RemoveBit(PLR_MATRIX);
     if (icon->decker->deck && GET_OBJ_VAL(icon->decker->deck, 0) == 0) {
-      act("Smoke emerges from $n's $p.", FALSE, icon->decker->ch, icon->decker->deck, NULL, TO_ROOM);
-      act("Smoke emerges from $p.", FALSE, icon->decker->ch, icon->decker->deck, NULL, TO_CHAR);
+      act("Smoke emerges from $n's $p.", FALSE, ch, icon->decker->deck, NULL, TO_ROOM);
+      act("Smoke emerges from $p.", FALSE, ch, icon->decker->deck, NULL, TO_CHAR);
     }
-    struct char_data *ch = icon->decker->ch;
     extract_icon(icon);
     PLR_FLAGS(ch).RemoveBit(PLR_MATRIX);
     SendGMCPMatrixInfo(ch);
     SendGMCPMatrixDeck(ch);
 
-    // No reason to double-damage
-    if (!PLR_FLAGGED(ch, PLR_MATRIX))
-      return FALSE;
     // If they're stunned or dead, there's no reason to take dumpshock damage.
     if (GET_POS(ch) <= POS_STUNNED)
       return FALSE; 

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -444,6 +444,8 @@ int system_test(rnum_t host, struct char_data *ch, int type, int software, int m
   }
 
   int target = HOST.stats[type][MTX_STAT_RATING];
+  snprintf(rollbuf, sizeof(rollbuf), "System test against %s with software %s: Starting TN %d", acifs_strings[type], programs[software].name, target);
+
   if (PERSONA->type == ICON_LIVING_PERSONA) {
     // We lower the TN by the channel rating
     int channel_rating = GET_OTAKU_PATH(ch) == OTAKU_PATH_TECHNOSHAM ? 1 : 0;
@@ -476,13 +478,12 @@ int system_test(rnum_t host, struct char_data *ch, int type, int software, int m
       }
     }
   }
-  snprintf(rollbuf, sizeof(rollbuf), "System test against %s with software %s: Starting TN %d", acifs_strings[type], programs[software].name, target);
 
   int skill = get_skill(ch, SKILL_COMPUTER, target) + MIN(GET_MAX_HACKING(ch), GET_REM_HACKING(ch));
   GET_REM_HACKING(ch) -= skill - get_skill(ch, SKILL_COMPUTER, detect);
   detect = 0;
 
-  snprintf(ENDOF(rollbuf), sizeof(rollbuf) - strlen(rollbuf), ", after get_skill %d, plus called modifier %d is %d", target, modifier, target + modifier);
+  snprintf(ENDOF(rollbuf), sizeof(rollbuf) - strlen(rollbuf), ", after get_skill %d", target);
 
   if (modifier) {
     target += modifier;

--- a/src/newmatrix.cpp
+++ b/src/newmatrix.cpp
@@ -96,7 +96,7 @@ void unload_active_program(struct matrix_icon *persona, struct obj_data *soft)
 {
   if (!persona || !soft) return;
   struct obj_data *temp = NULL;
-  persona->decker->active -= GET_PROGRAM_SIZE(soft);
+  persona->decker->active += GET_PROGRAM_SIZE(soft);
   REMOVE_FROM_LIST(soft, persona->decker->software, next_content);
   extract_obj(soft);
 }

--- a/src/otaku.cpp
+++ b/src/otaku.cpp
@@ -89,7 +89,7 @@ int get_otaku_int(struct char_data *ch) {
   /* Handling Drugs */
   int detox_force = affected_by_spell(ch, SPELL_DETOX);
   if (GET_DRUG_STAGE(ch, DRUG_PSYCHE) == DRUG_STAGE_ONSET && !IS_DRUG_DETOX(DRUG_PSYCHE, detox_force))
-    int_stat += 2;
+    int_stat++;
 
   return int_stat;
 }


### PR DESCRIPTION
1. `decker->active` is the amount of free memory, so unloading a program should add to this value, not subtract.

2. Fix rolls output for system tests so that the displayed starting TN is actually the starting TN, and to remove the duplicate "called modifier" display when the modifier is not zero (and removed entirely when it is zero).
Addresses: https://discord.com/channels/564618629467996170/788953927269613608/1355447999177953402

3. Fix missing dumpshock damage.
Addresses: https://discord.com/channels/564618629467996170/788953927269613608/1358548420708794428