### PR TITLE
banishing a spirit counts as a kill for autoruns

### DIFF
--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -6256,6 +6256,9 @@ void perform_violence(void)
         act("$N is banished to the metaplanes as $n drains the last of its magical force.", FALSE, mage, 0, spirit, TO_ROOM);
         stop_fighting(spirit);
         stop_fighting(mage);
+        if (COULD_BE_ON_QUEST(mage)) {
+          check_quest_kill(mage, spirit);
+        } 
         end_spirit_existance(spirit, TRUE);
         AFF_FLAGS(mage).RemoveBit(AFF_BANISH);
       } else if ((GET_REAL_MAG(mage) / 100) - GET_TEMP_MAGIC_LOSS(mage) < 1) {


### PR DESCRIPTION
```
<10P 10M> 

You lock minds with Oeezheeth and succeed in weakening it!
You drain Oeezheeth off the last of its magical force, banishing it to the metaplanes!
You blink and suddenly Oeezheeth, surrounded by a spell aura appears!

<10P 10M> 
recap
...

Objectives:
 - Kill Oeezheeth (done)
```