### PR TITLE
Fix cpool allocation behavior

### DIFF
--- a/src/act.other.cpp
+++ b/src/act.other.cpp
@@ -4598,7 +4598,7 @@ ACMD(do_cpool)
   extern int get_skill_num_in_use_for_weapons(struct char_data *ch);
   extern int get_skill_dice_in_use_for_weapons(struct char_data *ch);
 
-  int dodge = 0, bod = 0, off = 0, total = GET_COMBAT_POOL(ch);
+  int dodge = 0, bod = 0, off = 0;
 
   if (!*argument) {
     do_pool(ch, argument, 0, 0);
@@ -4622,38 +4622,49 @@ ACMD(do_cpool)
     dodge = 0;
   }
 
+  // Dodge also doesn't apply when prone, but prone combat code already adds dodge dice to soak
+
   if (dodge < 0 || bod < 0 || off < 0) {
     send_to_char("Combat pool values cannot be negative!\r\n", ch);
     return;
   }
 
-  total -= ch->real_abils.defense_pool = GET_DODGE(ch) = MIN(dodge, total);
-  total -= ch->real_abils.body_pool = GET_BODY_POOL(ch) = MIN(bod, total);
+  // Allow storing overallocated values to support weapon switching and dynamic cpool totals
+  ch->real_abils.defense_pool = dodge;
+  ch->real_abils.body_pool = bod;
+  ch->real_abils.offense_pool = off;
 
   int skill_num = get_skill_num_in_use_for_weapons(ch);
-  int skill_dice = get_skill_dice_in_use_for_weapons(ch);
+  int dice_max = get_skill_dice_in_use_for_weapons(ch);
+  int remainder = GET_COMBAT_POOL(ch);
 
   if (GET_CHIPJACKED_SKILL(ch, skill_num)) {
-    skill_dice = 0;
+    dice_max = 0;
     if (off > 0) {
       send_to_char("You're using an activesoft, so you can't allocate any dice to your offense pool.\r\n", ch);
       off = 0;
     }
   }
 
-  if (off > skill_dice) {
-    send_to_char(ch, "You're not skilled enough with %s, so your offense pool is capped at %d.\r\n", skills[skill_num].name, skill_dice);
-    off = skill_dice;
-  }
+  // Now set allocation for current cpool/weapon
+  remainder -= GET_DODGE(ch) = MIN(dodge, remainder);
+  remainder -= GET_BODY_POOL(ch) = MIN(bod, remainder);
 
