### PR TITLE
fix radio forms and matrix comma broadcasts

### DIFF
--- a/src/act.comm.cpp
+++ b/src/act.comm.cpp
@@ -940,9 +940,14 @@ ACMD(do_broadcast)
   }
 
   radio = find_radio(ch, &cyberware, &vehicle, &matrix);
-  if (PLR_FLAGGED(ch, PLR_MATRIX) && !matrix) {
-    send_to_char("You can't access the radio frequencies without a radio link.\r\n", ch);
-    return;
+  if (PLR_FLAGGED(ch, PLR_MATRIX) && !matrix && !IS_OTAKU(ch)) {
+    if (IS_OTAKU(ch) && !cyberware) {
+      send_to_char("You can't access the radio frequencies without a radio complex form, and a cyber radio.\r\n", ch);
+      return;
+    } else if (!matrix) {
+      send_to_char("You can't access the radio frequencies without a radio link.\r\n", ch);
+      return;
+    }
   }
 
   if (IS_NPC(ch) || IS_SENATOR(ch)) {

--- a/src/act.comm.cpp
+++ b/src/act.comm.cpp
@@ -768,13 +768,17 @@ ACMD(do_radio)
   bool cyberware = FALSE, vehicle = FALSE, matrix = FALSE;
 
   radio = find_radio(ch, &cyberware, &vehicle, &matrix);
-  if (PLR_FLAGGED(ch, PLR_MATRIX) && !matrix && !IS_OTAKU(ch)) {
-    if (IS_OTAKU(ch) && !cyberware) {
-      send_to_char("You can't access the radio frequencies without a radio complex form, and a cyber radio.\r\n", ch);
-      return;
-    } else if (!matrix) {
-      send_to_char("You can't access the radio frequencies without a radio link.\r\n", ch);
-      return;
+  if (PLR_FLAGGED(ch, PLR_MATRIX)) {
+    if (IS_OTAKU(ch)) {
+      if (!cyberware) {
+        send_to_char("You can't access the radio frequencies without a radio complex form, and a cyber radio.\r\n", ch);
+        return;
+      }
+    } else {
+      if (!matrix) {
+        send_to_char("You can't access the radio frequencies without a radio link.\r\n", ch);
+        return;
+      }
     }
   }
 
@@ -940,13 +944,17 @@ ACMD(do_broadcast)
   }
 
   radio = find_radio(ch, &cyberware, &vehicle, &matrix);
-  if (PLR_FLAGGED(ch, PLR_MATRIX) && !matrix && !IS_OTAKU(ch)) {
-    if (IS_OTAKU(ch) && !cyberware) {
-      send_to_char("You can't access the radio frequencies without a radio complex form, and a cyber radio.\r\n", ch);
-      return;
-    } else if (!matrix) {
-      send_to_char("You can't access the radio frequencies without a radio link.\r\n", ch);
-      return;
+  if (PLR_FLAGGED(ch, PLR_MATRIX)) {
+    if (IS_OTAKU(ch)) {
+      if (!cyberware) {
+        send_to_char("You can't access the radio frequencies without a radio complex form, and a cyber radio.\r\n", ch);
+        return;
+      }
+    } else {
+      if (!matrix) {
+        send_to_char("You can't access the radio frequencies without a radio link.\r\n", ch);
+        return;
+      }
     }
   }
 

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -1405,6 +1405,7 @@ struct command_info mtx_info[] =
     { "answer", 0, do_comcall, 0, SCMD_ANSWER, BLOCKS_IDLE_REWARD },
     { "asist", 0, do_asist, 0, 0, BLOCKS_IDLE_REWARD },
     { "broadcast", 0, do_broadcast, 0, 0, BLOCKS_IDLE_REWARD },
+    { ",", 0, do_broadcast, 0, 0, BLOCKS_IDLE_REWARD },
     { "bug", 0, do_gen_write, 0, SCMD_BUG, BLOCKS_IDLE_REWARD },
     { "call", 0, do_comcall, 0, SCMD_RING, BLOCKS_IDLE_REWARD },
   //{ "control", 0, do_control, 0, 0, BLOCKS_IDLE_REWARD },     // This is a rigging command?


### PR DESCRIPTION
(did not realise this check would fail)

1: ~~broadcast as an otaku would fail on checking for the Radio Link as `do_radio` has a sub check for the complex form/cyber radio, but `do_broadcast` does not, so do the same check here~~ the test didn't exactly work as it should have, it just got skipped and then passed or failed on checking for any kind of radio at all at the end of the prechecks

2: also add the comma alias as a broadcast option in the matrix