### PR TITLE
reverse order of IS_NPC and falling tests in simple_move

### DIFF
--- a/src/act.movement.cpp
+++ b/src/act.movement.cpp
@@ -590,7 +590,7 @@ int do_simple_move(struct char_data *ch, int dir, int extra, struct char_data *v
   if (ROOM_FLAGGED(ch->in_room, ROOM_FALL) && !IS_ASTRAL(ch) && !IS_AFFECTED(ch, AFF_LEVITATE) && !(IS_SENATOR(ch) && PRF_FLAGGED(ch, PRF_NOHASSLE))) {
     bool character_died;
     // We break the return code paradigm here to avoid having the code check follower data for a dead NPC.
-    if (IS_NPC(ch) && (character_died = perform_fall(ch))) {
+    if ((character_died = perform_fall(ch)) && IS_NPC(ch)) {
       return 0;
     }
     return 1;

--- a/src/act.movement.cpp
+++ b/src/act.movement.cpp
@@ -590,7 +590,8 @@ int do_simple_move(struct char_data *ch, int dir, int extra, struct char_data *v
   if (ROOM_FLAGGED(ch->in_room, ROOM_FALL) && !IS_ASTRAL(ch) && !IS_AFFECTED(ch, AFF_LEVITATE) && !(IS_SENATOR(ch) && PRF_FLAGGED(ch, PRF_NOHASSLE))) {
     bool character_died;
     // We break the return code paradigm here to avoid having the code check follower data for a dead NPC.
-    if ((character_died = perform_fall(ch)) && IS_NPC(ch)) {
+    bool is_npc = IS_NPC(ch);
+    if ((character_died = perform_fall(ch)) && is_npc) {
       return 0;
     }
     return 1;


### PR DESCRIPTION
by checking IS_NPC first, if you're not a NPC, you'll never actually be made to do any kind of falling test

based on a convo with morbiusphyre on discord here: https://discord.com/channels/564618629467996170/580066110418845696/1418927641263738960 we concluded that falling was probably broken, I tried building the codebase to test it, seems it is, moving where perform_fall(ch) is called to not be dependent on IS_NPC(ch) being true first made my test dummies start to fall off things as I would expect/remember?

<details><summary>Climbing a fire escape currently:</summary>

```
>
l
Down Northeast 167th Street
   While it was at one point a proper road, recent renovations have left it a
bit narrower than it was previously, making the passage of vehicles a bit
problematic until they decided to put up some one way signs. Several renovated
buildings sporting new paint jobs rise up along each side of the street, their
fire escapes looming overhead and offering a glimpse of what the place used to
look like, since it appears they haven't gotten around to replacing or
scrubbing all of the rust off of them yet. 
Obvious exits:
North - At 80th Street and Northeast 167th Street
South - 79th Street and Northeast 167th Street
Up    - On the lower fire escape
Streetlights drive back the nighttime darkness.
You struggle to see through the heavy rain that sheets down from the sky.

>
u
On the lower fire escape
   The fire escapes are clearly quite old and haven't seen a good cleaning,
let alone a fresh coat of paint in decades. Understandably, this has left them
in poor shape as they attempt to stand up to the elements, leaving large
portions of their steel construction rusted and weakened, with some of the
steps and ladders threatening to give way and fall onto the streets below. 
Obvious exits:
Up    - On the fire escape
Down  - Down Northeast 167th Street

>
u
On the fire escape
   There's little in choices in the matter, it's either up or down at this
point. The windows of the building the fire escape is attached to have been
boarded up with thick planks of wooden and nailed fifty different ways. Some
of the windows appear to have debris pressed up against them from inside,
perhaps from a partial collapse of the interior, making it impossible to climb
inside from this end. 
Obvious exits:
Up    - At the top of the fire escape
Down  - On the lower fire escape
```
</details>
<details>
<summary>With IS_NPC and perform_fall() reversed:</summary>

```
<10P 10M> l
Down Northeast 167th Street
   While it was at one point a proper road, recent renovations have left it a
bit narrower than it was previously, making the passage of vehicles a bit
problematic until they decided to put up some one way signs. Several renovated
buildings sporting new paint jobs rise up along each side of the street, their
fire escapes looming overhead and offering a glimpse of what the place used to
look like, since it appears they haven't gotten around to replacing or
scrubbing all of the rust off of them yet. 
Obvious exits:
North - At 80th Street and Northeast 167th Street
South - 79th Street and Northeast 167th Street
Up    - On the lower fire escape
Streetlights drive back the nighttime darkness.
You struggle to see through the heavy rain that sheets down from the sky.

<10P 10M> u
On the lower fire escape
   The fire escapes are clearly quite old and haven't seen a good cleaning,
let alone a fresh coat of paint in decades. Understandably, this has left them
in poor shape as they attempt to stand up to the elements, leaving large
portions of their steel construction rusted and weakened, with some of the
steps and ladders threatening to give way and fall onto the streets below. 
Obvious exits:
Up    - On the fire escape
Down  - Down Northeast 167th Street
You grab on to the wall and keep yourself from falling!

<10P 10M> u
On the fire escape
   There's little in choices in the matter, it's either up or down at this
point. The windows of the building the fire escape is attached to have been
boarded up with thick planks of wooden and nailed fifty different ways. Some
of the windows appear to have debris pressed up against them from inside,
perhaps from a partial collapse of the interior, making it impossible to climb
inside from this end. 
Obvious exits:
Up    - At the top of the fire escape
Down  - On the lower fire escape
You grab on to the wall and keep yourself from falling!

<10P 10M> u
At the top of the fire escape
   The top of the fire escape leads onto the rooftop of the building it is
attached to, though that isn't to say it'll be a safe trip by any means due to
the poor shape the structure is in. The steps and ladders of the fire escape
are a little loose and most of it sways under the movement of those attempting
to climb up or down it. The street below is a good ways down, so it'd probably
be best to take your time and be careful should you decide to use it. 
Obvious exits:
West  - On a roof top
Down  - On the fire escape
You grab on to the wall and keep yourself from falling!
```

```
At the top of the elevator shaft
   Finally, at the top of the shaft.. Which would normally be a good thing, if
it weren't for the fact that the floor here is practically nonexistent. Aside
from a little rotten wooden planks sticking out haphazardly along the edges of
the shaft, there isn't much in the way of places to stand, so it would be best
for all involved to move carefully. An old service door stands off to the
western side of what's left of the room, while a mangled pair of outer
elevator doors stands permanently ajar along the east wall, which by the flow
of air coming into the room seems to be outside the building. 
Obvious exits:
East  - On a roof top
West  - A closed door
Down  - A dark elevator shaft
You grab on to the wall and keep yourself from falling!

<10P 10M> d
It is pitch black...
You can't even begin to figure out such a complex task...

Your fingers slip, sending your stomach rising into your throat as you plummet towards the floor!

Inside a nonfunctional elevator
   It doesn't look like anyone has bothered to clean in here for the last few
decades, the dust and cobwebs having had plenty of time to settle and take up
residence, along with a few spiders to go along with them. The buttons lining
the panel are have their plastic labels cracked or missing, and it appears
that there is no electricity running the elevator itself. The floor shows a
few cracks in its facade and is nearly rusted through in some spot, so careful
where you put your feet. A service panel cut in the ceiling of the elevator
appears to have its security latch broken, so climbing up into the shaft above
may be possible. 
Obvious exits:
West  - A closed elevator
Up    - A closed hatch
You hit the floor with bruising force.
```
</details>
