### PR TITLE
add kinesics emotes for social adepts

### DIFF
--- a/src/awake.hpp
+++ b/src/awake.hpp
@@ -2227,6 +2227,7 @@ enum {
 #define SCMD_EMOTE      1
 #define SCMD_VEMOTE     2
 #define SCMD_AECHO      3
+#define SCMD_KEMOTE     4
 
 /* do_gen_door */
 #define SCMD_OPEN       0

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -778,6 +778,8 @@ struct command_info cmd_info[] =
     { "jobs"       , POS_DEAD    , do_recap    , 0, 0, BLOCKS_IDLE_REWARD },
     { "junk"       , POS_RESTING , do_drop     , 0, SCMD_JUNK, BLOCKS_IDLE_REWARD },
 
+    { "kecho"      , POS_LYING   , do_new_echo , 0, SCMD_KEMOTE, BLOCKS_IDLE_REWARD },
+    { "kemote"     , POS_LYING   , do_new_echo , 0, SCMD_KEMOTE, BLOCKS_IDLE_REWARD },
     // { "kil"        , POS_FIGHTING, do_kil      , 0, 0, BLOCKS_IDLE_REWARD },
     { "kill"       , POS_FIGHTING, do_kill     , 0, SCMD_KILL, BLOCKS_IDLE_REWARD },
     { "keep"       , POS_LYING   , do_keep     , 0, 0, BLOCKS_IDLE_REWARD },

--- a/src/newecho.cpp
+++ b/src/newecho.cpp
@@ -691,6 +691,15 @@ void send_echo_to_char(struct char_data *actor, struct char_data *viewer, const 
   // Add a newline.
   strlcat(mutable_echo_string, "\r\n", sizeof(mutable_echo_string));
 
+  // Prepend a kinesics to kemotes
+  if (subcmd == SCMD_KEMOTE) {
+    if (echo_string[0] == '\'' && echo_string[1] == 's') {
+      snprintf(mutable_echo_string, sizeof(mutable_echo_string), "(Kinesics) @self%s", echo_string);
+    } else {
+      snprintf(mutable_echo_string, sizeof(mutable_echo_string), "(Kinesics) @self %s", echo_string);
+    }
+  }
+
   // Finally(!), send it to the viewer.
   send_to_char(viewer, capitalize(mutable_echo_string));
 
@@ -719,9 +728,10 @@ ACMD(do_new_echo) {
 
   // Check for adepts using thier kinesics powers
   if (subcmd == SCMD_KEMOTE) {
-    FAILURE_CASE(!(GET_TRADITION(ch) == TRAD_ADEPT), "You cannot use kinesics emotes unless you are an adept.\r\n");
-    FAILURE_CASE(GET_POWER(ch, ADEPT_KINESICS) == 0, "You cannot use kinesics emotes without activating kinesics.\r\n");
-    FAILURE_CASE(ch->desc && strchr(argument, '"') != NULL, "You cannot use speech in a kinesics emote.\r\n");
+    FAILURE_CASE(!(GET_TRADITION(ch) == TRAD_ADEPT), "You cannot use kinesics emotes unless you are an adept.");
+    FAILURE_CASE(GET_POWER(ch, ADEPT_KINESICS) == 0, "You cannot use kinesics emotes without activating kinesics.");
+    FAILURE_CASE(ch->desc && strchr(argument, '"') != NULL, "You cannot use speech in a kinesics emote.");
+    FAILURE_CASE(ch->desc && strlen(argument) > 80, "Kinesics emotes are limited to 80 characters or less.");
   }
 
   // Reject hitchers. They have no body and would break things.
@@ -932,29 +942,29 @@ ACMD(do_new_echo) {
     {
       send_echo_to_char(ch, viewer, (const char *) emote_buf, must_echo_with_name, subcmd, FALSE);
     }
+    // Send it to anyone who's rigging a vehicle here.
+    for (struct veh_data *veh = in_room ? in_room->vehicles : in_veh->carriedvehs;
+        veh;
+        veh = veh->next_veh)
+    {
+      if (veh->rigger) {
+        send_echo_to_char(ch, veh->rigger, (const char *) emote_buf, must_echo_with_name, subcmd, TRUE);
+      }
+
+      for (struct char_data *viewer = veh->people; viewer; viewer = viewer->next_in_veh) {
+        send_echo_to_char(ch, viewer, (const char *) emote_buf, must_echo_with_name, subcmd, FALSE);
+      }
+    }
   } else {
     // Kinesics emotes are only sent to adepts with kinesics activated
     for (struct char_data *viewer = in_room ? in_room->people : in_veh->people;
          viewer;
          viewer = in_room ? viewer->next_in_room : viewer->next_in_veh)
     {
-      if (GET_TRADITION(viewer) == TRAD_ADEPT && GET_POWER(viewer, ADEPT_KINESICS) > 0) {
+      // Staff can always see these, non-adept questors can see them but only if the adept has the hired flag
+      if ((GET_TRADITION(viewer) == TRAD_ADEPT && GET_POWER(viewer, ADEPT_KINESICS) || access_level(viewer, LVL_BUILDER) || (PRF_FLAGGED(ch, PRF_HIRED) && PRF_FLAGGED(viewer, PRF_QUESTOR)))) {
         send_echo_to_char(ch, viewer, (const char *) emote_buf, TRUE, subcmd, FALSE);
       }
-    }
-  }
-
-  // Send it to anyone who's rigging a vehicle here.
-  for (struct veh_data *veh = in_room ? in_room->vehicles : in_veh->carriedvehs;
-       veh;
-       veh = veh->next_veh)
-  {
-    if (veh->rigger) {
-      send_echo_to_char(ch, veh->rigger, (const char *) emote_buf, must_echo_with_name, subcmd, TRUE);
-    }
-
-    for (struct char_data *viewer = veh->people; viewer; viewer = viewer->next_in_veh) {
-      send_echo_to_char(ch, viewer, (const char *) emote_buf, must_echo_with_name, subcmd, FALSE);
     }
   }
 

--- a/src/newecho.cpp
+++ b/src/newecho.cpp
@@ -925,14 +925,19 @@ ACMD(do_new_echo) {
   ch->char_specials.last_social_action = 0;
 
   // Iterate over the viewers in the room or vehicle.
-  for (struct char_data *viewer = in_room ? in_room->people : in_veh->people;
-       viewer;
-       viewer = in_room ? viewer->next_in_room : viewer->next_in_veh)
-  {
-    if (subcmd != SCMD_KEMOTE) {
+  if (subcmd != SCMD_KEMOTE) {
+    for (struct char_data *viewer = in_room ? in_room->people : in_veh->people;
+         viewer;
+         viewer = in_room ? viewer->next_in_room : viewer->next_in_veh)
+    {
       send_echo_to_char(ch, viewer, (const char *) emote_buf, must_echo_with_name, subcmd, FALSE);
-    } else {
-      // Kinesics emotes are only sent to adepts with active kinesics
+    }
+  } else {
+    // Kinesics emotes are only sent to adepts with kinesics activated
+    for (struct char_data *viewer = in_room ? in_room->people : in_veh->people;
+         viewer;
+         viewer = in_room ? viewer->next_in_room : viewer->next_in_veh)
+    {
       if (GET_TRADITION(viewer) == TRAD_ADEPT && GET_POWER(viewer, ADEPT_KINESICS) > 0) {
         send_echo_to_char(ch, viewer, (const char *) emote_buf, TRUE, subcmd, FALSE);
       }

--- a/src/newecho.cpp
+++ b/src/newecho.cpp
@@ -961,8 +961,9 @@ ACMD(do_new_echo) {
          viewer;
          viewer = in_room ? viewer->next_in_room : viewer->next_in_veh)
     {
-      // Staff can always see these, non-adept questors can see them but only if the adept has the hired flag
-      if ((GET_TRADITION(viewer) == TRAD_ADEPT && GET_POWER(viewer, ADEPT_KINESICS) || access_level(viewer, LVL_BUILDER) || (PRF_FLAGGED(ch, PRF_HIRED) && PRF_FLAGGED(viewer, PRF_QUESTOR)))) {
+      // Staff can always see these, non-adept questors can see them in the NERPcorpolis
+      if ((GET_TRADITION(viewer) == TRAD_ADEPT && GET_POWER(viewer, ADEPT_KINESICS)) || access_level(viewer, LVL_BUILDER) ||
+          (VNUM_IS_NERPCORPOLIS(GET_ROOM_VNUM(ch->in_room) && PRF_FLAGGED(viewer, PRF_QUESTOR)))) {
         send_echo_to_char(ch, viewer, (const char *) emote_buf, TRUE, subcmd, FALSE);
       }
     }

--- a/src/newecho.cpp
+++ b/src/newecho.cpp
@@ -717,6 +717,13 @@ ACMD(do_new_echo) {
     in_veh = veh->in_veh;
   }
 
+  // Check for adepts using thier kinesics powers
+  if (subcmd == SCMD_KEMOTE) {
+    FAILURE_CASE(!(GET_TRADITION(ch) == TRAD_ADEPT), "You cannot use kinesics emotes unless you are an adept.\r\n");
+    FAILURE_CASE(GET_POWER(ch, ADEPT_KINESICS) == 0, "You cannot use kinesics emotes without activating kinesics.\r\n");
+    FAILURE_CASE(ch->desc && strchr(argument, '"') != NULL, "You cannot use speech in a kinesics emote.\r\n");
+  }
+
   // Reject hitchers. They have no body and would break things.
   FAILURE_CASE(PLR_FLAGGED(ch, PLR_MATRIX) && !ch->persona, "You can't do that while hitching.\r\n");
 
@@ -922,7 +929,14 @@ ACMD(do_new_echo) {
        viewer;
        viewer = in_room ? viewer->next_in_room : viewer->next_in_veh)
   {
-    send_echo_to_char(ch, viewer, (const char *) emote_buf, must_echo_with_name, subcmd, FALSE);
+    if (subcmd != SCMD_KEMOTE) {
+      send_echo_to_char(ch, viewer, (const char *) emote_buf, must_echo_with_name, subcmd, FALSE);
+    } else {
+      // Kinesics emotes are only sent to adepts with active kinesics
+      if (GET_TRADITION(viewer) == TRAD_ADEPT && GET_POWER(viewer, ADEPT_KINESICS) > 0) {
+        send_echo_to_char(ch, viewer, (const char *) emote_buf, TRUE, subcmd, FALSE);
+      }
+    }
   }
 
   // Send it to anyone who's rigging a vehicle here.


### PR DESCRIPTION
needs a helpfile update, I don't know how those are done...

* two new_echo sub commands: KEMOTE and KECHO (they're identical, just a different way of typing it)
* only works if you are an adept with your kinesics currently activated, otherwise, it just tells you why you can't do it
* speech in quotation marks is not permitted and must_echo_with_name is enforced as it's all body language in TT
* only adepts with kinesics currently active will see it