### PR TITLE
Fixes to socials and load_single_veh (also credit finaltwist)

### DIFF
--- a/lib/misc/socials
+++ b/lib/misc/socials
@@ -183,7 +183,7 @@ You collapse in a heap.
 $n collapses in a heap.
 #
 
-crack 0 0
+em_crack 0 0
 You crack your knuckles.
 $n noisily cracks $s knuckles.
 #
@@ -393,7 +393,7 @@ You waste a fart on someone who's not even here.
 Quit farting around.
 $n farts all over $mself. Frankly, the spectacle is disgusting.
 
-flip 1 8
+em_flip 1 8
 You flip head over heels.
 $n flips head over heels.
 #
@@ -628,7 +628,7 @@ MMMMEEEEEEEEOOOOOOOOOWWWWWWWWWWWW.
 $n purrs contentedly.
 #
 
-roll 1 0
+em_roll 1 0
 You roll your eyes in disgust.
 $n rolls $s eyes in disgust.
 You look at $M and roll your eyes in disgust.
@@ -803,7 +803,7 @@ No one answers to that name here.
 You thank yourself since nobody else wants to!
 $n thanks $mself since you won't.
 
-think 1 0
+em_think 1 0
 You think about life, the universe and everything.
 $n sinks deeply into thought about the meaning of life.
 You think about what purpose $E has in relation to your part of life.
@@ -1065,7 +1065,8 @@ Hey, leave them alone!
 $n reaches out to scratch $N's head for $M.
 $n reaches out to scratch your head for you! Er.....ok....
 They obviously don't like you scratching them.
-#
+You scratch your head.
+$n scratches $s head.
 
 swear 0 5
 You swear profusely.
@@ -1074,7 +1075,8 @@ You scream abusive comments at $N!
 $n starts screaming truly abusive things at $N! How uncouth.
 $N screams truly abusive remarks at you! You gonna take that?
 Awww, noone to vent your anger on.
-#
+You scream abusive comments at yourself!
+$n starts screaming truly abusive things at $mself! How uncouth.
 
 disregard 0 5
 Disregarding nothing...?
@@ -1168,7 +1170,8 @@ You cheer $N on!
 $n cheers $N on!
 $n cheers you on! Go for it!
 Nope...looks like you're on your own.
-#
+You cheer yourself on!
+$n cheers $mself on!
 
 howl 0 5
 You howl, long and painfully.

--- a/src/act.social.cpp
+++ b/src/act.social.cpp
@@ -329,6 +329,21 @@ char *fread_action(FILE * fl, int nr)
 
 void boot_social_messages(void)
 {
+  /* Definitions in the social file should be either 4 or 9 lines as follows:
+
+      <command> <hide if invisible> <min vict position>
+      <msg to char, no arg provided>
+      <msg to others, no arg provided>
+      <msg to char, arg found>    <-- if this is "#", then stop here
+      <msg to others, arg found>
+      <msg to victim, arg found>
+      <msg to char, arg NOT found>
+      <msg to char, victim is the char>
+      <msg to others, victim is the char>
+  
+    A "#" line indicates a null message (i.e., no message will be sent).
+    A "$" line indicates the end of the definitions (any past this point will be skipped).
+  */
   FILE *fl;
   int nr, hide, min_pos, curr_soc = -1;
   char next_soc[250];
@@ -349,8 +364,14 @@ void boot_social_messages(void)
   /* now read 'em */
   for (;;) {
     fscanf(fl, " %249s ", next_soc);
-    if (*next_soc == '$')
+    if (*next_soc == '$') {
+      log_vfprintf("End of socials file reached");
       break;
+    }
+    if (curr_soc >= list_top+6 - 1) {
+      log_vfprintf("End of allocated socials array, stopping at '%s'", next_soc);
+      break;
+    }
     if ((nr = find_command(next_soc)) < 0)
       log_vfprintf("Unknown social '%s' in social file", next_soc);
 

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -1140,6 +1140,10 @@ struct command_info cmd_info[] =
     { "doh"      , POS_LYING   , do_action   , 0, 0, BLOCKS_IDLE_REWARD },
     { "drool"    , POS_LYING   , do_action   , 0, 0, BLOCKS_IDLE_REWARD },
     // Socials E
+    { "em_crack" , POS_LYING   , do_action   , 0, 0, BLOCKS_IDLE_REWARD },
+    { "em_flip"  , POS_LYING   , do_action   , 0, 0, BLOCKS_IDLE_REWARD },
+    { "em_roll"  , POS_LYING   , do_action   , 0, 0, BLOCKS_IDLE_REWARD },
+    { "em_think" , POS_LYING   , do_action   , 0, 0, BLOCKS_IDLE_REWARD },
     { "envy"     , POS_LYING   , do_action   , 0, 0, BLOCKS_IDLE_REWARD },
     { "eyebrow"  , POS_LYING   , do_action   , 0, 0, BLOCKS_IDLE_REWARD },
     // Socials F

--- a/src/vehicle_save_load.cpp
+++ b/src/vehicle_save_load.cpp
@@ -474,8 +474,8 @@ void load_single_veh(const char *filename) {
   log_vfprintf("Loading vehicle file %s.", filename);
   if (!(file.Open(filename, "r"))) {
     log_vfprintf("Warning: Unable to open vehfile %s for reading. Skipping.", filename);
+    return;
   }
-
 
   VTable data;
   data.Parse(&file);


### PR DESCRIPTION
Fixes resulting from discussion with FinalTwist (details start at: https://discord.com/channels/564618629467996170/564621949842751508/1418725432945021049 )

1. don't continue reading from socials file if there's no room remaining in the allocated array
2. add comment documenting socials file format to `boot_social_messages`
3. fix socials: scratch, swear, cheer
4. rename socials: crack, flip, roll, think to em_crack, em_flip, em_roll, em_think 
5. when attempting `load_single_veh` but the file doesn't exist, return immediately