-  total -= ch->real_abils.offense_pool = GET_OFFENSE(ch) = MIN(total, off);
-  if (total > 0) {
-    if (IS_ASTRAL(ch)) {
-      GET_DODGE(ch) += total;
-      send_to_char(ch, "Putting the %d remaining dice in your ranged-attack dodging pool.\r\n", total);
+  if (off > dice_max) {
+    send_to_char(ch, "You're not skilled enough with %s, so your offense pool is capped at %d.\r\n", skills[skill_num].name, dice_max);
+    off = dice_max;
+  }
+  remainder -= GET_OFFENSE(ch) = MIN(off, remainder);
+
+  // Any remaining dice are reallocated based on existing dodge/soak assignments
+  // Where dodge == soak, extra dice default to soak
+  if (remainder) {
+    if (GET_DODGE(ch) > GET_BODY_POOL(ch)) {
+      GET_DODGE(ch) += remainder;
+      send_to_char(ch, "Putting the %d remaining dice in your dodge pool.\r\n", remainder);
     } else {
-      GET_BODY_POOL(ch) += total;
-      send_to_char(ch, "Putting the %d remaining dice in your body pool.\r\n", total);
+      GET_BODY_POOL(ch) += remainder;
+      send_to_char(ch, "Putting the %d remaining dice in your body pool.\r\n", remainder);
     }
   }
 

--- a/src/act.other.cpp
+++ b/src/act.other.cpp
@@ -82,6 +82,7 @@ extern void check_quest_destroy(struct char_data *ch, struct obj_data *obj);
 extern int get_docwagon_faux_id(struct char_data *ch);
 extern unsigned int get_johnson_overall_max_rep(struct char_data *johnson);
 extern unsigned int get_johnson_overall_min_rep(struct char_data *johnson);
+extern void set_combat_pools(struct char_data *ch, int dodge, int soak, int offense, bool message);
 
 extern bool restring_with_args(struct char_data *ch, char *argument, bool using_sysp);
 
@@ -4595,10 +4596,7 @@ extern ACMD_DECLARE(do_pool);
 
 ACMD(do_cpool)
 {
-  extern int get_skill_num_in_use_for_weapons(struct char_data *ch);
-  extern int get_skill_dice_in_use_for_weapons(struct char_data *ch);
-
-  int dodge = 0, bod = 0, off = 0;
+  int dodge = 0, soak = 0, offense = 0;
 
   if (!*argument) {
     do_pool(ch, argument, 0, 0);
@@ -4613,63 +4611,20 @@ ACMD(do_cpool)
   }
 
   half_chop(buf, argument, arg, sizeof(arg));
-  bod = atoi(argument);
-  off = atoi(arg);
+  soak = atoi(argument);
+  offense = atoi(arg);
 
-  if (dodge > 0 && IS_ASTRAL(ch)) {
-    send_to_char("Astral characters have no need to dodge anything, so your dice have been re-allocated to Body.\r\n", ch);
-    bod += dodge;
-    dodge = 0;
-  }
-
-  // Dodge also doesn't apply when prone, but prone combat code already adds dodge dice to soak
-
-  if (dodge < 0 || bod < 0 || off < 0) {
+  if (dodge < 0 || soak < 0 || offense < 0) {
     send_to_char("Combat pool values cannot be negative!\r\n", ch);
     return;
   }
 
-  // Allow storing overallocated values to support weapon switching and dynamic cpool totals
+  // Store uncapped values to support dynamic scenarios (weap swaps, temp buffs)
   ch->real_abils.defense_pool = dodge;
-  ch->real_abils.body_pool = bod;
-  ch->real_abils.offense_pool = off;
+  ch->real_abils.body_pool = soak;
+  ch->real_abils.offense_pool = offense;
 
-  int skill_num = get_skill_num_in_use_for_weapons(ch);
-  int dice_max = get_skill_dice_in_use_for_weapons(ch);
-  int remainder = GET_COMBAT_POOL(ch);
-
-  if (GET_CHIPJACKED_SKILL(ch, skill_num)) {
-    dice_max = 0;
-    if (off > 0) {
-      send_to_char("You're using an activesoft, so you can't allocate any dice to your offense pool.\r\n", ch);
-      off = 0;
-    }
-  }
-
-  // Now set allocation for current cpool/weapon
-  remainder -= GET_DODGE(ch) = MIN(dodge, remainder);
-  remainder -= GET_BODY_POOL(ch) = MIN(bod, remainder);
-
-  if (off > dice_max) {
-    send_to_char(ch, "You're not skilled enough with %s, so your offense pool is capped at %d.\r\n", skills[skill_num].name, dice_max);
-    off = dice_max;
-  }
-  remainder -= GET_OFFENSE(ch) = MIN(off, remainder);
-
-  // Any remaining dice are reallocated based on existing dodge/soak assignments
-  // Where dodge == soak, extra dice default to soak
-  if (remainder) {
-    if (GET_DODGE(ch) > GET_BODY_POOL(ch)) {
-      GET_DODGE(ch) += remainder;
-      send_to_char(ch, "Putting the %d remaining dice in your dodge pool.\r\n", remainder);
-    } else {
-      GET_BODY_POOL(ch) += remainder;
-      send_to_char(ch, "Putting the %d remaining dice in your body pool.\r\n", remainder);
-    }
-  }
-
-  send_to_char(ch, "Pools set as: Ranged Dodge: %d, Damage Soak: %d, Offense: %d\r\n", GET_DODGE(ch), GET_BODY_POOL(ch), GET_OFFENSE(ch));
-  SendGMCPCharPools(ch);
+  set_combat_pools(ch, dodge, soak, offense, TRUE);
 
 #ifdef APPLY_DELAY_ON_POOL_CHANGE_IN_COMBAT
   // If they're in combat, add a delay to lessen the pool-shoot-pool cheese strat.
@@ -4695,8 +4650,6 @@ ACMD(do_spool)
     send_to_char("Syntax: ^WSPOOL <casting> <drain> <defence>^n, where each value is a number. Ex: SPOOL 1 5 4\r\n", ch);
     return;
   }
-
-  FAILURE_CASE_PRINTF(cast > GET_SKILL(ch, SKILL_SORCERY), "You can't allocate more than %d dice to your casting pool (limited by Sorcery skill).", GET_SKILL(ch, SKILL_SORCERY));
 
   half_chop(buf, argument, arg, sizeof(arg));
   drain = atoi(argument);

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -5951,6 +5951,83 @@ void roll_individual_initiative(struct char_data *ch)
   }
 }
 
+
+void set_combat_pools(struct char_data *ch, int dodge, int soak, int offense, bool message) {
+  extern int get_skill_num_in_use_for_weapons(struct char_data *ch);
+  extern int get_skill_dice_in_use_for_weapons(struct char_data *ch);
+
+  if (!ch) {
+    mudlog("SYSERR: Received NULL ch to set_casting_pools!", ch, LOG_SYSLOG, TRUE);
+    return;
+  }
+
+  if (dodge < 0 || soak < 0 || offense < 0) {
+    mudlog_vfprintf(ch, LOG_SYSLOG, "SYSERR: Received invalid val to set_combat_pools(%s, %d, %d, %d)!", GET_CHAR_NAME(ch), dodge, soak, offense);
+    return;
+  }
+
+  int skill_num = get_skill_num_in_use_for_weapons(ch);
+  int dice_max = get_skill_dice_in_use_for_weapons(ch);
+  int remainder = GET_COMBAT_POOL(ch);
+
+  if (GET_CHIPJACKED_SKILL(ch, skill_num) && offense > 0) {
+    if (message) {
+      send_to_char("You're using an activesoft, so you can't allocate any dice to your offense pool.\r\n", ch);
+    }
+    offense = 0;
+  }
+
+  if (offense > dice_max) {
+    if (message) {
+      send_to_char(ch, "You're not skilled enough with %s, so your offense pool is capped at %d.\r\n", skills[skill_num].name, dice_max);
+    }
+    offense = dice_max;
+  }
+
+  // There's nothing to dodge on the astral plane.
+  if (IS_ASTRAL(ch) && dodge > 0) {
+    if (message) {
+      send_to_char("Astral characters have no need to dodge anything, so your dice have been re-allocated to your soak pool.\r\n", ch);
+    }
+    dodge = 0;
+  }
+
+  // Dodge also doesn't apply when prone, but prone combat code already moves dodge to soak
+  // if (AFF_FLAGGED(ch, AFF_PRONE) && dodge > 0) {
+  //   if (message) {
+  //     send_to_char("Prone characters can't dodge anything, so your dice have been re-allocated to your soak pool.\r\n", ch);
+  //   }
+  //   dodge = 0;
+  // }
+
+  remainder -= GET_DODGE(ch) = MIN(dodge, remainder);
+  remainder -= GET_BODY_POOL(ch) = MIN(soak, remainder);
+  remainder -= GET_OFFENSE(ch) = MIN(offense, remainder);
+
+  // Any remaining dice are reallocated to dodge/soak based on existing dodge/soak assignments
+  // Where dodge == soak, extra dice defaults to soak
+  if (remainder) {
+    if (GET_DODGE(ch) > GET_BODY_POOL(ch)) {
+      if (message) {
+        send_to_char(ch, "Putting the %d remaining dice in your dodge pool.\r\n", remainder);
+      }
+      GET_DODGE(ch) += remainder;
+    } else {
+      if (message) {
+        send_to_char(ch, "Putting the %d remaining dice in your soak pool.\r\n", remainder);
+      }
+      GET_BODY_POOL(ch) += remainder;
+    }
+  }
+
+  if (message) {
+    send_to_char(ch, "You entered: Ranged Dodge: %d, Damage Soak: %d, Offense: %d\r\n", dodge, soak, offense);
+    send_to_char(ch, "Pools set to: Ranged Dodge: %d, Damage Soak: %d, Offense: %d\r\n", GET_DODGE(ch), GET_BODY_POOL(ch), GET_OFFENSE(ch));
+    SendGMCPCharPools(ch);
+  }
+}
+
+
 void decide_combat_pool(void)
 {
   PERF_PROF_SCOPE(pr_, __func__);

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -1040,39 +1040,38 @@ void affect_total(struct char_data * ch)
     }
   }
 
