### PR TITLE
Otaku caps rebalancing

### DIFF
--- a/src/cf_create.cpp
+++ b/src/cf_create.cpp
@@ -159,7 +159,7 @@ void cfedit_parse(struct descriptor_data *d, const char *arg)
     if (option_n > GET_SKILL(CH, SKILL_COMPUTER)) {
       send_to_char(CH, "You can't create a complex form of a higher rating than your computer skill.\r\n"
                    "Enter Rating: ");
-    } else if (option_n > GET_OTAKU_MPCP(CH)) {
+    } else if (option_n > get_otaku_mpcp(CH)) {
       send_to_char(CH, "You can't create a complex form of a higher rating than your living persona's MPCP rating.\r\n"
                    "Enter Rating: ");
     } else if (option_n <= 0) {

--- a/src/otaku.cpp
+++ b/src/otaku.cpp
@@ -154,6 +154,20 @@ int get_otaku_rea(struct char_data *ch) {
   return rea_stat;
 }
 
+int get_otaku_mpcp(struct char_data *ch) {
+  int mpcp = (get_otaku_int(ch) + get_otaku_wil(ch) + get_otaku_cha(ch) + 2) / 3
+             + GET_ECHO(ch, ECHO_IMPROVED_MPCP);
+
+  // HOUSERULE: cap otaku MPCP to 2x REAL int
+#ifdef DIES_IRAE
+  return MIN(GET_REAL_INT(ch) * 2, mpcp);
+#else
+  // human/elf/dwarf otaku have 7 max real int, so cap 14
+  // let troll/ork otaku reach the same mpcp cap
+  return MIN(14, mpcp);
+#endif
+}
+
 extern struct obj_data *make_new_finished_part(int part_type, int mpcp, int rating=0);
 struct obj_data *make_otaku_deck(struct char_data *ch) {
   if (!ch) {
@@ -169,7 +183,7 @@ struct obj_data *make_otaku_deck(struct char_data *ch) {
   struct obj_data *new_deck = read_object(OBJ_CUSTOM_CYBERDECK_SHELL, VIRTUAL, OBJ_LOAD_REASON_OTAKU_RESONANCE);
 
   // Add parts.
-  int mpcp = GET_OTAKU_MPCP(ch);
+  int mpcp = get_otaku_mpcp(ch);
 
   // Real values are assigned in update_otaku_deck()
   obj_to_obj(make_new_finished_part(PART_MPCP, mpcp, mpcp), new_deck);
@@ -264,9 +278,9 @@ void _update_living_persona(struct char_data *ch, struct obj_data *cyberdeck, in
 }
 
 void update_otaku_deck(struct char_data *ch, struct obj_data *cyberdeck) {
-  int mpcp = GET_OTAKU_MPCP(ch);
+  int mpcp = get_otaku_mpcp(ch);
 
-  GET_CYBERDECK_MPCP(cyberdeck) = MIN(12, mpcp);
+  GET_CYBERDECK_MPCP(cyberdeck) = mpcp;
   GET_CYBERDECK_HARDENING(cyberdeck) = (get_otaku_wil(ch) + 1) / 2 + GET_ECHO(ch, ECHO_IMPROVED_HARD);
   GET_CYBERDECK_HARDENING(cyberdeck) = MIN(get_otaku_wil(ch), GET_CYBERDECK_HARDENING(cyberdeck));
   GET_CYBERDECK_ACTIVE_MEMORY(cyberdeck) = 0; // Otaku do not have active memory.

--- a/src/otaku.cpp
+++ b/src/otaku.cpp
@@ -255,6 +255,7 @@ void _update_living_persona(struct char_data *ch, struct obj_data *cyberdeck, in
   ch->persona->decker->hardening = GET_CYBERDECK_HARDENING(cyberdeck);
   ch->persona->decker->response = GET_CYBERDECK_RESPONSE_INCREASE(cyberdeck);
 
+  // HOUSERULE: cap otaku persona ratings to 1x MPCP
   for (struct obj_data *part = cyberdeck->contains; part; part = part->next_content) {
     if (GET_OBJ_TYPE(part) != ITEM_PART) continue;
     switch (GET_OBJ_VAL(part, 0)) {
@@ -262,16 +263,16 @@ void _update_living_persona(struct char_data *ch, struct obj_data *cyberdeck, in
         GET_PART_RATING(part) = mpcp;
         break;
       case PART_BOD:
-        ch->persona->decker->bod = MIN(mpcp * 1.5, GET_PART_RATING(part) + GET_ECHO(ch, ECHO_PERSONA_BOD));
+        ch->persona->decker->bod = MIN(mpcp, GET_PART_RATING(part) + GET_ECHO(ch, ECHO_PERSONA_BOD));
         break;
       case PART_EVASION:
-        ch->persona->decker->evasion = MIN(mpcp * 1.5, GET_PART_RATING(part) + GET_ECHO(ch, ECHO_PERSONA_EVAS));
+        ch->persona->decker->evasion = MIN(mpcp, GET_PART_RATING(part) + GET_ECHO(ch, ECHO_PERSONA_EVAS));
         break;
       case PART_SENSOR:
-        ch->persona->decker->sensor = MIN(mpcp * 1.5, GET_PART_RATING(part) + GET_ECHO(ch, ECHO_PERSONA_SENS));
+        ch->persona->decker->sensor = MIN(mpcp, GET_PART_RATING(part) + GET_ECHO(ch, ECHO_PERSONA_SENS));
         break;
       case PART_MASKING:
-        ch->persona->decker->masking = MIN(mpcp * 1.5, GET_PART_RATING(part) + GET_ECHO(ch, ECHO_PERSONA_MASK));
+        ch->persona->decker->masking = MIN(mpcp, GET_PART_RATING(part) + GET_ECHO(ch, ECHO_PERSONA_MASK));
         break;
     }
   }

--- a/src/otaku.hpp
+++ b/src/otaku.hpp
@@ -7,11 +7,7 @@ struct otaku_echo {
   bool nerps;
 };
 
-int     get_otaku_cha(struct char_data *ch);
-int     get_otaku_wil(struct char_data *ch);
-int     get_otaku_int(struct char_data *ch);
-int     get_otaku_qui(struct char_data *ch);
-int     get_otaku_rea(struct char_data *ch);
+int     get_otaku_mpcp(struct char_data *ch);
 
 void    update_otaku_deck(struct char_data *ch, struct obj_data *cyberdeck);
 
@@ -22,14 +18,5 @@ void    update_otaku_deck(struct char_data *ch, struct obj_data *cyberdeck);
 #define COMPLEX_FORM_TYPES 11
 
 extern int complex_form_programs[COMPLEX_FORM_TYPES];
-
-#define GET_OTAKU_MPCP(ch)           \
-  (({ \
-    int mpcp = (get_otaku_int(ch) + get_otaku_wil(ch) + get_otaku_cha(ch) + 2) / 3; \
-    if (GET_ECHO(ch, ECHO_IMPROVED_MPCP)) { \
-      mpcp = MIN(get_otaku_int(ch) * 2, mpcp + GET_ECHO(ch, ECHO_IMPROVED_MPCP)); \
-    } \
-    mpcp; \
-  }))
 
 #endif


### PR DESCRIPTION
1. HOUSERULE: otaku MPCP capped at 14. Capping otaku MPCP to 2x REAL int seems a reasonable compromise between the custom deck cap of 12 and the rules-as-written 2x modified int. Since there seems to be some strong opinions on disadvantaging trolls/orks, this PR allows all implemented otaku races to reach 14 (i.e., 2x human/elf/dwarf otaku max real int).

2. HOUSERULE: otaku persona ratings capped at 1x MPCP. This prevents otaku from reaching detection factor (DF) of 18+, which would have effectively negated the otaku weakness to matrix damage since they'd so rarely spawn IC from tally count. This does allow cyberadepts to reach a max DF of 16, which will still be quite strong, but should help close the gap with the technoshaman bonus to matrix operation TNs.

My impression is that otaku will still be more competent in the matrix, but the increased vulnerability to matrix damage should also increase risk. Whether this is enough to balance them vs non-otaku mundanes may depend on how things look after fixing how black IC work (see: https://discord.com/channels/564618629467996170/797657781507194880/1354280321096613977).