### PR TITLE
Proof of Concept: Scope hinting via prefixes

### DIFF
--- a/src/act.movement.cpp
+++ b/src/act.movement.cpp
@@ -1512,8 +1512,11 @@ ACMD(do_gen_door)
   two_arguments(argument, type, dir);
   RIG_VEH(ch, veh);
 
+  // Scope hint: "exit." prefix forces door/exit resolution, skipping object and vehicle searches.
+  bool force_exit_search = strip_exit_scope_prefix(type);
+
   // 'unlock 1' etc for subscribed vehs
-  if (*type && is_number(type)) {
+  if (!force_exit_search && *type && is_number(type)) {
     num = atoi(type);
     bool has_deck = FALSE;
     for (obj = ch->carrying; obj; obj = obj->next_content)
@@ -1533,7 +1536,7 @@ ACMD(do_gen_door)
   }
 
   // If it's a cardinal direction, make a note to NOT attempt to match an object or vehicle
-  bool cardinal = false; 
+  bool cardinal = false;
   for (int dir_idx = NORTH; dir_idx <= DOWN; dir_idx++) {
     if (!str_cmp(type, exitdirs[dir_idx]) || !str_cmp(type, fulldirs[dir_idx])) {
       cardinal = true;
@@ -1542,8 +1545,8 @@ ACMD(do_gen_door)
   }
 
   // Check for an object or vehicle nearby that matches the keyword.
-  // Checking for a cardinal direction first stops objects intercepting doors
-  if (cardinal || (!generic_find(type, FIND_OBJ_EQUIP | FIND_OBJ_INV | FIND_OBJ_ROOM, ch, &victim, &obj)
+  // Cardinal directions and "exit." scope hint both skip object/vehicle searches and go straight to find_door.
+  if (force_exit_search || cardinal || (!generic_find(type, FIND_OBJ_EQUIP | FIND_OBJ_INV | FIND_OBJ_ROOM, ch, &victim, &obj)
       && !veh
       && !(veh = get_veh_list(type, ch->in_veh ? ch->in_veh->carriedvehs : ch->in_room->vehicles, ch)))) {
     if ((door = find_door(ch, type, dir, cmd_door[subcmd])) == -1) {

--- a/src/act.offensive.cpp
+++ b/src/act.offensive.cpp
@@ -171,8 +171,13 @@ bool perform_hit(struct char_data *ch, char *argument, const char *cmdname)
     return TRUE;
   }
 
-  vict = get_char_room_vis(ch, arg);
-  veh = get_veh_list(arg, ch->in_room->vehicles, ch);
+  // Scope hint: "exit." prefix forces door resolution, skipping character and vehicle searches.
+  bool force_exit_search = strip_exit_scope_prefix(arg);
+
+  if (!force_exit_search) {
+    vict = get_char_room_vis(ch, arg);
+    veh = get_veh_list(arg, ch->in_room->vehicles, ch);
+  }
 
   if (!vict && !veh) {
     if ((dir = messageless_find_door(ch, arg, buf2, cmdname)) < 0)
@@ -762,7 +767,14 @@ ACMD(do_kick)
     return;
   }
 
+  // Scope hint: "exit." prefix forces door resolution, skipping character search.
+  bool force_exit_search = strip_exit_scope_prefix(arg);
+
   if ((dir = messageless_find_door(ch, arg, buf2, "do_kick")) < 0) {
+    if (force_exit_search) {
+      send_to_char("There doesn't seem to be an exit by that name here.\r\n", ch);
+      return;
+    }
     if (!(vict = get_char_room_vis(ch, arg)))
       send_to_char("They aren't here.\r\n", ch);
     else if (vict == ch) {

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -3611,12 +3611,32 @@ int const_generic_find(const char *name, int bitvector, struct char_data * ch,
                  struct char_data ** tar_ch, struct obj_data ** tar_obj)
 {
   int i;
+  char scoped_name[MAX_INPUT_LENGTH];
 
   *tar_ch = NULL;
   *tar_obj = NULL;
   struct veh_data *rigged_veh = (ch)->char_specials.rigging;
 
   if (!*name)
+    return (0);
+
+  // Scope hint prefixes: restrict which scopes generic_find searches.
+  // "room.X" searches only room contents, "inv.X" only inventory, "worn.X" only equipment.
+  if (!strncmp(name, "room.", 5)) {
+    strlcpy(scoped_name, name + 5, sizeof(scoped_name));
+    name = scoped_name;
+    bitvector &= (FIND_OBJ_ROOM | FIND_OBJ_VEH_ROOM);
+  } else if (!strncmp(name, "inv.", 4)) {
+    strlcpy(scoped_name, name + 4, sizeof(scoped_name));
+    name = scoped_name;
+    bitvector &= FIND_OBJ_INV;
+  } else if (!strncmp(name, "worn.", 5)) {
+    strlcpy(scoped_name, name + 5, sizeof(scoped_name));
+    name = scoped_name;
+    bitvector &= FIND_OBJ_EQUIP;
+  }
+
+  if (!*name || !bitvector)
     return (0);
 
   /* Technically, this is intended to find characters outside of vehicles... but this is broken.
@@ -3726,6 +3746,16 @@ int const_generic_find(const char *name, int bitvector, struct char_data * ch,
     }
   }
   return (0);
+}
+
+/* Strips "exit." scope prefix from arg if present. Returns TRUE if stripped. */
+bool strip_exit_scope_prefix(char *arg)
+{
+  if (!strncmp(arg, "exit.", 5)) {
+    memmove(arg, arg + 5, strlen(arg + 5) + 1);
+    return true;
+  }
+  return false;
 }
 
 /* a function to scan for "all" or "all.x" */

--- a/src/handler.hpp
+++ b/src/handler.hpp
@@ -112,6 +112,8 @@ int     find_all_dots(char *arg, size_t arg_size);
 #define FIND_ALL        1
 #define FIND_ALLDOT     2
 
+bool    strip_exit_scope_prefix(char *arg);
+
 
 /* Generic Find */
 


### PR DESCRIPTION
Currently `const_generic_find` is used for a number operations, and numeric prefixes allow differentiating items on multiple keyword matches.  However, these numeric indices are calculated per-scope via `get_number`. This leads to issues if someone is for example 2 items that match a keyword (or the same item like a ring) and is trying to refer to another match/copy in their inventory: `1.keyword` ends up matching the first instance in their equipment, while `3.keyword` fails because there is no 3rd item in equipment, and the inventory scope is indexing that match at `1.keyword`. While this is mostly an inconvenience, there are cases, such as sustaining foci supporting a ritual-cast spell where there is an associated cost to removing/swapping items.

Proposing  adding scope hinting prefixes: `worn.`, `inv.`, `room.` which narrow the scope bitmap ans therefore search space to the relevant scope, if it is valid for that command. The above scenario can be resolved by using `inv.keyword` or `inv.1.keyword` to match the item in inventory. 

Additionally, experimenting with adding a logical scope: `exit.` to force exist/door interactions in a similar fashion, allowing the use of keywords beyond the cardinal directions. This might need some additional input/be expanded to other commands if it is thought to be useful, hoping for some feedback on this.