### PR TITLE
Error messages for negative cpool, spool, spell force, or adept power level

### DIFF
--- a/src/act.obj.cpp
+++ b/src/act.obj.cpp
@@ -4697,6 +4697,11 @@ ACMD(do_activate)
 			}
 		}
 
+		if (desired_level <= 0) {
+			send_to_char("Power level must be greater than zero!", ch);
+			return;
+		}
+
 		// Find powers they have skill in first.
 		for (i = 0; i < ADEPT_NUMPOWER; i++)
 			if (GET_POWER_TOTAL(ch, i) && is_abbrev(name, adept_powers[i]))

--- a/src/act.other.cpp
+++ b/src/act.other.cpp
@@ -4561,6 +4561,11 @@ ACMD(do_cpool)
     dodge = 0;
   }
 
+  if (dodge < 0 || bod < 0 || off < 0) {
+    send_to_char("Combat pool values cannot be negative!", ch);
+    return;
+  }
+
   total -= ch->real_abils.defense_pool = GET_DODGE(ch) = MIN(dodge, total);
   total -= ch->real_abils.body_pool = GET_BODY_POOL(ch) = MIN(bod, total);
 
@@ -4625,6 +4630,11 @@ ACMD(do_spool)
   half_chop(arg, argument, buf, sizeof(buf));
   def = atoi(argument);
   reflect = atoi(buf);
+
+  if (cast < 0 || drain < 0 || def < 0 || reflect < 0) {
+    send_to_char("Spell pool values cannot be negative!", ch);
+    return;
+  }
 
   set_casting_pools(ch, cast, drain, def, reflect, TRUE);
 }

--- a/src/newmagic.cpp
+++ b/src/newmagic.cpp
@@ -3855,6 +3855,12 @@ ACMD(do_cast)
     send_to_char(ch, "You don't know '%s' at that high a force.\r\n", spell_name);
     return;
   }
+
+  if (force <= 0) {
+    send_to_char("Spell force must be greater than zero!", ch);
+    return;
+  }
+
   if (spells[spell->type].physical && IS_PROJECT(ch)) {
     send_to_char("You can't cast physical spells on the astral plane.\r\n", ch);
     return;


### PR DESCRIPTION
As title. This addresses the following bug reports:
https://discord.com/channels/564618629467996170/788953927269613608/1368635248988000288
https://discord.com/channels/564618629467996170/788953927269613608/1368634207575871559
https://discord.com/channels/564618629467996170/788953927269613608/1368633648320086056
https://discord.com/channels/564618629467996170/788953927269613608/1368630312086798377