### PR TITLE
Fix wakyambi height and weight, and give them reach

### DIFF
--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -629,7 +629,8 @@ void affect_total(struct char_data * ch)
 
   // Set reach, depending on race. Stripped out the 'you only get it at X height' thing since it's not canon and a newbie trap.
   if ((GET_RACE(ch) == RACE_TROLL || GET_RACE(ch) == RACE_CYCLOPS || GET_RACE(ch) == RACE_FOMORI || GET_RACE(ch) == RACE_GIANT ||
-       GET_RACE(ch) == RACE_MINOTAUR || GET_RACE(ch) == RACE_GHOUL_TROLL || GET_RACE(ch) == RACE_DRAKE_TROLL) /* && GET_HEIGHT(ch) > 260 */)
+       GET_RACE(ch) == RACE_MINOTAUR || GET_RACE(ch) == RACE_GHOUL_TROLL || GET_RACE(ch) == RACE_DRAKE_TROLL || GET_RACE(ch) == RACE_WAKYAMBI)
+      /* && GET_HEIGHT(ch) > 260 */)
     GET_REACH(ch) = 1;
   else
     GET_REACH(ch) = 0;

--- a/src/limits.cpp
+++ b/src/limits.cpp
@@ -1802,14 +1802,14 @@ float gen_size(int race, bool height, int size, int pronouns)
     case RACE_WAKYAMBI:
       if (pronouns == PRONOUNS_MASCULINE) {
         if (height)
-          return number(180, 205) * mod;
+          return number(270, 295) * mod;
         else
-          return number(70, 82) * mod;
+          return number(100, 115) * mod;
       } else {
         if (height)
-          return number(175, 195) * mod;
+          return number(255, 280) * mod;
         else
-          return number(60, 75) * mod;
+          return number(90, 105) * mod;
       }
       break;
     case RACE_OGRE:


### PR DESCRIPTION
Previously, the code used elf heights and weights for wakyambi.

Per SR Companion pg 41, they "are noticeably thinner and taller than other elves, many growing as tall as trolls and a rare few even taller." This PR fixes these values so that they match Shadowrun Supplemental 13 pg 28, Table 1. SR3 Standard Heights & Weights.

In addition, SR4 and SR5 give wakyambi a reach bonus through their "elongated limbs quality", matching trolls. While SR3 doesn't provide the bonus, their description, as well as chargen cost vs racial bonuses (priority B for +2 charisma, +1 willpower, and low light vision) lead me to believe they should have it (and so I've included it in this PR). 