-  int skill_used = get_skill_num_in_use_for_weapons(ch);
+  int skill_num = get_skill_num_in_use_for_weapons(ch);
   int dice_max = get_skill_dice_in_use_for_weapons(ch);
+  int remainder = GET_COMBAT_POOL(ch);
 
-  if (GET_CHIPJACKED_SKILL(ch, skill_used)) {
+  if (GET_CHIPJACKED_SKILL(ch, skill_num)) {
     dice_max = 0;
   }
 
   // There's nothing to dodge on the astral plane.
+  // Dodge also doesn't apply when prone, but prone combat code already moves dodge to soak
   if (IS_ASTRAL(ch))
     GET_DODGE(ch) = 0;
   else {
-    GET_DODGE(ch) = MIN(GET_DODGE(ch), GET_COMBAT_POOL(ch));
-
-    if (ch_is_npc && AFF_FLAGGED(ch, AFF_PRONE)) {
-      GET_BODY_POOL(ch) += GET_DODGE(ch) / 2;
-      GET_DODGE(ch) = 0;
-      // The remaining points will be assigned to offense in the next stanza.
-    }
+    remainder -= GET_DODGE(ch) = MIN(GET_DODGE(ch), remainder);
   }
 
-  GET_BODY_POOL(ch) = MIN(GET_BODY_POOL(ch), GET_COMBAT_POOL(ch) - GET_DODGE(ch));
-  GET_OFFENSE(ch) = GET_COMBAT_POOL(ch) - GET_DODGE(ch) - GET_BODY_POOL(ch);
-  if (GET_OFFENSE(ch) > dice_max) {
-    if (ch_is_npc && !IS_ASTRAL(ch) && AFF_FLAGGED(ch, AFF_PRONE)) {
-      GET_BODY_POOL(ch) += GET_OFFENSE(ch) - dice_max;
+  remainder -= GET_BODY_POOL(ch) = MIN(GET_BODY_POOL(ch), remainder);
+  remainder -= GET_OFFENSE(ch) = MIN(MIN(GET_OFFENSE(ch), dice_max), remainder);
+
+  // Any offense dice above cap are reallocated based on existing dodge/soak assignments
+  // Where dodge == soak, extra dice default to soak
+  if (remainder) {
+    if (GET_DODGE(ch) > GET_BODY_POOL(ch)) {
+      GET_DODGE(ch) += remainder;
     } else {
-      GET_DODGE(ch) += GET_OFFENSE(ch) - dice_max;
+      GET_BODY_POOL(ch) += remainder;
     }
-    GET_OFFENSE(ch) = dice_max;
   }
 
   // NPCs specialize their defenses: unless they've got crazy dodge dice, they'll want to just soak.
   // AKA, 'your average wage slave is not going to try to do the Matrix bullet dodge when he sees a gun.'
+  // ..with the perform_violence combat loop, NPC cpool is set by decide_combat_pool. When does this code matter? - Khai
   if (ch_is_npc) {
     if (GET_DODGE(ch) < 8) {
       GET_BODY_POOL(ch) += GET_DODGE(ch);

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -49,6 +49,7 @@ extern int max_ability(int i);
 extern int calculate_vehicle_entry_load(struct veh_data *veh);
 extern void end_quest(struct char_data *ch, bool succeeded);
 extern void set_casting_pools(struct char_data *ch, int casting, int drain, int spell_defense, int reflection, bool message);
+extern void set_combat_pools(struct char_data *ch, int dodge, int soak, int offense, bool message);
 extern void calc_weight(struct char_data *);
 extern void exdesc_conceal_reveal(struct char_data *vict, int wearloc, bool check_for_reveal);
 #ifdef USE_ZONE_HOTLOADING
@@ -1040,38 +1041,11 @@ void affect_total(struct char_data * ch)
     }
   }
 
-  int skill_num = get_skill_num_in_use_for_weapons(ch);
-  int dice_max = get_skill_dice_in_use_for_weapons(ch);
-  int remainder = GET_COMBAT_POOL(ch);
-
-  if (GET_CHIPJACKED_SKILL(ch, skill_num)) {
-    dice_max = 0;
-  }
-
-  // There's nothing to dodge on the astral plane.
-  // Dodge also doesn't apply when prone, but prone combat code already moves dodge to soak
-  if (IS_ASTRAL(ch))
-    GET_DODGE(ch) = 0;
-  else {
-    remainder -= GET_DODGE(ch) = MIN(GET_DODGE(ch), remainder);
-  }
-
-  remainder -= GET_BODY_POOL(ch) = MIN(GET_BODY_POOL(ch), remainder);
-  remainder -= GET_OFFENSE(ch) = MIN(MIN(GET_OFFENSE(ch), dice_max), remainder);
-
-  // Any offense dice above cap are reallocated based on existing dodge/soak assignments
-  // Where dodge == soak, extra dice default to soak
-  if (remainder) {
-    if (GET_DODGE(ch) > GET_BODY_POOL(ch)) {
-      GET_DODGE(ch) += remainder;
-    } else {
-      GET_BODY_POOL(ch) += remainder;
-    }
-  }
+  set_combat_pools(ch, ch->real_abils.defense_pool, ch->real_abils.body_pool, ch->real_abils.offense_pool, FALSE);
 
   // NPCs specialize their defenses: unless they've got crazy dodge dice, they'll want to just soak.
   // AKA, 'your average wage slave is not going to try to do the Matrix bullet dodge when he sees a gun.'
-  // ..with the perform_violence combat loop, NPC cpool is set by decide_combat_pool. When does this code matter? - Khai
+  // ..with the perform_violence combat loop, NPC cpool is set immediately prior by decide_combat_pool. When does this code matter? - Khai
   if (ch_is_npc) {
     if (GET_DODGE(ch) < 8) {
       GET_BODY_POOL(ch) += GET_DODGE(ch);
@@ -1222,6 +1196,7 @@ void affect_total(struct char_data * ch)
 
   SendGMCPCharPools(ch);
 }
+
 
 /*
  * If ch is affected by specified spell, returns force, otherwise returns 0.


### PR DESCRIPTION
Previously, unallocated cpool dice would claim to be allocated to soak but end up in offense and/or dodge instead. This is because the `affect_total` cpool logic was different than the `do_cpool` logic.

In addition to fixing the bug, this PR does the following:
1. Refactored so that do_cpool and affect_total both call set_combat_pools.
2. Unallocated cpool dice will be allocated to soak or dodge depending on where allocated dice already exist. If you have already allocated more dice to dodge than soak, then your unallocated dice will be added to dodge, otherwise it will be added to soak.
3. You can attempt to over-allocate cpool and that setting will be saved (though actual pools will be capped as normal). This allows your cpool to automatically adapt to changes while following the player's priorities (e.g., different weapon skills changing offense cap, temporary stat buffs changing cpool totals, etc).
4. Removed adding dodge to astral - dodge is not used in astral combat.

Example: assume 10 total cpool, with 2 ranks of brawling and 6 ranks of pistols.
`cpool 0 0 0` -> all 10 unallocated dice default to soak
`cpool 1 0 0` -> the 9 unallocated dice are added to the 1 that's already allocated to dodge
`cpool 0 0 15` -> with brawling, offense is capped at 2 due to skill, leaving 8 in soak. Draw the pistol, offense automatically changes to cap 6 and soak to 4.
`cpool 0 10 5` -> all 10 cpool go in soak, with 0 remaining for offense. Add a combat sense spell and those dice will go into offense first because of the saved over-allocation (up to the lower of the over-allocated 5, or the offense cap at weapon skill), and then any remaining dice are added to soak.

This PR addresses:
https://discord.com/channels/564618629467996170/788953927269613608/1518520055527374931
https://discord.com/channels/564618629467996170/788953927269613608/1475395618393423912
https://discord.com/channels/564618629467996170/788953927269613608/1376382525911466176
(and others)

- Khai